### PR TITLE
Fixes 2

### DIFF
--- a/source/frameHandler.cpp
+++ b/source/frameHandler.cpp
@@ -321,8 +321,8 @@ ValuePairList frameHandler::getPixelValues(QPoint pixelPos, int frameIdx, frameH
 {
   Q_UNUSED(frameIdx);
 
-  int width  = qMin(frameSize.width(), item2->frameSize.width());
-  int height = qMin(frameSize.height(), item2->frameSize.height());
+  int width  = qMin(frameSize.width(), item2 ? item2->frameSize.width() : 0);
+  int height = qMin(frameSize.height(), item2 ? item2->frameSize.height() : 0);
 
   if (pixelPos.x() < 0 || pixelPos.x() >= width || pixelPos.y() < 0 || pixelPos.y() >= height)
     return ValuePairList();

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -337,6 +337,15 @@ bool MainWindow::handleKeyPress(QKeyEvent *event, bool keyFromSeparateView)
   return false;
 }
 
+bool MainWindow::eventFilter(QObject *watched, QEvent *event)
+{
+  if (watched == qApp && event->type() == QEvent::FileOpen) {
+    QStringList fileList(static_cast<QFileOpenEvent *>(event)->file());
+    loadFiles(fileList);
+  }
+  return QMainWindow::eventFilter(watched, event);
+}
+
 void MainWindow::keyPressEvent(QKeyEvent *event)
 {
   //qDebug() << QTime::currentTime().toString("hh:mm:ss.zzz")<<"Key: "<< event;

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -103,6 +103,7 @@ public slots:
 
 protected:
 
+  virtual bool eventFilter(QObject *watched, QEvent *event) Q_DECL_OVERRIDE;
   virtual void keyPressEvent(QKeyEvent *event) Q_DECL_OVERRIDE;
   virtual void focusInEvent(QFocusEvent *event) Q_DECL_OVERRIDE;
 

--- a/source/yuviewapp.cpp
+++ b/source/yuviewapp.cpp
@@ -17,10 +17,17 @@
 */
 
 #include "yuviewapp.h"
+
+#include "mainwindow.h"
 #include "typedef.h"
 
-YUViewApp::YUViewApp( int & argc, char **argv ) : QApplication(argc, argv)
+int main(int argc, char *argv[])
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+  QApplication::setAttribute(Qt::AA_EnableHighDpiScaling); // DPI support
+#endif
+  QApplication app(argc, argv);
+
   //printf("Build Version: %s \n",YUVIEW_HASH);
   // check the YUVIEW_HASH against the JSON output from here:
   // https://api.github.com/repos/IENT/YUView/commits
@@ -35,51 +42,28 @@ YUViewApp::YUViewApp( int & argc, char **argv ) : QApplication(argc, argv)
   QApplication::setOrganizationName("Institut für Nachrichtentechnik, RWTH Aachen University");
   QApplication::setOrganizationDomain("ient.rwth-aachen.de");
 
-  w = new MainWindow();
+  MainWindow w;
+  app.installEventFilter(&w);
+
+  QStringList args = app.arguments();
 
 #if UPDATE_FEATURE_ENABLE && _WIN32
-  if (argc == 2 && qstrcmp(argv[1], "updateElevated") == 0)
+  if (args.size() == 2 && args[1] == "updateElevated")
   {
     // The process should now be elevated and we will force an update
-    w->forceUpdateElevated();
-    argc = 1; // Don't interprete the "updateElevated" argument as a file
+    w.forceUpdateElevated();
+    args.removeLast();
   }
   else
-    w->autoUpdateCheck();
+    w.autoUpdateCheck();
 #else
-  w->autoUpdateCheck();
+  w.autoUpdateCheck();
 #endif
 
-  QStringList fileList;
-  for ( int i = 1; i < argc; ++i )
-    fileList.append( QString(argv[i]) );
+  QStringList fileList = args.mid(1);
   if (!fileList.empty())
-    w->loadFiles(fileList);
+    w.loadFiles(fileList);
 
-  w->show();
-}
-
-bool YUViewApp::event(QEvent *event)
-{
-  QStringList fileList;
-
-  switch (event->type())
-  {
-  case QEvent::FileOpen:
-    fileList.append((static_cast<QFileOpenEvent *>(event))->file());
-    w->loadFiles( fileList );
-    return true;
-  default:
-    return QApplication::event(event);
-  }
-}
-
-int main(int argc, char *argv[])
-{
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
-  QApplication::setAttribute(Qt::AA_EnableHighDpiScaling); // DPI support
-#endif
-
-  YUViewApp a(argc, argv);
-  return a.exec();
+  w.show();
+  return app.exec();
 }

--- a/source/yuviewapp.h
+++ b/source/yuviewapp.h
@@ -19,29 +19,4 @@
 #ifndef YUVIEWAPP_H
 #define YUVIEWAPP_H
 
-#include <QApplication>
-
-#include "mainwindow.h"
-
-class YUViewApp : public QApplication
-{
-    Q_OBJECT
-
-public:
-    YUViewApp(int & argc, char **argv);
-    QObject* getMainWindow() {return w;}
-
-protected:
-    bool event(QEvent *);
-
-private:
-
-    MainWindow *w;
-
-signals:
-
-public slots:
-
-};
-
 #endif // YUVIEWAPP_H


### PR DESCRIPTION
1. Fix null pointer dereference in `frameHandler::getPixelValues`.

2. Handle the `Event::FileOpen` directly in the main window.

   This avoids the need to overload `QApplication` and makes `main` take on a more typical form: instantiate the application, then the widget, then show it and execute.

3. Fix commandline argument file name encoding on Windows by using the arguments decoded by `QCoreApplication`. `char ** argv` is essentially broken on Windows. `QCoreApplication::arguments()` implements the decoding properly and gives `QStrings` back.

I'm leaving the `youviewapp.h` file around for now.

