### PR TITLE
First batch of fixes

### DIFF
--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -71,11 +71,11 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
   connect(ui->displaySplitView, SIGNAL(signalShowSeparateWindow(bool)), &separateViewWindow, SLOT(setVisible(bool)));
 
   // Connect the playlistWidget signals to some slots
-  connect(p_playlistWidget, SIGNAL(selectionChanged(playlistItem*, playlistItem*, bool)), ui->fileInfoWidget, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*)));
+  connect(p_playlistWidget, SIGNAL(selectionRangeChanged(playlistItem*, playlistItem*, bool)), ui->fileInfoWidget, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*)));
   connect(p_playlistWidget, SIGNAL(selectedItemChanged(bool)), ui->fileInfoWidget, SLOT(updateFileInfo(bool)));
-  connect(p_playlistWidget, SIGNAL(selectionChanged(playlistItem*, playlistItem*, bool)), ui->playbackController, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*, bool)));
-  connect(p_playlistWidget, SIGNAL(selectionChanged(playlistItem*, playlistItem*, bool)), ui->propertiesWidget, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*)));
-  connect(p_playlistWidget, SIGNAL(selectionChanged(playlistItem*, playlistItem*, bool)), this, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*)));
+  connect(p_playlistWidget, SIGNAL(selectionRangeChanged(playlistItem*, playlistItem*, bool)), ui->playbackController, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*, bool)));
+  connect(p_playlistWidget, SIGNAL(selectionRangeChanged(playlistItem*, playlistItem*, bool)), ui->propertiesWidget, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*)));
+  connect(p_playlistWidget, SIGNAL(selectionRangeChanged(playlistItem*, playlistItem*, bool)), this, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*)));
   connect(p_playlistWidget, SIGNAL(selectedItemChanged(bool)), ui->playbackController, SLOT(selectionPropertiesChanged(bool)));
   connect(p_playlistWidget, SIGNAL(itemAboutToBeDeleted(playlistItem*)), ui->propertiesWidget, SLOT(itemAboutToBeDeleted(playlistItem*)));
   connect(p_playlistWidget, SIGNAL(openFileDialog()), this, SLOT(showFileOpenDialog()));

--- a/source/playlistItemHEVCFile.cpp
+++ b/source/playlistItemHEVCFile.cpp
@@ -1197,11 +1197,11 @@ void playlistItemHEVCFile::fillStatisticList()
   statSource.addStatType(refIdx1);
 
   StatisticsType motionVec0(7, "Motion Vector 0", vectorType);
-  motionVec0.colorRange = new DefaultColorRange("col3_bblg", -16, 16);
+  motionVec0.colorRange.reset(new DefaultColorRange("col3_bblg", -16, 16));
   statSource.addStatType(motionVec0);
 
   StatisticsType motionVec1(8, "Motion Vector 1", vectorType);
-  motionVec1.colorRange = new DefaultColorRange("col3_bblg", -16, 16);
+  motionVec1.colorRange.reset(new DefaultColorRange("col3_bblg", -16, 16));
   statSource.addStatType(motionVec1);
 
   StatisticsType intraDirY(9, "Intra Dir Luma", "jet", 0, 34);

--- a/source/playlistItemStatisticsFile.cpp
+++ b/source/playlistItemStatisticsFile.cpp
@@ -326,11 +326,11 @@ void playlistItemStatisticsFile::readHeaderFromFile()
       }
       else if (rowItemList[1] == "range")
       {
-        aType.colorRange = new ColorRange(rowItemList);
+        aType.colorRange.reset(new ColorRange(rowItemList));
       }
       else if (rowItemList[1] == "defaultRange")
       {
-        aType.colorRange = new DefaultColorRange(rowItemList);
+        aType.colorRange.reset(new DefaultColorRange(rowItemList));
       }
       else if (rowItemList[1] == "vectorColor")
       {

--- a/source/playlistTreeWidget.cpp
+++ b/source/playlistTreeWidget.cpp
@@ -307,7 +307,7 @@ void PlaylistTreeWidget::slotSelectionChanged()
   // The selection changed. Get the first and second selection and emit the selectionChanged signal.
   playlistItem *item1, *item2;
   getSelectedItems(item1, item2);
-  emit selectionChanged(item1, item2, false);
+  emit selectionRangeChanged(item1, item2, false);
 
   // Also notify the cache that a new object was selected
   emit playlistChanged();
@@ -411,12 +411,12 @@ bool PlaylistTreeWidget::selectNextItem(bool wrapAround, bool callByPlayback)
     // Do what the function slotSelectionChanged usually does but this time with changedByPlayback=false.
     playlistItem *item1, *item2;
     getSelectedItems(item1, item2);
-    emit selectionChanged(item1, item2, true);
+    emit selectionRangeChanged(item1, item2, true);
 
     connect(this, SIGNAL(itemSelectionChanged()), this, SLOT(slotSelectionChanged()));
   }
   else
-    // Set next item as current and emit the selectionChanged event with changedByPlayback=false.
+    // Set next item as current and emit the selectionRangeChanged event with changedByPlayback=false.
     setCurrentItem( topLevelItem(idx + 1) );
 
   // Another item was selected. The caching thread also has to be notified about this.

--- a/source/playlistTreeWidget.h
+++ b/source/playlistTreeWidget.h
@@ -91,7 +91,7 @@ signals:
 
   // The current selection changed. Give the new first (and second) selection.
   // chageByPlayback is true if the selection changed because of the playback going to the next frame.
-  void selectionChanged(playlistItem *first, playlistItem *second, bool chageByPlayback);
+  void selectionRangeChanged(playlistItem *first, playlistItem *second, bool chageByPlayback);
 
   // The properties of (one of) the currently selected items changed.
   // We need to update the values of the item. Redraw the item if redraw is set.

--- a/source/statisticHandler.cpp
+++ b/source/statisticHandler.cpp
@@ -288,10 +288,10 @@ ValuePairList statisticHandler::getValuesAt(QPoint pos)
  * we do not overwrite our statistics type, we just change their parameters
  * return if something has changed where a redraw would be necessary
 */
-bool statisticHandler::setStatisticsTypeList(StatisticsTypeList typeList)
+bool statisticHandler::setStatisticsTypeList(const StatisticsTypeList & typeList)
 {
   bool bChanged = false;
-  foreach(StatisticsType aType, typeList)
+  foreach(const StatisticsType & aType, typeList)
   {
     StatisticsType* internalType = getStatisticsType(aType.typeID);
 

--- a/source/statisticHandler.h
+++ b/source/statisticHandler.h
@@ -50,7 +50,7 @@ public:
   // Get the list of all statistics that this source can provide
   StatisticsTypeList getStatisticsTypeList() { return statsTypeList; }
   // Set the attributes of the statistics that this source can provide (rendered, drawGrid...)
-  bool setStatisticsTypeList(StatisticsTypeList typeList);
+  bool setStatisticsTypeList(const StatisticsTypeList &typeList);
   // Return true if any of the statistics are actually rendered
   bool anyStatisticsRendered();
 
@@ -78,7 +78,7 @@ public:
   QSize statFrameSize;
 
   // Add new statistics type. Add all types using this function before creating the controls (createStatisticsHandlerControls).
-  void addStatType(StatisticsType type) { statsTypeList.append(type); }
+  void addStatType(const StatisticsType &type) { statsTypeList.append(type); }
   // Clear the statistics type list.
   void clearStatTypes();
 

--- a/source/statisticsExtensions.h
+++ b/source/statisticsExtensions.h
@@ -19,6 +19,7 @@
 #ifndef STATISTICSEXTENSIONS_H
 #define STATISTICSEXTENSIONS_H
 
+#include <QSharedPointer>
 #include <QStringList>
 #include <QMap>
 #include "typedef.h"
@@ -388,8 +389,6 @@ public:
     renderGrid = true;
     alphaFactor = 50;
 
-    colorRange = NULL;
-
     vectorSampling = 1;
     scaleToBlockSize = false;
     visualizationType = colorRangeType;
@@ -402,27 +401,25 @@ public:
     renderGrid = true;
     alphaFactor = 50;
 
-    colorRange = NULL;
-
     vectorSampling = 1;
     scaleToBlockSize = false;
     visualizationType = visType;
   }
-  StatisticsType(int tID, QString sName, QString defaultColorRangeName, int rangeMin, int rangeMax)
+  StatisticsType(int tID, QString sName, QString defaultColorRangeName, int rangeMin, int rangeMax) :
+    colorRange(new DefaultColorRange(defaultColorRangeName, rangeMin, rangeMax))
   {
     typeID = tID;
     typeName = sName;
     render = false;
     renderGrid = true;
     alphaFactor = 50;
-
-    colorRange = new DefaultColorRange(defaultColorRangeName, rangeMin, rangeMax);
 
     vectorSampling = 1;
     scaleToBlockSize = false;
     visualizationType = colorMapType;
   }
-  StatisticsType(int tID, QString sName, visualizationType_t visType, int cRangeMin, QColor cRangeMinColor, int cRangeMax, QColor cRangeMaxColor )
+  StatisticsType(int tID, QString sName, visualizationType_t visType, int cRangeMin, QColor cRangeMinColor, int cRangeMax, QColor cRangeMaxColor ) :
+    colorRange(new ColorRange(cRangeMin, cRangeMinColor, cRangeMax, cRangeMaxColor))
   {
     typeID = tID;
     typeName = sName;
@@ -430,20 +427,9 @@ public:
     renderGrid = true;
     alphaFactor = 50;
 
-    colorRange = new ColorRange(cRangeMin, cRangeMinColor, cRangeMax, cRangeMaxColor);
-
     vectorSampling = 1;
     scaleToBlockSize = false;
     visualizationType = visType;
-  }
-
-  ~StatisticsType()
-  {
-    if( colorRange == NULL )
-    {
-      delete colorRange;
-      colorRange = NULL;
-    }
   }
 
   void readFromRow(QStringList row)
@@ -480,7 +466,7 @@ public:
 
   // only one of the next should be set, depending on type
   ColorMap colorMap;
-  ColorRange* colorRange; // can either be a ColorRange or a DefaultColorRange
+  QSharedPointer<ColorRange> colorRange; // can either be a ColorRange or a DefaultColorRange
   QColor vectorColor;
   QColor gridColor;
 

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -216,25 +216,7 @@
    <attribute name="dockWidgetArea">
     <number>2</number>
    </attribute>
-   <widget class="PropertiesWidget" name="propertiesWidget">
-    <layout class="QVBoxLayout" name="verticalLayout_7">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="leftMargin">
-      <number>9</number>
-     </property>
-     <property name="topMargin">
-      <number>9</number>
-     </property>
-     <property name="rightMargin">
-      <number>9</number>
-     </property>
-     <property name="bottomMargin">
-      <number>9</number>
-     </property>
-    </layout>
-   </widget>
+   <widget class="PropertiesWidget" name="propertiesWidget"/>
   </widget>
   <widget class="QDockWidget" name="playbackControllerDock">
    <property name="sizePolicy">


### PR DESCRIPTION
1. The propertiesWidget in the propertiesDock has a layout. Don't add another one.
2. Fix StatisticsType so that it is safely copyable. The colorRange was being leaked due to a typo in its destructor. Without the typo, it would have been a dangling pointer.
3. Don't hide the virtual QAbstractItemView::selectionChanged method. This gets rid of warnings on modern clang.