### PR TITLE
Safety Work Part 1 (smaller chunk)

### DIFF
--- a/YUView.pro
+++ b/YUView.pro
@@ -34,6 +34,7 @@ SOURCES += source/fileInfoWidget.cpp \
     source/settingswindow.cpp \
     source/splitViewWidget.cpp \
     source/statisticHandler.cpp \
+    source/typedef.cpp \
 	source/updateHandler.cpp \
     source/videoCache.cpp \
     source/videoHandler.cpp \

--- a/source/fileInfoWidget.cpp
+++ b/source/fileInfoWidget.cpp
@@ -24,11 +24,10 @@
  * If you provide a list of QString tuples, this class will fill a grid layout with the 
  * corresponding labels.
  */
-FileInfoWidget::FileInfoWidget(QWidget *parent) : QWidget(parent)
+FileInfoWidget::FileInfoWidget(QWidget *parent) :
+  QWidget(parent),
+  infoLayout(this)
 {
-  infoLayout = new QGridLayout;
-  setLayout(infoLayout);
-  
   currentItem1 = NULL;
   currentItem2 = NULL;
 
@@ -41,7 +40,6 @@ FileInfoWidget::FileInfoWidget(QWidget *parent) : QWidget(parent)
 
 FileInfoWidget::~FileInfoWidget()
 {
-  delete infoLayout;
 }
 
 void FileInfoWidget::updateFileInfo(bool redraw)
@@ -73,11 +71,8 @@ void FileInfoWidget::setFileInfo()
     parentWidget()->setWindowTitle(FILEINFOWIDGET_DEFAULT_WINDOW_TITEL);
 
   // Clear the grid layout
-  foreach(QLabel *l, labelList) 
-  {
-    infoLayout->removeWidget(l);
+  foreach(QLabel *l, labelList)
     delete l;
-  }
   labelList.clear();
   nrLabelPairs = 0;
 }
@@ -112,11 +107,8 @@ void FileInfoWidget::setFileInfo(QString fileInfoTitle, QList<infoItem> fileInfo
     // Update the grid layout. Delete all the labels and add as many new ones as necessary.
 
     // Clear the grid layout
-    foreach(QLabel *l, labelList) 
-    {
-      infoLayout->removeWidget(l);
+    foreach(QLabel *l, labelList)
       delete l;
-    }
     labelList.clear();
 
     // For each item in the list add a two labels to the grid layout
@@ -136,11 +128,11 @@ void FileInfoWidget::setFileInfo(QString fileInfoTitle, QList<infoItem> fileInfo
       newValueLabel->setWordWrap(true);
 
       // Add to grid
-      infoLayout->addWidget(newTextLabel, i, 0);
-      infoLayout->addWidget(newValueLabel, i, 1);
+      infoLayout.addWidget(newTextLabel, i, 0);
+      infoLayout.addWidget(newValueLabel, i, 1);
 
       // Set row stretch to 0
-      infoLayout->setRowStretch(i, 0);
+      infoLayout.setRowStretch(i, 0);
 
       i++;
 
@@ -149,8 +141,8 @@ void FileInfoWidget::setFileInfo(QString fileInfoTitle, QList<infoItem> fileInfo
       labelList.append(newValueLabel);
     }
 
-    infoLayout->setColumnStretch(1, 1);	///< Set the second column to strectch
-    infoLayout->setRowStretch(i, 1);		///< Set the last rwo to strectch
+    infoLayout.setColumnStretch(1, 1);	///< Set the second column to strectch
+    infoLayout.setRowStretch(i, 1);		///< Set the last rwo to strectch
 
     nrLabelPairs = i;
   }

--- a/source/fileInfoWidget.h
+++ b/source/fileInfoWidget.h
@@ -94,7 +94,7 @@ private:
   void setFileInfo();
 
   // The grid layout that contains all the infoItems
-  QGridLayout *infoLayout;
+  QGridLayout infoLayout;
 
   // The list containing pointers to all labels in the grid layout
   QList<QLabel*> labelList;

--- a/source/frameHandler.cpp
+++ b/source/frameHandler.cpp
@@ -50,9 +50,8 @@ frameHandler::frameSizePresetList frameHandler::presetFrameSizes;
 
 // ---------------- frameHandler ---------------------------------
 
-frameHandler::frameHandler() : ui(new Ui::frameHandler)
+frameHandler::frameHandler() : ui(new SafeUi<Ui::frameHandler>)
 {
-  controlsCreated = false;
 }
 
 frameHandler::~frameHandler()
@@ -60,12 +59,12 @@ frameHandler::~frameHandler()
   delete ui;
 }
 
-QLayout *frameHandler::createFrameHandlerControls(QWidget *parentWidget, bool isSizeFixed)
+QLayout *frameHandler::createFrameHandlerControls(bool isSizeFixed)
 {
   // Absolutely always only call this function once!
-  assert(!controlsCreated);
+  assert(!ui->created());
 
-  ui->setupUi(parentWidget);
+  ui->setupUi();
 
   // Set default values
   ui->widthSpinBox->setMaximum(100000);
@@ -84,9 +83,6 @@ QLayout *frameHandler::createFrameHandlerControls(QWidget *parentWidget, bool is
   connect(ui->heightSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotVideoControlChanged()));
   connect(ui->frameSizeComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotVideoControlChanged()));
 
-  // The controls have been created and can be used now
-  controlsCreated = true;
-
   return ui->frameHandlerLayout;
 }
 
@@ -101,7 +97,7 @@ void frameHandler::setFrameSize(QSize newSize, bool emitSignal)
   frameSize = newSize;
   cachingFrameSizeMutex.unlock();
 
-  if (!controlsCreated)
+  if (!ui->created())
     // spin boxes not created yet
     return;
 

--- a/source/frameHandler.cpp
+++ b/source/frameHandler.cpp
@@ -50,40 +50,39 @@ frameHandler::frameSizePresetList frameHandler::presetFrameSizes;
 
 // ---------------- frameHandler ---------------------------------
 
-frameHandler::frameHandler() : ui(new SafeUi<Ui::frameHandler>)
+frameHandler::frameHandler()
 {
 }
 
 frameHandler::~frameHandler()
 {
-  delete ui;
 }
 
 QLayout *frameHandler::createFrameHandlerControls(bool isSizeFixed)
 {
   // Absolutely always only call this function once!
-  assert(!ui->created());
+  assert(!ui.created());
 
-  ui->setupUi();
+  ui.setupUi();
 
   // Set default values
-  ui->widthSpinBox->setMaximum(100000);
-  ui->widthSpinBox->setValue( frameSize.width() );
-  ui->widthSpinBox->setEnabled( !isSizeFixed );
-  ui->heightSpinBox->setMaximum(100000);
-  ui->heightSpinBox->setValue( frameSize.height() );
-  ui->heightSpinBox->setEnabled( !isSizeFixed );
-  ui->frameSizeComboBox->addItems( presetFrameSizes.getFormatedNames() );
+  ui.widthSpinBox->setMaximum(100000);
+  ui.widthSpinBox->setValue( frameSize.width() );
+  ui.widthSpinBox->setEnabled( !isSizeFixed );
+  ui.heightSpinBox->setMaximum(100000);
+  ui.heightSpinBox->setValue( frameSize.height() );
+  ui.heightSpinBox->setEnabled( !isSizeFixed );
+  ui.frameSizeComboBox->addItems( presetFrameSizes.getFormatedNames() );
   int idx = presetFrameSizes.findSize( frameSize );
-  ui->frameSizeComboBox->setCurrentIndex(idx);
-  ui->frameSizeComboBox->setEnabled( !isSizeFixed );
+  ui.frameSizeComboBox->setCurrentIndex(idx);
+  ui.frameSizeComboBox->setEnabled( !isSizeFixed );
 
   // Connect all the change signals from the controls to "connectWidgetSignals()"
-  connect(ui->widthSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotVideoControlChanged()));
-  connect(ui->heightSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotVideoControlChanged()));
-  connect(ui->frameSizeComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotVideoControlChanged()));
+  connect(ui.widthSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotVideoControlChanged()));
+  connect(ui.heightSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotVideoControlChanged()));
+  connect(ui.frameSizeComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotVideoControlChanged()));
 
-  return ui->frameHandlerLayout;
+  return ui.frameHandlerLayout;
 }
 
 void frameHandler::setFrameSize(QSize newSize, bool emitSignal)
@@ -97,24 +96,24 @@ void frameHandler::setFrameSize(QSize newSize, bool emitSignal)
   frameSize = newSize;
   cachingFrameSizeMutex.unlock();
 
-  if (!ui->created())
+  if (!ui.created())
     // spin boxes not created yet
     return;
 
   // Set the width/height spin boxes without emitting another signal (disconnect/set/reconnect)
   if (!emitSignal)
   {
-    QObject::disconnect(ui->widthSpinBox, SIGNAL(valueChanged(int)), NULL, NULL);
-    QObject::disconnect(ui->heightSpinBox, SIGNAL(valueChanged(int)), NULL, NULL);
+    QObject::disconnect(ui.widthSpinBox, SIGNAL(valueChanged(int)), NULL, NULL);
+    QObject::disconnect(ui.heightSpinBox, SIGNAL(valueChanged(int)), NULL, NULL);
   }
 
-  ui->widthSpinBox->setValue( newSize.width() );
-  ui->heightSpinBox->setValue( newSize.height() );
+  ui.widthSpinBox->setValue( newSize.width() );
+  ui.heightSpinBox->setValue( newSize.height() );
 
   if (!emitSignal)
   {
-    QObject::connect(ui->widthSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotVideoControlChanged()));
-    QObject::connect(ui->heightSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotVideoControlChanged()));
+    QObject::connect(ui.widthSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotVideoControlChanged()));
+    QObject::connect(ui.heightSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotVideoControlChanged()));
   }
 }
 
@@ -133,21 +132,21 @@ void frameHandler::slotVideoControlChanged()
   QObject *sender = QObject::sender();
 
   QSize newSize;
-  if (sender == ui->widthSpinBox || sender == ui->heightSpinBox)
+  if (sender == ui.widthSpinBox || sender == ui.heightSpinBox)
   {
-    newSize = QSize( ui->widthSpinBox->value(), ui->heightSpinBox->value() );
+    newSize = QSize( ui.widthSpinBox->value(), ui.heightSpinBox->value() );
     if (newSize != frameSize)
     {
       // Set the comboBox index without causing another signal to be emitted (disconnect/set/reconnect).
-      QObject::disconnect(ui->frameSizeComboBox, SIGNAL(currentIndexChanged(int)), NULL, NULL);
+      QObject::disconnect(ui.frameSizeComboBox, SIGNAL(currentIndexChanged(int)), NULL, NULL);
       int idx = presetFrameSizes.findSize( newSize );
-      ui->frameSizeComboBox->setCurrentIndex(idx);
-      QObject::connect(ui->frameSizeComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotVideoControlChanged()));
+      ui.frameSizeComboBox->setCurrentIndex(idx);
+      QObject::connect(ui.frameSizeComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotVideoControlChanged()));
     }
   }
-  else if (sender == ui->frameSizeComboBox)
+  else if (sender == ui.frameSizeComboBox)
   {
-    newSize = presetFrameSizes.getSize( ui->frameSizeComboBox->currentIndex() ); 
+    newSize = presetFrameSizes.getSize( ui.frameSizeComboBox->currentIndex() );
   }
 
   if (newSize != frameSize && newSize != QSize(-1,-1))

--- a/source/frameHandler.h
+++ b/source/frameHandler.h
@@ -120,7 +120,7 @@ private:
   static frameSizePresetList presetFrameSizes;
   QStringList getFrameSizePresetNames();
  
-  SafeUi<Ui::frameHandler> *ui;
+  SafeUi<Ui::frameHandler> ui;
 
 protected slots:
 

--- a/source/frameHandler.h
+++ b/source/frameHandler.h
@@ -68,7 +68,7 @@ public:
   // isSizeFixed: For example a YUV file does not have a fixed size (the user can change this),
   // other sources might provide a fixed size which the user cannot change (HEVC file, png image sequences ...)
   // If the size is fixed, do not add the controls for the size.
-  virtual QLayout *createFrameHandlerControls(QWidget *parentWidget, bool isSizeFixed=false);
+  virtual QLayout *createFrameHandlerControls(bool isSizeFixed=false);
 
   // Draw the pixel values of the visible pixels in the center of each pixel.
   // Only draw values for the given range of pixels and frame index.
@@ -120,9 +120,7 @@ private:
   static frameSizePresetList presetFrameSizes;
   QStringList getFrameSizePresetNames();
  
-  bool controlsCreated;    ///< Have the video controls been created already?
-
-  Ui::frameHandler *ui;
+  SafeUi<Ui::frameHandler> *ui;
 
 protected slots:
 

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -35,7 +35,7 @@
 #include <QImageReader>
 #include "playlistItems.h"
 
-MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow)
+MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
 {
   QSettings settings;
   qRegisterMetaType<indexRange>("indexRange");
@@ -46,7 +46,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
   if (!settings.contains("OverlayGrid/Color"))
     settings.setValue("OverlayGrid/Color", QColor(0, 0, 0));
 
-  ui->setupUi(this);
+  ui.setupUi(this);
 
   // Create the update handler
   updater = new updateHandler(this);
@@ -59,36 +59,36 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
   separateViewWindow.setWindowTitle("Seperate View");
   separateViewWindow.setGeometry(0, 0, 300, 600);
 
-  p_playlistWidget = ui->playlistTreeWidget;
+  p_playlistWidget = ui.playlistTreeWidget;
 
   // Setup the display controls of the splitViewWidget and add them to the displayDockWidget.
-  ui->displaySplitView->setupControls( ui->displayDockWidget );
-  connect(ui->displaySplitView, SIGNAL(signalToggleFullScreen()), this, SLOT(toggleFullscreen()));
+  ui.displaySplitView->setupControls( ui.displayDockWidget );
+  connect(ui.displaySplitView, SIGNAL(signalToggleFullScreen()), this, SLOT(toggleFullscreen()));
 
   // Setup primary/separate splitView
-  ui->displaySplitView->setSeparateWidget( separateViewWindow.splitView );
-  separateViewWindow.splitView->setPrimaryWidget( ui->displaySplitView );
-  connect(ui->displaySplitView, SIGNAL(signalShowSeparateWindow(bool)), &separateViewWindow, SLOT(setVisible(bool)));
+  ui.displaySplitView->setSeparateWidget( separateViewWindow.splitView );
+  separateViewWindow.splitView->setPrimaryWidget( ui.displaySplitView );
+  connect(ui.displaySplitView, SIGNAL(signalShowSeparateWindow(bool)), &separateViewWindow, SLOT(setVisible(bool)));
 
   // Connect the playlistWidget signals to some slots
-  connect(p_playlistWidget, SIGNAL(selectionRangeChanged(playlistItem*, playlistItem*, bool)), ui->fileInfoWidget, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*)));
-  connect(p_playlistWidget, SIGNAL(selectedItemChanged(bool)), ui->fileInfoWidget, SLOT(updateFileInfo(bool)));
-  connect(p_playlistWidget, SIGNAL(selectionRangeChanged(playlistItem*, playlistItem*, bool)), ui->playbackController, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*, bool)));
-  connect(p_playlistWidget, SIGNAL(selectionRangeChanged(playlistItem*, playlistItem*, bool)), ui->propertiesWidget, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*)));
+  connect(p_playlistWidget, SIGNAL(selectionRangeChanged(playlistItem*, playlistItem*, bool)), ui.fileInfoWidget, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*)));
+  connect(p_playlistWidget, SIGNAL(selectedItemChanged(bool)), ui.fileInfoWidget, SLOT(updateFileInfo(bool)));
+  connect(p_playlistWidget, SIGNAL(selectionRangeChanged(playlistItem*, playlistItem*, bool)), ui.playbackController, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*, bool)));
+  connect(p_playlistWidget, SIGNAL(selectionRangeChanged(playlistItem*, playlistItem*, bool)), ui.propertiesWidget, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*)));
   connect(p_playlistWidget, SIGNAL(selectionRangeChanged(playlistItem*, playlistItem*, bool)), this, SLOT(currentSelectedItemsChanged(playlistItem*, playlistItem*)));
-  connect(p_playlistWidget, SIGNAL(selectedItemChanged(bool)), ui->playbackController, SLOT(selectionPropertiesChanged(bool)));
-  connect(p_playlistWidget, SIGNAL(itemAboutToBeDeleted(playlistItem*)), ui->propertiesWidget, SLOT(itemAboutToBeDeleted(playlistItem*)));
+  connect(p_playlistWidget, SIGNAL(selectedItemChanged(bool)), ui.playbackController, SLOT(selectionPropertiesChanged(bool)));
+  connect(p_playlistWidget, SIGNAL(itemAboutToBeDeleted(playlistItem*)), ui.propertiesWidget, SLOT(itemAboutToBeDeleted(playlistItem*)));
   connect(p_playlistWidget, SIGNAL(openFileDialog()), this, SLOT(showFileOpenDialog()));
       
-  ui->displaySplitView->setAttribute(Qt::WA_AcceptTouchEvents);
+  ui.displaySplitView->setAttribute(Qt::WA_AcceptTouchEvents);
 
   createMenusAndActions();
 
-  ui->playbackController->setSplitViews( ui->displaySplitView, separateViewWindow.splitView );
-  ui->playbackController->setPlaylist( ui->playlistTreeWidget );
-  ui->displaySplitView->setPlaybackController( ui->playbackController );
-  ui->displaySplitView->setPlaylistTreeWidget( p_playlistWidget );
-  separateViewWindow.splitView->setPlaybackController( ui->playbackController );
+  ui.playbackController->setSplitViews( ui.displaySplitView, separateViewWindow.splitView );
+  ui.playbackController->setPlaylist( ui.playlistTreeWidget );
+  ui.displaySplitView->setPlaybackController( ui.playbackController );
+  ui.displaySplitView->setPlaylistTreeWidget( p_playlistWidget );
+  separateViewWindow.splitView->setPlaybackController( ui.playbackController );
   separateViewWindow.splitView->setPlaylistTreeWidget( p_playlistWidget );
 
   // load geometry and active dockable widgets from user preferences
@@ -98,35 +98,35 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
   separateViewWindow.restoreState(settings.value("separateViewWindow/windowState").toByteArray());
   
   connect(&p_settingswindow, SIGNAL(settingsChanged()), this, SLOT(updateSettings()));
-  connect(&p_settingswindow, SIGNAL(settingsChanged()), ui->displaySplitView, SLOT(updateSettings()));
+  connect(&p_settingswindow, SIGNAL(settingsChanged()), ui.displaySplitView, SLOT(updateSettings()));
   connect(&p_settingswindow, SIGNAL(settingsChanged()), separateViewWindow.splitView, SLOT(updateSettings()));
   connect(&p_settingswindow, SIGNAL(settingsChanged()), p_playlistWidget, SLOT(updateSettings()));
   
-  connect(ui->openButton, SIGNAL(clicked()), this, SLOT(showFileOpenDialog()));
+  connect(ui.openButton, SIGNAL(clicked()), this, SLOT(showFileOpenDialog()));
 
   // Connect signals from the separate window
-  connect(&separateViewWindow, SIGNAL(signalSingleWindowMode()), ui->displaySplitView, SLOT(toggleSeparateViewHideShow()));
+  connect(&separateViewWindow, SIGNAL(signalSingleWindowMode()), ui.displaySplitView, SLOT(toggleSeparateViewHideShow()));
   connect(&separateViewWindow, SIGNAL(unhandledKeyPress(QKeyEvent*)), this, SLOT(handleKeyPress(QKeyEvent*)));
     
   // Call this once to init FrameCache and other settings
   updateSettings();
 
   // Set the controls in the state handler. Thiw way, the state handler can save/load the current state of the view.
-  stateHandler.setConctrols(ui->playbackController, p_playlistWidget, ui->displaySplitView, separateViewWindow.splitView);
+  stateHandler.setConctrols(ui.playbackController, p_playlistWidget, ui.displaySplitView, separateViewWindow.splitView);
   // Give the playlist a pointer to the state handler so it can save the states ti playlist
   p_playlistWidget->setViewStateHandler(&stateHandler);
 
   // Create the videoCache object
-  cache = new videoCache(p_playlistWidget, ui->playbackController);
+  cache = new videoCache(p_playlistWidget, ui.playbackController);
 }
 
 void MainWindow::createMenusAndActions()
 {
   fileMenu = menuBar()->addMenu(tr("&File"));
   openYUVFileAction = fileMenu->addAction("&Open File...", this, SLOT(showFileOpenDialog()), Qt::CTRL + Qt::Key_O);
-  addTextAction = fileMenu->addAction("&Add Text Frame", ui->playlistTreeWidget, SLOT(addTextItem()));
-  addDifferenceAction = fileMenu->addAction("&Add Difference Sequence", ui->playlistTreeWidget, SLOT(addDifferenceItem()));
-  addOverlayAction = fileMenu->addAction("&Add Overlay", ui->playlistTreeWidget, SLOT(addOverlayItem()));
+  addTextAction = fileMenu->addAction("&Add Text Frame", ui.playlistTreeWidget, SLOT(addTextItem()));
+  addDifferenceAction = fileMenu->addAction("&Add Difference Sequence", ui.playlistTreeWidget, SLOT(addDifferenceItem()));
+  addOverlayAction = fileMenu->addAction("&Add Overlay", ui.playlistTreeWidget, SLOT(addOverlayItem()));
   fileMenu->addSeparator();
   for (int i = 0; i < MAX_RECENT_FILES; ++i)
   {
@@ -149,27 +149,27 @@ void MainWindow::createMenusAndActions()
   showSettingsAction = fileMenu->addAction("&Settings", &p_settingswindow, SLOT(show()) );
 
   viewMenu = menuBar()->addMenu(tr("&View"));
-  zoomToStandardAction = viewMenu->addAction("Zoom to 1:1", ui->displaySplitView, SLOT(resetViews()), Qt::CTRL + Qt::Key_0);
-  zoomToFitAction = viewMenu->addAction("Zoom to Fit", ui->displaySplitView, SLOT(zoomToFit()), Qt::CTRL + Qt::Key_9);
-  zoomInAction = viewMenu->addAction("Zoom in", ui->displaySplitView, SLOT(zoomIn()), Qt::CTRL + Qt::Key_Plus);
-  zoomOutAction = viewMenu->addAction("Zoom out", ui->displaySplitView, SLOT(zoomOut()), Qt::CTRL + Qt::Key_Minus);
+  zoomToStandardAction = viewMenu->addAction("Zoom to 1:1", ui.displaySplitView, SLOT(resetViews()), Qt::CTRL + Qt::Key_0);
+  zoomToFitAction = viewMenu->addAction("Zoom to Fit", ui.displaySplitView, SLOT(zoomToFit()), Qt::CTRL + Qt::Key_9);
+  zoomInAction = viewMenu->addAction("Zoom in", ui.displaySplitView, SLOT(zoomIn()), Qt::CTRL + Qt::Key_Plus);
+  zoomOutAction = viewMenu->addAction("Zoom out", ui.displaySplitView, SLOT(zoomOut()), Qt::CTRL + Qt::Key_Minus);
   viewMenu->addSeparator();
-  togglePlaylistAction = viewMenu->addAction("Hide/Show P&laylist", ui->playlistDockWidget->toggleViewAction(), SLOT(trigger()),Qt::CTRL + Qt::Key_L);
-  toggleDisplayOptionsAction = viewMenu->addAction("Hide/Show &Display Options", ui->displayDockWidget->toggleViewAction(), SLOT(trigger()),Qt::CTRL + Qt::Key_D);
-  togglePropertiesAction = viewMenu->addAction("Hide/Show &Properties", ui->propertiesDock->toggleViewAction(), SLOT(trigger()));
-  toggleFileInfoAction = viewMenu->addAction("Hide/Show &FileInfo", ui->fileInfoDock->toggleViewAction(), SLOT(trigger()));
+  togglePlaylistAction = viewMenu->addAction("Hide/Show P&laylist", ui.playlistDockWidget->toggleViewAction(), SLOT(trigger()),Qt::CTRL + Qt::Key_L);
+  toggleDisplayOptionsAction = viewMenu->addAction("Hide/Show &Display Options", ui.displayDockWidget->toggleViewAction(), SLOT(trigger()),Qt::CTRL + Qt::Key_D);
+  togglePropertiesAction = viewMenu->addAction("Hide/Show &Properties", ui.propertiesDock->toggleViewAction(), SLOT(trigger()));
+  toggleFileInfoAction = viewMenu->addAction("Hide/Show &FileInfo", ui.fileInfoDock->toggleViewAction(), SLOT(trigger()));
   viewMenu->addSeparator();
-  toggleControlsAction = viewMenu->addAction("Hide/Show Playback &Controls", ui->playbackControllerDock->toggleViewAction(), SLOT(trigger()));
+  toggleControlsAction = viewMenu->addAction("Hide/Show Playback &Controls", ui.playbackControllerDock->toggleViewAction(), SLOT(trigger()));
   viewMenu->addSeparator();
   toggleFullscreenAction = viewMenu->addAction("&Fullscreen Mode", this, SLOT(toggleFullscreen()), Qt::CTRL + Qt::Key_F);
-  toggleSingleSeparateWindowModeAction = viewMenu->addAction("&Single/Separate Window Mode", ui->displaySplitView, SLOT(toggleSeparateViewHideShow()), Qt::CTRL + Qt::Key_W);
+  toggleSingleSeparateWindowModeAction = viewMenu->addAction("&Single/Separate Window Mode", ui.displaySplitView, SLOT(toggleSeparateViewHideShow()), Qt::CTRL + Qt::Key_W);
 
   playbackMenu = menuBar()->addMenu(tr("&Playback"));
-  playPauseAction = playbackMenu->addAction("Play/Pause", ui->playbackController, SLOT(on_playPauseButton_clicked()), Qt::Key_Space);
-  nextItemAction = playbackMenu->addAction("Next Playlist Item", ui->playlistTreeWidget, SLOT(selectNextItem()), Qt::Key_Down);
-  previousItemAction = playbackMenu->addAction("Previous Playlist Item", ui->playlistTreeWidget, SLOT(selectPreviousItem()), Qt::Key_Up);
-  nextFrameAction = playbackMenu->addAction("Next Frame", ui->playbackController, SLOT(nextFrame()), Qt::Key_Right);
-  previousFrameAction = playbackMenu->addAction("Previous Frame", ui->playbackController, SLOT(previousFrame()), Qt::Key_Left);
+  playPauseAction = playbackMenu->addAction("Play/Pause", ui.playbackController, SLOT(on_playPauseButton_clicked()), Qt::Key_Space);
+  nextItemAction = playbackMenu->addAction("Next Playlist Item", ui.playlistTreeWidget, SLOT(selectNextItem()), Qt::Key_Down);
+  previousItemAction = playbackMenu->addAction("Previous Playlist Item", ui.playlistTreeWidget, SLOT(selectPreviousItem()), Qt::Key_Up);
+  nextFrameAction = playbackMenu->addAction("Next Frame", ui.playbackController, SLOT(nextFrame()), Qt::Key_Right);
+  previousFrameAction = playbackMenu->addAction("Previous Frame", ui.playbackController, SLOT(previousFrame()), Qt::Key_Left);
 
   helpMenu = menuBar()->addMenu(tr("&Help"));
   aboutAction = helpMenu->addAction("About YUView", this, SLOT(showAbout()));
@@ -204,7 +204,6 @@ void MainWindow::updateRecentFileActions()
 
 MainWindow::~MainWindow()
 {
-  delete ui;
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)
@@ -276,7 +275,7 @@ void MainWindow::deleteItem()
   //qDebug() << QTime::currentTime().toString("hh:mm:ss.zzz") << "MainWindow::deleteItem()";
 
   // stop playback first
-  ui->playbackController->pausePlayback();
+  ui.playbackController->pausePlayback();
 
   p_playlistWidget->deleteSelectedPlaylistItems();
 }
@@ -301,27 +300,27 @@ bool MainWindow::handleKeyPress(QKeyEvent *event, bool keyFromSeparateView)
   }
   else if (key == Qt::Key_Space)
   {
-    ui->playbackController->on_playPauseButton_clicked();
+    ui.playbackController->on_playPauseButton_clicked();
     return true;
   }
   else if (key == Qt::Key_Right)
   {
-    ui->playbackController->nextFrame();
+    ui.playbackController->nextFrame();
     return true;
   }
   else if (key == Qt::Key_Left)
   {
-    ui->playbackController->previousFrame();
+    ui.playbackController->previousFrame();
     return true;
   }
   else if (key == Qt::Key_Down)
   {
-    ui->playlistTreeWidget->selectNextItem();
+    ui.playlistTreeWidget->selectNextItem();
     return true;
   }
   else if (key == Qt::Key_Up)
   {
-    ui->playlistTreeWidget->selectPreviousItem();
+    ui.playlistTreeWidget->selectPreviousItem();
     return true;
   }
   else if (stateHandler.handleKeyPress(event, keyFromSeparateView))
@@ -331,7 +330,7 @@ bool MainWindow::handleKeyPress(QKeyEvent *event, bool keyFromSeparateView)
   else if (!keyFromSeparateView)
   {
     // See if the split view widget handles this key press. If not, return false.
-    return ui->displaySplitView->handleKeyPress(event);
+    return ui.displaySplitView->handleKeyPress(event);
   }
 
   return false;
@@ -374,15 +373,15 @@ void MainWindow::toggleFullscreen()
     // We are in full screen mode. Toggle back to windowed mode.
 
     // Show all dock panels
-    ui->propertiesDock->show();
-    ui->playlistDockWidget->show();
-    ui->displayDockWidget->show();
-    ui->playbackControllerDock->show();
-    ui->fileInfoDock->show();
+    ui.propertiesDock->show();
+    ui.playlistDockWidget->show();
+    ui.displayDockWidget->show();
+    ui.playbackControllerDock->show();
+    ui.fileInfoDock->show();
 
 #ifndef QT_OS_MAC
     // show the menu bar
-    ui->menuBar->show();
+    ui.menuBar->show();
 #endif
 
     // Show the window normal or maximized (depending on how it was shown before)
@@ -396,14 +395,14 @@ void MainWindow::toggleFullscreen()
     // Toggle to full screen mode
 
     // Hide panels
-    ui->propertiesDock->hide();
-    ui->playlistDockWidget->hide();
-    ui->displayDockWidget->hide();
-    ui->playbackControllerDock->hide();
-    ui->fileInfoDock->hide();
+    ui.propertiesDock->hide();
+    ui.playlistDockWidget->hide();
+    ui.displayDockWidget->hide();
+    ui.playbackControllerDock->hide();
+    ui.fileInfoDock->hide();
 #ifndef QT_OS_MAC
     // hide menu bar
-    ui->menuBar->hide();
+    ui.menuBar->hide();
 #endif
     
     // Save if the window is currently maximized
@@ -412,7 +411,7 @@ void MainWindow::toggleFullscreen()
     showFullScreen();
   }
 
-  ui->displaySplitView->resetViews();
+  ui.displaySplitView->resetViews();
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -469,7 +468,7 @@ void MainWindow::saveScreenshot() {
 
   QString filename = QFileDialog::getSaveFileName(this, tr("Save Screenshot"), settings.value("LastScreenshotPath").toString(), tr("PNG Files (*.png);"));
 
-  ui->displaySplitView->getScreenshot().save(filename);
+  ui.displaySplitView->getScreenshot().save(filename);
 
   filename = filename.section('/', 0, -2);
   settings.setValue("LastScreenshotPath", filename);
@@ -539,12 +538,12 @@ void MainWindow::resetWindowLayout()
   QSettings settings;
 
   // Quit full screen if anything is in full screen
-  ui->displaySplitView->showNormal();
+  ui.displaySplitView->showNormal();
   separateViewWindow.showNormal();
   showNormal();
 
   // Get the split view widget back to the main window and hide the seperate window
-  setCentralWidget(ui->displaySplitView);
+  setCentralWidget(ui.displaySplitView);
 
   // Reset the seperate window and save the state
   separateViewWindow.hide();
@@ -554,15 +553,15 @@ void MainWindow::resetWindowLayout()
   settings.setValue("separateViewWindow/windowState", separateViewWindow.saveState());
 
   // Dock all dock panels
-  ui->playlistDockWidget->setFloating(false);
-  ui->propertiesDock->setFloating(false);
-  ui->displayDockWidget->setFloating(false);
-  ui->playbackControllerDock->setFloating(false);
-  ui->fileInfoDock->setFloating(false);
+  ui.playlistDockWidget->setFloating(false);
+  ui.propertiesDock->setFloating(false);
+  ui.displayDockWidget->setFloating(false);
+  ui.playbackControllerDock->setFloating(false);
+  ui.fileInfoDock->setFloating(false);
   
 #ifndef QT_OS_MAC
   // show the menu bar
-  ui->menuBar->show();
+  ui.menuBar->show();
 #endif
 
   // Reset main window state (the size and position of the dock widgets)
@@ -578,5 +577,5 @@ void MainWindow::resetWindowLayout()
   settings.setValue("mainWindow/windowState", saveState());
 
   // Reset the split view
-  ui->displaySplitView->resetViews();
+  ui.displaySplitView->resetViews();
 }

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -66,8 +66,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
   connect(ui.displaySplitView, SIGNAL(signalToggleFullScreen()), this, SLOT(toggleFullscreen()));
 
   // Setup primary/separate splitView
-  ui.displaySplitView->setSeparateWidget( separateViewWindow.splitView );
-  separateViewWindow.splitView->setPrimaryWidget( ui.displaySplitView );
+  ui.displaySplitView->setSeparateWidget( &separateViewWindow.splitView );
+  separateViewWindow.splitView.setPrimaryWidget( ui.displaySplitView );
   connect(ui.displaySplitView, SIGNAL(signalShowSeparateWindow(bool)), &separateViewWindow, SLOT(setVisible(bool)));
 
   // Connect the playlistWidget signals to some slots
@@ -84,12 +84,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
 
   createMenusAndActions();
 
-  ui.playbackController->setSplitViews( ui.displaySplitView, separateViewWindow.splitView );
+  ui.playbackController->setSplitViews( ui.displaySplitView, &separateViewWindow.splitView );
   ui.playbackController->setPlaylist( ui.playlistTreeWidget );
   ui.displaySplitView->setPlaybackController( ui.playbackController );
   ui.displaySplitView->setPlaylistTreeWidget( p_playlistWidget );
-  separateViewWindow.splitView->setPlaybackController( ui.playbackController );
-  separateViewWindow.splitView->setPlaylistTreeWidget( p_playlistWidget );
+  separateViewWindow.splitView.setPlaybackController( ui.playbackController );
+  separateViewWindow.splitView.setPlaylistTreeWidget( p_playlistWidget );
 
   // load geometry and active dockable widgets from user preferences
   restoreGeometry(settings.value("mainWindow/geometry").toByteArray());
@@ -99,7 +99,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
   
   connect(&p_settingswindow, SIGNAL(settingsChanged()), this, SLOT(updateSettings()));
   connect(&p_settingswindow, SIGNAL(settingsChanged()), ui.displaySplitView, SLOT(updateSettings()));
-  connect(&p_settingswindow, SIGNAL(settingsChanged()), separateViewWindow.splitView, SLOT(updateSettings()));
+  connect(&p_settingswindow, SIGNAL(settingsChanged()), &separateViewWindow.splitView, SLOT(updateSettings()));
   connect(&p_settingswindow, SIGNAL(settingsChanged()), p_playlistWidget, SLOT(updateSettings()));
   
   connect(ui.openButton, SIGNAL(clicked()), this, SLOT(showFileOpenDialog()));
@@ -112,7 +112,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
   updateSettings();
 
   // Set the controls in the state handler. Thiw way, the state handler can save/load the current state of the view.
-  stateHandler.setConctrols(ui.playbackController, p_playlistWidget, ui.displaySplitView, separateViewWindow.splitView);
+  stateHandler.setConctrols(ui.playbackController, p_playlistWidget, ui.displaySplitView, &separateViewWindow.splitView);
   // Give the playlist a pointer to the state handler so it can save the states ti playlist
   p_playlistWidget->setViewStateHandler(&stateHandler);
 

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -57,7 +57,7 @@ public:
   
 private:
   PlaylistTreeWidget *p_playlistWidget;
-  Ui::MainWindow *ui;
+  Ui::MainWindow ui;
 
   QMessageBox *p_msg;
   bool p_ClearFrame;

--- a/source/playlistItemDifference.cpp
+++ b/source/playlistItemDifference.cpp
@@ -126,9 +126,9 @@ void playlistItemDifference::createPropertiesWidget( )
   line->setFrameShadow(QFrame::Sunken);
 
   // First add the parents controls (first video controls (width/height...) then yuv controls (format,...)
-  vAllLaout->addLayout( difference.createFrameHandlerControls(propertiesWidget, true) );
+  vAllLaout->addLayout( difference.createFrameHandlerControls(true) );
   vAllLaout->addWidget( line );
-  vAllLaout->addLayout( difference.createDifferenceHandlerControls(propertiesWidget) );
+  vAllLaout->addLayout( difference.createDifferenceHandlerControls() );
 
   // Insert a stretch at the bottom of the vertical global layout so that everything
   // gets 'pushed' to the top

--- a/source/playlistItemHEVCFile.cpp
+++ b/source/playlistItemHEVCFile.cpp
@@ -548,19 +548,19 @@ void playlistItemHEVCFile::createPropertiesWidget( )
   lineOne->setFrameShadow(QFrame::Sunken);
 
   // First add the parents controls (first index controllers (start/end...) then yuv controls (format,...)
-  vAllLaout->addLayout( createIndexControllers(propertiesWidget) );
+  vAllLaout->addLayout( createIndexControllers() );
   vAllLaout->addWidget( lineOne );
-  vAllLaout->addLayout( yuvVideo.createYUVVideoHandlerControls(propertiesWidget, true) );
+  vAllLaout->addLayout( yuvVideo.createYUVVideoHandlerControls(true) );
 
   if (internalsSupported)
   {
-    QFrame *line2 = new QFrame(propertiesWidget);
+    QFrame *line2 = new QFrame;
     line2->setObjectName(QStringLiteral("line"));
     line2->setFrameShape(QFrame::HLine);
     line2->setFrameShadow(QFrame::Sunken);
 
     vAllLaout->addWidget( line2 );
-    vAllLaout->addLayout( statSource.createStatisticsHandlerControls(propertiesWidget), 1 );
+    vAllLaout->addLayout( statSource.createStatisticsHandlerControls(), 1 );
   }
   else
   {

--- a/source/playlistItemImageFileSequence.cpp
+++ b/source/playlistItemImageFileSequence.cpp
@@ -130,7 +130,7 @@ void playlistItemImageFileSequence::createPropertiesWidget()
   QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget);
 
   // First add the parents controls (first video controls (width/height...)
-  vAllLaout->addLayout( createIndexControllers(propertiesWidget) );
+  vAllLaout->addLayout( createIndexControllers() );
     
   // Insert a stretch at the bottom of the vertical global layout so that everything
   // gets 'pushed' to the top

--- a/source/playlistItemOverlay.cpp
+++ b/source/playlistItemOverlay.cpp
@@ -25,9 +25,8 @@
 
 #define OVERLAY_TEXT "Please drop some items onto this overlay. All child items will be drawn on top of each other."
 
-playlistItemOverlay::playlistItemOverlay() 
-  : playlistItem("Overlay Item")
-  , ui(NULL)
+playlistItemOverlay::playlistItemOverlay() :
+  playlistItem("Overlay Item")
 {
   // TODO: Create new symbol for this
   setIcon(0, QIcon(":difference.png"));
@@ -190,7 +189,7 @@ void playlistItemOverlay::updateLayout(bool checkNumber)
   childItems[0] = firstItemRect;
   
   // Align the rest of the items
-  int alignmentMode = ui->alignmentMode->currentIndex();
+  int alignmentMode = ui.alignmentMode->currentIndex();
   for (int i = 1; i < childCount(); i++)
   {
     playlistItem *childItem = dynamic_cast<playlistItem*>(child(i));
@@ -261,14 +260,14 @@ void playlistItemOverlay::updateChildList()
     if (childList[i]->providesStatistics())
     {
       // Add the statistics controls also to the overlay widget
-      ui->verticalLayout->addWidget( childList[i]->getStatisticsHandler()->getSecondaryStatisticsHandlerControls() );
+      ui.verticalLayout->addWidget( childList[i]->getStatisticsHandler()->getSecondaryStatisticsHandlerControls() );
       statisticsPresent = true;
     }
 
   if (statisticsPresent)
   {
     // Remove the spacer
-    ui->verticalLayout->removeItem(vSpacer);
+    ui.verticalLayout->removeItem(vSpacer);
     delete vSpacer;
     vSpacer = NULL;
   }
@@ -276,7 +275,7 @@ void playlistItemOverlay::updateChildList()
   {
     // Add a spacer item at the end
     vSpacer = new QSpacerItem(0, 10, QSizePolicy::Ignored, QSizePolicy::MinimumExpanding);
-    ui->verticalLayout->addSpacerItem(vSpacer);
+    ui.verticalLayout->addSpacerItem(vSpacer);
   }
 
   childLlistUpdateRequired = false;
@@ -300,30 +299,29 @@ void playlistItemOverlay::itemAboutToBeDeleter(playlistItem *item)
 void playlistItemOverlay::createPropertiesWidget( )
 {
   // Absolutely always only call this once
-  Q_ASSERT_X( !ui, "playlistItemOverlay::createPropertiesWidget", "Always create the properties only once!");
+  Q_ASSERT_X(!propertiesWidget, "playlistItemOverlay::createPropertiesWidget", "Always create the properties only once!");
   
   // Create a new widget and populate it with controls
   propertiesWidget = new QWidget;
-  ui = new Ui::playlistItemOverlay_Widget;
-  ui->setupUi( propertiesWidget );
-  propertiesWidget->setLayout( ui->verticalLayout );
+  ui.setupUi( propertiesWidget );
+  propertiesWidget->setLayout( ui.verticalLayout );
 
   // Alignment mode
-  ui->alignmentMode->addItems( QStringList() << "Top Left" << "Top Center" << "Top Right" );
-  ui->alignmentMode->addItems( QStringList() << "Center Left" << "Center" << "Center Right" );
-  ui->alignmentMode->addItems( QStringList() << "Bottom Left" << "Bottom Center" << "Bottom Right" );
-  ui->alignmentMode->setCurrentIndex(alignmentMode);
+  ui.alignmentMode->addItems( QStringList() << "Top Left" << "Top Center" << "Top Right" );
+  ui.alignmentMode->addItems( QStringList() << "Center Left" << "Center" << "Center Right" );
+  ui.alignmentMode->addItems( QStringList() << "Bottom Left" << "Bottom Center" << "Bottom Right" );
+  ui.alignmentMode->setCurrentIndex(alignmentMode);
 
   // Offset
-  ui->alignmentHozizontal->setRange(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
-  ui->alignmentVertical->setRange(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
-  ui->alignmentHozizontal->setValue( manualAlignment.x() );
-  ui->alignmentVertical->setValue( manualAlignment.y() );
+  ui.alignmentHozizontal->setRange(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+  ui.alignmentVertical->setRange(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+  ui.alignmentHozizontal->setValue( manualAlignment.x() );
+  ui.alignmentVertical->setValue( manualAlignment.y() );
 
   // Conncet signals/slots
-  connect(ui->alignmentMode, SIGNAL(currentIndexChanged(int)), this, SLOT(controlChanged(int)));
-  connect(ui->alignmentHozizontal, SIGNAL(valueChanged(int)), this, SLOT(controlChanged(int)));
-  connect(ui->alignmentVertical, SIGNAL(valueChanged(int)), this, SLOT(controlChanged(int)));
+  connect(ui.alignmentMode, SIGNAL(currentIndexChanged(int)), this, SLOT(controlChanged(int)));
+  connect(ui.alignmentHozizontal, SIGNAL(valueChanged(int)), this, SLOT(controlChanged(int)));
+  connect(ui.alignmentVertical, SIGNAL(valueChanged(int)), this, SLOT(controlChanged(int)));
 }
 
 void playlistItemOverlay::savePlaylist(QDomElement &root, QDir playlistDir)
@@ -381,9 +379,9 @@ void playlistItemOverlay::controlChanged(int idx)
   Q_UNUSED(idx);
 
   // One of the controls changed. Update values and emit the redraw signal
-  alignmentMode = ui->alignmentMode->currentIndex();
-  manualAlignment.setX( ui->alignmentHozizontal->value() );
-  manualAlignment.setY( ui->alignmentVertical->value() );
+  alignmentMode = ui.alignmentMode->currentIndex();
+  manualAlignment.setX( ui.alignmentHozizontal->value() );
+  manualAlignment.setY( ui.alignmentVertical->value() );
 
   // No new item was added but update the layout of the items
   updateLayout(false);

--- a/source/playlistItemOverlay.h
+++ b/source/playlistItemOverlay.h
@@ -85,7 +85,7 @@ private:
   // Return the first child item (as playlistItem) or NULL if there is no child.
   playlistItem *getFirstChildPlaylistItem();
 
-  Ui_playlistItemOverlay_Widget *ui;
+  Ui::playlistItemOverlay_Widget *ui;
 
   int alignmentMode;
   QPoint manualAlignment;

--- a/source/playlistItemOverlay.h
+++ b/source/playlistItemOverlay.h
@@ -85,7 +85,7 @@ private:
   // Return the first child item (as playlistItem) or NULL if there is no child.
   playlistItem *getFirstChildPlaylistItem();
 
-  Ui::playlistItemOverlay_Widget *ui;
+  SafeUi<Ui::playlistItemOverlay_Widget> ui;
 
   int alignmentMode;
   QPoint manualAlignment;

--- a/source/playlistItemRawFile.cpp
+++ b/source/playlistItemRawFile.cpp
@@ -176,12 +176,12 @@ void playlistItemRawFile::createPropertiesWidget( )
   line->setFrameShadow(QFrame::Sunken);
   
   // First add the parents controls (first video controls (width/height...) then videoHandler controls (format,...)
-  vAllLaout->addLayout( createIndexControllers(propertiesWidget) );
+  vAllLaout->addLayout( createIndexControllers() );
   vAllLaout->addWidget( line );
   if (rawFormat == YUV)
-    vAllLaout->addLayout( getYUVVideo()->createYUVVideoHandlerControls(propertiesWidget) );
+    vAllLaout->addLayout( getYUVVideo()->createYUVVideoHandlerControls() );
   else if (rawFormat == RGB)
-    vAllLaout->addLayout( getRGBVideo()->createRGBVideoHandlerControls(propertiesWidget) );
+    vAllLaout->addLayout( getRGBVideo()->createRGBVideoHandlerControls() );
   
   // Insert a stretch at the bottom of the vertical global layout so that everything
   // gets 'pushed' to the top

--- a/source/playlistItemStatisticsFile.cpp
+++ b/source/playlistItemStatisticsFile.cpp
@@ -560,9 +560,9 @@ void playlistItemStatisticsFile::createPropertiesWidget()
   line->setFrameShape(QFrame::HLine);
   line->setFrameShadow(QFrame::Sunken);
 
-  vAllLaout->addLayout( createIndexControllers(propertiesWidget) );
+  vAllLaout->addLayout( createIndexControllers() );
   vAllLaout->addWidget( line );
-  vAllLaout->addLayout( statSource.createStatisticsHandlerControls(propertiesWidget) );
+  vAllLaout->addLayout( statSource.createStatisticsHandlerControls() );
 
   // Do not add any stretchers at the bottom because the statistics handler controls will
   // expand to take up as much space as there is available  

--- a/source/playlistItemText.cpp
+++ b/source/playlistItemText.cpp
@@ -41,7 +41,6 @@ playlistItemText::playlistItemText(QString initialText)
 
   color = Qt::black;
   text = initialText;
-  controlsCreated = false;
 }
 
 // The copy contructor. Copy all the setting from the other text item.
@@ -52,8 +51,6 @@ playlistItemText::playlistItemText(playlistItemText *cloneFromTxt)
   setIcon(0, QIcon(":img_text.png"));
   // Nothing can be dropped onto a text item
   setFlags(flags() & ~Qt::ItemIsDropEnabled);
-  
-  controlsCreated = false;
   
   // Copy playlistItemText properties
   color = cloneFromTxt->color;
@@ -86,9 +83,9 @@ void playlistItemText::createPropertiesWidget()
   line->setFrameShadow(QFrame::Sunken);
 
   // First add the parents controls (duration) then the text spcific controls (font, text...)
-  vAllLaout->addLayout( createStaticTimeController(propertiesWidget) );
+  vAllLaout->addLayout( createStaticTimeController() );
   vAllLaout->addWidget( line );
-  vAllLaout->addLayout( createTextController(propertiesWidget) );
+  vAllLaout->addLayout( createTextController() );
 
   // Insert a stretch at the bottom of the vertical global layout so that everything
   // gets 'pushed' to the top
@@ -98,14 +95,12 @@ void playlistItemText::createPropertiesWidget()
   propertiesWidget->setLayout( vAllLaout );
 }
 
-QLayout *playlistItemText::createTextController(QWidget *parentWidget)
+QLayout *playlistItemText::createTextController()
 {
-  Q_UNUSED(parentWidget);
-
   // Absolutely always only call this function once!
-  assert(!controlsCreated);
+  assert(!ui.created());
 
-  ui.setupUi( propertiesWidget );
+  ui.setupUi();
   
   // Set the text
   ui.textEdit->setPlainText(text);
@@ -117,7 +112,6 @@ QLayout *playlistItemText::createTextController(QWidget *parentWidget)
   connect(ui.selectColorButton, SIGNAL(clicked()), this, SLOT(on_selectColorButton_clicked()));
   connect(ui.textEdit, SIGNAL(textChanged()), this, SLOT(on_textEdit_textChanged()));
 
-  controlsCreated = true;
   return ui.topVBoxLayout;
 }
 

--- a/source/playlistItemText.h
+++ b/source/playlistItemText.h
@@ -62,7 +62,7 @@ protected:
   virtual void createPropertiesWidget() Q_DECL_OVERRIDE;
 
   // Create the text specific controls (font, color, text)
-  QLayout *createTextController(QWidget *parentWidget);
+  QLayout *createTextController();
 
 private:
 
@@ -70,8 +70,7 @@ private:
   QFont   font;
   QString text;
 
-  Ui_playlistItemText ui;
-  bool controlsCreated;
+  SafeUi<Ui::playlistItemText> ui;
 
 private slots:
   // Slots for the controls (automatically connected by the UI)

--- a/source/playlistitemIndexed.cpp
+++ b/source/playlistitemIndexed.cpp
@@ -24,16 +24,15 @@ playlistItemIndexed::playlistItemIndexed(QString itemNameOrFileName) :
   frameRate = DEFAULT_FRAMERATE;
   sampling  = 1;
   startEndFrame = indexRange(-1,-1);
-  controlsCreated = false;
   startEndFrameChanged = false;
 }
 
-QLayout *playlistItemIndexed::createIndexControllers(QWidget *parentWidget)
+QLayout *playlistItemIndexed::createIndexControllers()
 {
   // Absolutely always only call this function once!
-  assert(!controlsCreated);
+  assert(!ui.created());
     
-  ui.setupUi(parentWidget);
+  ui.setupUi();
     
   indexRange startEndFrameLimit = getstartEndFrameLimits();
   if (startEndFrame == indexRange(-1,-1))
@@ -59,8 +58,7 @@ QLayout *playlistItemIndexed::createIndexControllers(QWidget *parentWidget)
   connect(ui.endSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotVideoControlChanged()));
   connect(ui.rateSpinBox, SIGNAL(valueChanged(double)), this, SLOT(slotVideoControlChanged()));
   connect(ui.samplingSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotVideoControlChanged()));
-    
-  controlsCreated = true;
+
   return ui.gridLayout;
 }
 
@@ -89,7 +87,7 @@ void playlistItemIndexed::setStartEndFrame(indexRange range, bool emitSignal)
   startEndFrame.first = std::max(startEndFrameLimit.first, range.first);
   startEndFrame.second = std::min(startEndFrameLimit.second, range.second);
 
-  if (!controlsCreated)
+  if (!ui.created())
     // spin boxes not created yet
     return;
 

--- a/source/playlistitemIndexed.h
+++ b/source/playlistitemIndexed.h
@@ -59,7 +59,7 @@ protected slots:
 protected:
 
   // Add the control for the time that this item is shown to
-  QLayout *createIndexControllers(QWidget *parentWidget);
+  QLayout *createIndexControllers();
 
   void setStartEndFrame(indexRange range, bool emitSignal);
 
@@ -74,10 +74,9 @@ protected:
   indexRange startEndFrame;
 
 private:
-  bool controlsCreated;
   bool startEndFrameChanged;  //< Has the user changed the start/end frame yet?
 
-  Ui::playlistItemIndexed ui;
+  SafeUi<Ui::playlistItemIndexed> ui;
 
 };
 

--- a/source/playlistitemStatic.cpp
+++ b/source/playlistitemStatic.cpp
@@ -21,23 +21,21 @@
 playlistItemStatic::playlistItemStatic(QString itemNameOrFileName) :
     playlistItem(itemNameOrFileName)
 {
-  controlsCreated = false;
   duration = PLAYLISTITEMTEXT_DEFAULT_DURATION;
 }
 
-QLayout *playlistItemStatic::createStaticTimeController(QWidget *parentWidget)
+QLayout *playlistItemStatic::createStaticTimeController()
 {
   // Absolutely always only call this function once!
-  assert(!controlsCreated);
+  assert(!ui.created());
     
-  ui.setupUi(parentWidget);
+  ui.setupUi();
   // Set min/max duration
   ui.durationSpinBox->setMaximum(100000);
   ui.durationSpinBox->setValue(duration);
 
   connect(ui.durationSpinBox, SIGNAL(valueChanged(double)), this, SLOT(on_durationSpinBox_valueChanged(double)));
 
-  controlsCreated = true;
   return ui.horizontalLayout;
 }
 
@@ -76,7 +74,7 @@ void playlistItemStatic::createPropertiesWidget()
   line->setFrameShadow(QFrame::Sunken);
 
   // First add the parents controls (duration) then the text spcific controls (font, text...)
-  vAllLaout->addLayout( createStaticTimeController(propertiesWidget) );
+  vAllLaout->addLayout( createStaticTimeController() );
   vAllLaout->addWidget( line );
   
   // Insert a stretch at the bottom of the vertical global layout so that everything

--- a/source/playlistitemStatic.h
+++ b/source/playlistitemStatic.h
@@ -54,7 +54,7 @@ protected:
   virtual void createPropertiesWidget() Q_DECL_OVERRIDE;
 
   // Add the control for the time that this item is shown to
-  QLayout *createStaticTimeController(QWidget *parentWidget);
+  QLayout *createStaticTimeController();
 
   // Load/Save from/to playlist
   void appendPropertiesToPlaylist(QDomElementYUView &d);
@@ -64,9 +64,7 @@ protected:
   double duration;
 
 private:
-  bool controlsCreated;
-
-  Ui::PlaylistItemStatic ui;
+  SafeUi<Ui::PlaylistItemStatic> ui;
 
 };
 

--- a/source/propertiesWidget.cpp
+++ b/source/propertiesWidget.cpp
@@ -24,20 +24,16 @@
  * If you provide a list of QString tuples, this class will fill a grid layout with the 
  * corresponding labels.
  */
-PropertiesWidget::PropertiesWidget(QWidget *parent) : QWidget(parent)
+PropertiesWidget::PropertiesWidget(QWidget *parent) :
+  QWidget(parent),
+  topLayout(this)
 {
-  QVBoxLayout *layout = new QVBoxLayout;
-  layout->setContentsMargins(0, 0, 0, 0);
-  stack = new QStackedWidget(this);
-  layout->addWidget(stack);
-  setLayout(layout);
+  topLayout.setContentsMargins(0, 0, 0, 0);
+  topLayout.addWidget(&stack);
 
   // Create and add the empty widget. This widget is shown when no item is selected.
-  emptyWidget = new QWidget;
-  stack->addWidget(emptyWidget);
-
-  // Set the default window title and show an empty widget
-  stack->setCurrentWidget(emptyWidget);
+  stack.addWidget(&emptyWidget);
+  stack.setCurrentWidget(&emptyWidget);
 }
 
 PropertiesWidget::~PropertiesWidget()
@@ -62,17 +58,17 @@ void PropertiesWidget::currentSelectedItemsChanged(playlistItem *item1, playlist
     // Show the properties widget of the first selection
     QWidget *propertiesWidget = item1->getPropertiesWidget();
 
-    if ( stack->indexOf(propertiesWidget) == -1 )
+    if ( stack.indexOf(propertiesWidget) == -1 )
       // The properties widget was just created and is not in the stack yet.
-      stack->addWidget( propertiesWidget );
+      stack.addWidget( propertiesWidget );
 
     // Show the properties widget
-    stack->setCurrentWidget( propertiesWidget );
+    stack.setCurrentWidget( propertiesWidget );
   }
   else
   {
     // Show the empty widget
-    stack->setCurrentWidget( emptyWidget );
+    stack.setCurrentWidget( &emptyWidget );
   }
 }
 
@@ -83,7 +79,7 @@ void PropertiesWidget::itemAboutToBeDeleted(playlistItem *item)
     // The properties widget for the item was created and it should be in the widget stack.
     // Remove it from the stack but don't delete it. The playlistItem itself will take care of that.
     QWidget *w = item->getPropertiesWidget();
-    assert( stack->indexOf(w) != -1 );
-    stack->removeWidget( w );
+    assert( stack.indexOf(w) != -1 );
+    stack.removeWidget( w );
   }
 }

--- a/source/propertiesWidget.h
+++ b/source/propertiesWidget.h
@@ -22,6 +22,7 @@
 #include "playlistItem.h"
 #include "typedef.h"
 #include <QStackedWidget>
+#include <QVBoxLayout>
 
 // This is the text that will be shown in the dockWidgets title if no playlistitem is selected
 #define PROPERTIESWIDGET_DEFAULT_WINDOW_TITEL "Properties"
@@ -44,9 +45,9 @@ public slots:
   void itemAboutToBeDeleted(playlistItem *item);
 
 private:
-  
-  QStackedWidget *stack;
-  QWidget *emptyWidget;
+  QVBoxLayout topLayout;
+  QStackedWidget stack;
+  QWidget emptyWidget;
 };
 
 #endif // PROPERTIESWIDGET_H

--- a/source/separateWindow.cpp
+++ b/source/separateWindow.cpp
@@ -18,16 +18,15 @@
 
 #include "separateWindow.h"
 
-SeparateWindow::SeparateWindow() : QMainWindow()
+SeparateWindow::SeparateWindow() :
+  splitView(this, true)
 {
-  // Create a new splitViewWidget and set it as center widget
-  splitView = new splitViewWidget(this, true);
-  setCentralWidget(splitView);
-  splitView->setAttribute(Qt::WA_AcceptTouchEvents);
+  setCentralWidget(&splitView);
+  splitView.setAttribute(Qt::WA_AcceptTouchEvents);
 
-  connect(splitView, SIGNAL(signalToggleFullScreen()), this, SLOT(toggleFullscreen()));
-  connect(splitView, SIGNAL(signalShowSeparateWindow(bool)), this, SLOT(splitViewShowSeparateWindow(bool)));
-};
+  connect(&splitView, SIGNAL(signalToggleFullScreen()), this, SLOT(toggleFullscreen()));
+  connect(&splitView, SIGNAL(signalShowSeparateWindow(bool)), this, SLOT(splitViewShowSeparateWindow(bool)));
+}
 
 void SeparateWindow::toggleFullscreen()
 {
@@ -72,7 +71,7 @@ void SeparateWindow::keyPressEvent(QKeyEvent *event)
   else
   {
     // See if the split view widget handles this key press. If not, pass the event on to the QWidget.
-    if (!splitView->handleKeyPress(event))
+    if (!splitView.handleKeyPress(event))
       emit unhandledKeyPress(event);    
 
     //QWidget::keyPressEvent(event);

--- a/source/separateWindow.h
+++ b/source/separateWindow.h
@@ -31,7 +31,7 @@ class SeparateWindow : public QMainWindow
 
 public:
   explicit SeparateWindow();
-  splitViewWidget *splitView;
+  splitViewWidget splitView;
 
 signals:
   // Signal that the user wants to go back to single window mode

--- a/source/settingswindow.cpp
+++ b/source/settingswindow.cpp
@@ -37,8 +37,7 @@
 #endif
 
 SettingsWindow::SettingsWindow(QWidget *parent) :
-  QWidget(parent),
-  ui(new Ui::SettingsWindow)
+  QWidget(parent)
 {
   // Fet size of main memory - assume 2 GB first.
   // Unfortunately there is no Qt ways of doing this so this is platform dependent.
@@ -62,15 +61,15 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
   memSizeInMB = status.ullTotalPhys >> 20;
 #endif
 
-  ui->setupUi(this);
+  ui.setupUi(this);
 
   // Set the minimum and maximum values for memory
-  ui->maxMBLabel->setText(QString("%1 MB").arg(memSizeInMB));
-  ui->minMBLabel->setText(QString("%1 MB").arg(memSizeInMB / 100));
+  ui.maxMBLabel->setText(QString("%1 MB").arg(memSizeInMB));
+  ui.minMBLabel->setText(QString("%1 MB").arg(memSizeInMB / 100));
 
 #if !UPDATE_FEATURE_ENABLE
   // Updating is not supported. Disable the update strategy combo box.
-  ui->updateSettingComboBox->setEnabled(false);
+  ui.updateSettingComboBox->setEnabled(false);
 #endif
 
   loadSettings();
@@ -78,15 +77,14 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
 
 SettingsWindow::~SettingsWindow()
 {
-  delete ui;
 }
 
 unsigned int SettingsWindow::getCacheSizeInMB()
 {
   unsigned int useMem = 0;
   // update video cache
-  if ( ui->cachingGroupBox->isChecked() )
-    useMem = memSizeInMB * (ui->cacheThresholdSlider->value()+1) / 100;
+  if ( ui.cachingGroupBox->isChecked() )
+    useMem = memSizeInMB * (ui.cacheThresholdSlider->value()+1) / 100;
 
   return MAX(useMem, MIN_CACHE_SIZE_IN_MB);
 }
@@ -103,24 +101,24 @@ void SettingsWindow::on_saveButton_clicked()
 bool SettingsWindow::saveSettings()
 {
   settings.beginGroup("VideoCache");
-  settings.setValue("Enabled", ui->cachingGroupBox->isChecked());
-  settings.setValue("ThresholdValue", ui->cacheThresholdSlider->value());
+  settings.setValue("Enabled", ui.cachingGroupBox->isChecked());
+  settings.setValue("ThresholdValue", ui.cacheThresholdSlider->value());
   settings.setValue("ThresholdValueMB", getCacheSizeInMB());
   settings.endGroup();
 
-  settings.setValue("SplitViewLineStyle", ui->splitLineStyle->currentText());
-  settings.setValue("MouseMode", ui->mouseMode->currentText());
-  settings.setValue("MapVectorToColor", ui->MapVectorColorCheckBox->isChecked());
-  settings.setValue("ClearFrameEnabled", ui->clearFrameCheckBox->isChecked());
-  settings.setValue("WatchFiles", ui->watchFilesCheckBox->isChecked());
-  settings.setValue("ContinuePlaybackOnSequenceSelection", ui->playbackContinueNewSequenceCheckBox->isChecked());
+  settings.setValue("SplitViewLineStyle", ui.splitLineStyle->currentText());
+  settings.setValue("MouseMode", ui.mouseMode->currentText());
+  settings.setValue("MapVectorToColor", ui.MapVectorColorCheckBox->isChecked());
+  settings.setValue("ClearFrameEnabled", ui.clearFrameCheckBox->isChecked());
+  settings.setValue("WatchFiles", ui.watchFilesCheckBox->isChecked());
+  settings.setValue("ContinuePlaybackOnSequenceSelection", ui.playbackContinueNewSequenceCheckBox->isChecked());
   
   // Update settings
   settings.beginGroup("updates");
-  settings.setValue("checkForUpdates", ui->checkUpdatesGroupBox->isChecked());
+  settings.setValue("checkForUpdates", ui.checkUpdatesGroupBox->isChecked());
 #if UPDATE_FEATURE_ENABLE
   QString updateBehavior = "ask";
-  if (ui->updateSettingComboBox->currentIndex() == 0)
+  if (ui.updateSettingComboBox->currentIndex() == 0)
     updateBehavior = "auto";
   settings.setValue("updateBehavior", updateBehavior);
 #endif
@@ -134,35 +132,35 @@ bool SettingsWindow::saveSettings()
 bool SettingsWindow::loadSettings()
 {
   settings.beginGroup("VideoCache");
-  ui->cachingGroupBox->setChecked( settings.value("Enabled", true).toBool() );
-  ui->cacheThresholdSlider->setValue( settings.value("ThresholdValue", 49).toInt() );
+  ui.cachingGroupBox->setChecked( settings.value("Enabled", true).toBool() );
+  ui.cacheThresholdSlider->setValue( settings.value("ThresholdValue", 49).toInt() );
   settings.endGroup();
 
   QString splittingStyleString = settings.value("SplitViewLineStyle", "Solid Line").toString();
   if (splittingStyleString == "Handlers")
-    ui->splitLineStyle->setCurrentIndex(1);
+    ui.splitLineStyle->setCurrentIndex(1);
   else
-    ui->splitLineStyle->setCurrentIndex(0);
+    ui.splitLineStyle->setCurrentIndex(0);
   QString mouseModeString = settings.value("MouseMode", "Left Zoom, Right Move").toString();
   if (mouseModeString == "Left Zoom, Right Move")
-    ui->mouseMode->setCurrentIndex(0);
+    ui.mouseMode->setCurrentIndex(0);
   else
-    ui->mouseMode->setCurrentIndex(1);
-  ui->MapVectorColorCheckBox->setChecked(settings.value("MapVectorToColor",false).toBool());
-  ui->clearFrameCheckBox->setChecked(settings.value("ClearFrameEnabled",false).toBool());
-  ui->watchFilesCheckBox->setChecked(settings.value("WatchFiles",true).toBool());
-  ui->playbackContinueNewSequenceCheckBox->setChecked(settings.value("ContinuePlaybackOnSequenceSelection",false).toBool());
+    ui.mouseMode->setCurrentIndex(1);
+  ui.MapVectorColorCheckBox->setChecked(settings.value("MapVectorToColor",false).toBool());
+  ui.clearFrameCheckBox->setChecked(settings.value("ClearFrameEnabled",false).toBool());
+  ui.watchFilesCheckBox->setChecked(settings.value("WatchFiles",true).toBool());
+  ui.playbackContinueNewSequenceCheckBox->setChecked(settings.value("ContinuePlaybackOnSequenceSelection",false).toBool());
 
   // Updates settings
   settings.beginGroup("updates");
   bool checkForUpdates = settings.value("checkForUpdates", true).toBool();
-  ui->checkUpdatesGroupBox->setChecked(checkForUpdates);
+  ui.checkUpdatesGroupBox->setChecked(checkForUpdates);
 #if UPDATE_FEATURE_ENABLE
   QString updateBehavior = settings.value("updateBehavior", "ask").toString();
   if (updateBehavior == "ask")
-    ui->updateSettingComboBox->setCurrentIndex(1);
+    ui.updateSettingComboBox->setCurrentIndex(1);
   else if (updateBehavior == "auto")
-    ui->updateSettingComboBox->setCurrentIndex(0);
+    ui.updateSettingComboBox->setCurrentIndex(0);
 #endif
   settings.endGroup();
 
@@ -171,15 +169,15 @@ bool SettingsWindow::loadSettings()
 
 void SettingsWindow::on_cacheThresholdSlider_valueChanged(int value)
 {
-  ui->cacheThresholdLabel->setText(QString("Threshold (%1 MB)").arg(memSizeInMB * (value+1) / 100));
+  ui.cacheThresholdLabel->setText(QString("Threshold (%1 MB)").arg(memSizeInMB * (value+1) / 100));
 }
 
 void SettingsWindow::on_cachingGroupBox_toggled(bool enable)
 {
-  ui->cacheThresholdLabel->setEnabled( enable );
-  ui->cacheThresholdSlider->setEnabled( enable );
-  ui->maxMBLabel->setEnabled( enable );
-  ui->minMBLabel->setEnabled( enable );
+  ui.cacheThresholdLabel->setEnabled( enable );
+  ui.cacheThresholdSlider->setEnabled( enable );
+  ui.maxMBLabel->setEnabled( enable );
+  ui.minMBLabel->setEnabled( enable );
 }
 
 void SettingsWindow::on_gridColorButton_clicked()

--- a/source/settingswindow.h
+++ b/source/settingswindow.h
@@ -67,7 +67,7 @@ private:
   // The installed memory size. The constructor sets this.
   unsigned int memSizeInMB;
 
-  Ui::SettingsWindow *ui;
+  Ui::SettingsWindow ui;
 };
 
 #endif // SETTINGSWINDOW_H

--- a/source/splitViewWidget.cpp
+++ b/source/splitViewWidget.cpp
@@ -40,11 +40,6 @@ splitViewWidget::splitViewWidget(QWidget *parent, bool separateView)
   playbackPrimary = false;
   isViewFrozen = false;
 
-  // Setup the controls for the primary splitviewWidget. The separateView will use (connect to) the primarys controls.
-  controls = NULL;
-  if (!separateView)
-    controls = new Ui::splitViewControlsWidget;
-
   splittingPoint = 0.5;
   splittingDragging = false;
   setSplitEnabled(false);
@@ -1119,18 +1114,18 @@ void splitViewWidget::setupControls(QDockWidget *dock)
 {
   // Initialize the controls and add them to the given widget.
   QWidget *controlsWidget = new QWidget(dock);
-  controls->setupUi( controlsWidget );
+  controls.setupUi( controlsWidget );
   dock->setWidget( controlsWidget );
 
   // Connect signals/slots
-  connect(controls->SplitViewgroupBox, SIGNAL(toggled(bool)), this, SLOT(on_SplitViewgroupBox_toggled(bool)));
-  connect(controls->viewComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(on_viewComboBox_currentIndexChanged(int)));
-  connect(controls->regularGridCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_regularGridCheckBox_toggled(bool)));
-  connect(controls->gridSizeBox, SIGNAL(valueChanged(int)), this, SLOT(on_gridSizeBox_valueChanged(int)));
-  connect(controls->zoomBoxCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_zoomBoxCheckBox_toggled(bool)));
-  connect(controls->separateViewGroupBox, SIGNAL(toggled(bool)), this, SLOT(on_separateViewGroupBox_toggled(bool)));
-  connect(controls->linkViewsCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_linkViewsCheckBox_toggled(bool)));
-  connect(controls->playbackPrimaryCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_playbackPrimaryCheckBox_toggled(bool)));
+  connect(controls.SplitViewgroupBox, SIGNAL(toggled(bool)), this, SLOT(on_SplitViewgroupBox_toggled(bool)));
+  connect(controls.viewComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(on_viewComboBox_currentIndexChanged(int)));
+  connect(controls.regularGridCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_regularGridCheckBox_toggled(bool)));
+  connect(controls.gridSizeBox, SIGNAL(valueChanged(int)), this, SLOT(on_gridSizeBox_valueChanged(int)));
+  connect(controls.zoomBoxCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_zoomBoxCheckBox_toggled(bool)));
+  connect(controls.separateViewGroupBox, SIGNAL(toggled(bool)), this, SLOT(on_separateViewGroupBox_toggled(bool)));
+  connect(controls.linkViewsCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_linkViewsCheckBox_toggled(bool)));
+  connect(controls.playbackPrimaryCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_playbackPrimaryCheckBox_toggled(bool)));
 }
 
 void splitViewWidget::on_viewComboBox_currentIndexChanged(int index)
@@ -1170,13 +1165,13 @@ void splitViewWidget::setViewMode(ViewMode v, bool emitSignal)
   if (!emitSignal)
   {
     // Disconnet signals
-    disconnect(controls->viewComboBox, SIGNAL(currentIndexChanged(int)), NULL, NULL);
+    disconnect(controls.viewComboBox, SIGNAL(currentIndexChanged(int)), NULL, NULL);
   }
 
   if (v == SIDE_BY_SIDE)
-    controls->viewComboBox->setCurrentIndex(0);
+    controls.viewComboBox->setCurrentIndex(0);
   else if (v == COMPARISON)
-    controls->viewComboBox->setCurrentIndex(1);
+    controls.viewComboBox->setCurrentIndex(1);
 
   viewMode = v;
   otherWidget->viewMode = v;
@@ -1184,8 +1179,8 @@ void splitViewWidget::setViewMode(ViewMode v, bool emitSignal)
   if (!emitSignal)
   {
     // Reconnect the signals
-    connect(controls->viewComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(on_viewComboBox_currentIndexChanged(int)));
-    connect(controls->viewComboBox, SIGNAL(currentIndexChanged(int)), otherWidget, SLOT(on_viewComboBox_currentIndexChanged(int)));
+    connect(controls.viewComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(on_viewComboBox_currentIndexChanged(int)));
+    connect(controls.viewComboBox, SIGNAL(currentIndexChanged(int)), otherWidget, SLOT(on_viewComboBox_currentIndexChanged(int)));
   }
 }
 
@@ -1195,12 +1190,12 @@ void splitViewWidget::setPrimaryWidget(splitViewWidget *primary)
   otherWidget = primary;
 
   // The primary splitViewWidget did set up controls for the widget. Connect signals/slots from these controls also here.
-  connect(primary->controls->SplitViewgroupBox, SIGNAL(toggled(bool)), this, SLOT(on_SplitViewgroupBox_toggled(bool)));
-  connect(primary->controls->viewComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(on_viewComboBox_currentIndexChanged(int)));
-  connect(primary->controls->regularGridCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_regularGridCheckBox_toggled(bool)));
-  connect(primary->controls->gridSizeBox, SIGNAL(valueChanged(int)), this, SLOT(on_gridSizeBox_valueChanged(int)));
-  connect(primary->controls->zoomBoxCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_zoomBoxCheckBox_toggled(bool)));
-  connect(primary->controls->linkViewsCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_linkViewsCheckBox_toggled(bool)));
+  connect(primary->controls.SplitViewgroupBox, SIGNAL(toggled(bool)), this, SLOT(on_SplitViewgroupBox_toggled(bool)));
+  connect(primary->controls.viewComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(on_viewComboBox_currentIndexChanged(int)));
+  connect(primary->controls.regularGridCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_regularGridCheckBox_toggled(bool)));
+  connect(primary->controls.gridSizeBox, SIGNAL(valueChanged(int)), this, SLOT(on_gridSizeBox_valueChanged(int)));
+  connect(primary->controls.zoomBoxCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_zoomBoxCheckBox_toggled(bool)));
+  connect(primary->controls.linkViewsCheckBox, SIGNAL(toggled(bool)), this, SLOT(on_linkViewsCheckBox_toggled(bool)));
 }
 
 void splitViewWidget::setSeparateWidget(splitViewWidget *separate)
@@ -1227,10 +1222,10 @@ void splitViewWidget::toggleSeparateViewHideShow()
 {
   Q_ASSERT_X(!isSeparateWidget, "setSeparateWidget", "Call this function only on the primary widget.");
 
-  if (!controls->separateViewGroupBox->isChecked())
-    controls->separateViewGroupBox->setChecked(true);
+  if (!controls.separateViewGroupBox->isChecked())
+    controls.separateViewGroupBox->setChecked(true);
   else
-    controls->separateViewGroupBox->setChecked(false);
+    controls.separateViewGroupBox->setChecked(false);
 }
 
 QPixmap splitViewWidget::getScreenshot()
@@ -1269,7 +1264,7 @@ void splitViewWidget::freezeView(bool freeze)
   }
   if (!isViewFrozen && freeze)
   {
-    if (!isSeparateWidget && controls->separateViewGroupBox->isChecked() && !playbackPrimary)
+    if (!isSeparateWidget && controls.separateViewGroupBox->isChecked() && !playbackPrimary)
     {
       isViewFrozen = true;
       setMouseTracking(false);
@@ -1282,7 +1277,7 @@ void splitViewWidget::on_playbackPrimaryCheckBox_toggled(bool state)
 {
   playbackPrimary = state;
 
-  if (!isSeparateWidget && controls->separateViewGroupBox->isChecked() && playback->playing())
+  if (!isSeparateWidget && controls.separateViewGroupBox->isChecked() && playback->playing())
   {
     // We have to freeze/unfreeze the widget
     freezeView(!state);
@@ -1317,9 +1312,9 @@ void splitViewWidget::setViewState(QPoint offset, double zoom, bool split, doubl
 {
   // Set all the values
   if (isSeparateWidget)
-    otherWidget->controls->SplitViewgroupBox->setChecked(split);
+    otherWidget->controls.SplitViewgroupBox->setChecked(split);
   else
-    controls->SplitViewgroupBox->setChecked(split);
+    controls.SplitViewgroupBox->setChecked(split);
   centerOffset = offset;
   zoomFactor = zoom;
   splittingPoint = splitPoint;

--- a/source/splitViewWidget.h
+++ b/source/splitViewWidget.h
@@ -72,7 +72,7 @@ public:
 
   // Update the splitView. If playback is running, call the second funtion so that the control can update conditionally.
   void update() { QWidget::update(); }
-  void update(bool playback) { if (isSeparateWidget || !controls->separateViewGroupBox->isChecked() || !playback || playbackPrimary) update(); }
+  void update(bool playback) { if (isSeparateWidget || !controls.separateViewGroupBox->isChecked() || !playback || playbackPrimary) update(); }
 
   // Freeze/unfreeze the view. If the view is frozen, it will take a screenshot of the current state and show that
   // in grayscale until it is unfrozen again.
@@ -146,7 +146,7 @@ protected:
   void keyPressEvent(QKeyEvent *event) Q_DECL_OVERRIDE;
 
   // The controls for the splitView (splitView, drawGrid ...)
-  Ui::splitViewControlsWidget *controls;
+  SafeUi<Ui::splitViewControlsWidget> controls;
 
   virtual void paintEvent(QPaintEvent *event) Q_DECL_OVERRIDE;
   virtual void mouseMoveEvent(QMouseEvent * event) Q_DECL_OVERRIDE;

--- a/source/statisticHandler.cpp
+++ b/source/statisticHandler.cpp
@@ -43,8 +43,7 @@ void rotateVector(float angle, float vx, float vy, float &nx, float &ny)
   ny /= n_abs;
 }
 
-statisticHandler::statisticHandler():
-  ui(NULL), ui2(NULL)
+statisticHandler::statisticHandler()
 {
   lastFrameIdx = -1;
   statsCacheFrameIdx = -1;
@@ -58,9 +57,6 @@ statisticHandler::statisticHandler():
 
 statisticHandler::~statisticHandler()
 {
-  delete ui;
-  if (ui2)
-    delete ui2;
 }
 
 void statisticHandler::paintStatistics(QPainter *painter, int frameIdx, double zoomFactor)
@@ -333,19 +329,18 @@ QLayout *statisticHandler::createStatisticsHandlerControls(bool recreateControls
   if (!recreateControlsOnly)
   {
     // Absolutely always only do this once
-    Q_ASSERT_X(!ui, "statisticHandler::addPropertiesWidget", "The primary statistics controls must only be created once.");
+    Q_ASSERT_X(!ui.created(), "statisticHandler::createStatisticsHandlerControls", "The primary statistics controls must only be created once.");
 
-    ui = new SafeUi<Ui::statisticHandler>;
-    ui->setupUi();
+    ui.setupUi();
   }
 
   // Add the controls to the gridLayer
   for (int row = 0; row < statsTypeList.length(); ++row)
   {
     // Append the name (with the checkbox to enable/disable the statistics item)
-    QCheckBox *itemNameCheck = new QCheckBox( statsTypeList[row].typeName, ui->scrollAreaWidgetContents);
+    QCheckBox *itemNameCheck = new QCheckBox( statsTypeList[row].typeName, ui.scrollAreaWidgetContents);
     itemNameCheck->setChecked( statsTypeList[row].render );
-    ui->gridLayout->addWidget(itemNameCheck, row+2, 0);
+    ui.gridLayout->addWidget(itemNameCheck, row+2, 0);
     connect(itemNameCheck, SIGNAL(stateChanged(int)), this, SLOT(onStatisticsControlChanged()));
     itemNameCheckBoxes[0].append(itemNameCheck);
 
@@ -354,23 +349,23 @@ QLayout *statisticHandler::createStatisticsHandlerControls(bool recreateControls
     opacitySlider->setMinimum(0);
     opacitySlider->setMaximum(100);
     opacitySlider->setValue(statsTypeList[row].alphaFactor);
-    ui->gridLayout->addWidget(opacitySlider, row+2, 1);
+    ui.gridLayout->addWidget(opacitySlider, row+2, 1);
     connect(opacitySlider, SIGNAL(valueChanged(int)), this, SLOT(onStatisticsControlChanged()));
     itemOpacitySliders[0].append(opacitySlider);
 
     // Append the grid checkbox
-    QCheckBox *gridCheckbox = new QCheckBox( "", ui->scrollAreaWidgetContents );
+    QCheckBox *gridCheckbox = new QCheckBox( "", ui.scrollAreaWidgetContents );
     gridCheckbox->setChecked( statsTypeList[row].renderGrid );
-    ui->gridLayout->addWidget(gridCheckbox, row+2, 2);
+    ui.gridLayout->addWidget(gridCheckbox, row+2, 2);
     connect(gridCheckbox, SIGNAL(stateChanged(int)), this, SLOT(onStatisticsControlChanged()));
     itemGridCheckBoxes[0].append(gridCheckbox);
 
     if (statsTypeList[row].visualizationType==vectorType)
     {
       // Append the arrow checkbox
-      QCheckBox *arrowCheckbox = new QCheckBox( "", ui->scrollAreaWidgetContents );
+      QCheckBox *arrowCheckbox = new QCheckBox( "", ui.scrollAreaWidgetContents );
       arrowCheckbox->setChecked( statsTypeList[row].showArrow );
-      ui->gridLayout->addWidget(arrowCheckbox, row+2, 3);
+      ui.gridLayout->addWidget(arrowCheckbox, row+2, 3);
       connect(arrowCheckbox, SIGNAL(stateChanged(int)), this, SLOT(onStatisticsControlChanged()));
       itemArrowCheckboxes[0].append(arrowCheckbox);
 
@@ -384,34 +379,33 @@ QLayout *statisticHandler::createStatisticsHandlerControls(bool recreateControls
 
   // Add a spacer at the very bottom
   QSpacerItem *verticalSpacer = new QSpacerItem(1, 1, QSizePolicy::Minimum, QSizePolicy::Expanding);
-  ui->gridLayout->addItem(verticalSpacer, statsTypeList.length()+2, 0, 1, 1);
+  ui.gridLayout->addItem(verticalSpacer, statsTypeList.length()+2, 0, 1, 1);
   spacerItems[0] = verticalSpacer;
 
   // Update all controls
   onStatisticsControlChanged();
 
-  return ui->verticalLayout;
+  return ui.verticalLayout;
 }
 
 QWidget *statisticHandler::getSecondaryStatisticsHandlerControls(bool recreateControlsOnly)
 {
-  if (!ui2 || recreateControlsOnly)
+  if (!ui2.created() || recreateControlsOnly)
   {
-    if (!recreateControlsOnly)
+    if (!ui2.created())
     {
-      ui2 = new SafeUi<Ui::statisticHandler>;
       secondaryControlsWidget = new QWidget;
-      ui2->setupUi();
-      secondaryControlsWidget->setLayout( ui2->verticalLayout );
+      ui2.setupUi();
+      secondaryControlsWidget->setLayout( ui2.verticalLayout );
     }
 
     // Add the controls to the gridLayer
     for (int row = 0; row < statsTypeList.length(); ++row)
     {
       // Append the name (with the checkbox to enable/disable the statistics item)
-      QCheckBox *itemNameCheck = new QCheckBox( statsTypeList[row].typeName, ui2->scrollAreaWidgetContents);
+      QCheckBox *itemNameCheck = new QCheckBox( statsTypeList[row].typeName, ui2.scrollAreaWidgetContents);
       itemNameCheck->setChecked( statsTypeList[row].render );
-      ui2->gridLayout->addWidget(itemNameCheck, row+2, 0);
+      ui2.gridLayout->addWidget(itemNameCheck, row+2, 0);
       connect(itemNameCheck, SIGNAL(stateChanged(int)), this, SLOT(onSecondaryStatisticsControlChanged()));
       itemNameCheckBoxes[1].append(itemNameCheck);
 
@@ -420,23 +414,23 @@ QWidget *statisticHandler::getSecondaryStatisticsHandlerControls(bool recreateCo
       opacitySlider->setMinimum(0);
       opacitySlider->setMaximum(100);
       opacitySlider->setValue(statsTypeList[row].alphaFactor);
-      ui2->gridLayout->addWidget(opacitySlider, row+2, 1);
+      ui2.gridLayout->addWidget(opacitySlider, row+2, 1);
       connect(opacitySlider, SIGNAL(valueChanged(int)), this, SLOT(onSecondaryStatisticsControlChanged()));
       itemOpacitySliders[1].append(opacitySlider);
 
       // Append the grid checkbox
-      QCheckBox *gridCheckbox = new QCheckBox( "", ui2->scrollAreaWidgetContents );
+      QCheckBox *gridCheckbox = new QCheckBox( "", ui2.scrollAreaWidgetContents );
       gridCheckbox->setChecked( statsTypeList[row].renderGrid );
-      ui2->gridLayout->addWidget(gridCheckbox, row+2, 2);
+      ui2.gridLayout->addWidget(gridCheckbox, row+2, 2);
       connect(gridCheckbox, SIGNAL(stateChanged(int)), this, SLOT(onSecondaryStatisticsControlChanged()));
       itemGridCheckBoxes[1].append(gridCheckbox);
 
       if (statsTypeList[row].visualizationType==vectorType)
       {
         // Append the arrow checkbox
-        QCheckBox *arrowCheckbox = new QCheckBox( "", ui2->scrollAreaWidgetContents );
+        QCheckBox *arrowCheckbox = new QCheckBox( "", ui2.scrollAreaWidgetContents );
         arrowCheckbox->setChecked( statsTypeList[row].showArrow );
-        ui2->gridLayout->addWidget(arrowCheckbox, row+2, 3);
+        ui2.gridLayout->addWidget(arrowCheckbox, row+2, 3);
         connect(arrowCheckbox, SIGNAL(stateChanged(int)), this, SLOT(onSecondaryStatisticsControlChanged()));
         itemArrowCheckboxes[1].append(arrowCheckbox);
 
@@ -450,7 +444,7 @@ QWidget *statisticHandler::getSecondaryStatisticsHandlerControls(bool recreateCo
 
     // Add a spacer at the very bottom
     QSpacerItem *verticalSpacer = new QSpacerItem(1, 1, QSizePolicy::Minimum, QSizePolicy::Expanding);
-    ui2->gridLayout->addItem(verticalSpacer, statsTypeList.length()+2, 0, 1, 1);
+    ui2.gridLayout->addItem(verticalSpacer, statsTypeList.length()+2, 0, 1, 1);
     spacerItems[1] = verticalSpacer;
 
     // Update all controls
@@ -482,7 +476,7 @@ void statisticHandler::onStatisticsControlChanged()
       itemArrowCheckboxes[0][row]->setEnabled( enable );
 
     // Update the secondary controls if they were created
-    if (ui2 && itemNameCheckBoxes[1].length() > 0)
+    if (ui2.created() && itemNameCheckBoxes[1].length() > 0)
     {
       // Update the controls that changed
       if (itemNameCheckBoxes[0][row]->isChecked() != itemNameCheckBoxes[1][row]->isChecked())
@@ -575,8 +569,7 @@ void statisticHandler::onSecondaryStatisticsControlChanged()
 void statisticHandler::deleteSecondaryStatisticsHandlerControls()
 {
   secondaryControlsWidget->deleteLater();
-  delete ui2;
-  ui2 = NULL;
+  ui2.clear();
   itemNameCheckBoxes[1].clear();
   itemOpacitySliders[1].clear();
   itemGridCheckBoxes[1].clear();
@@ -665,7 +658,7 @@ void statisticHandler::updateStatisticsHandlerControls()
   {
     // Update the controls from the current settings in statsTypeList
     onStatisticsControlChanged();
-    if (ui2)
+    if (ui2.created())
       onSecondaryStatisticsControlChanged();
   }
   else
@@ -678,11 +671,11 @@ void statisticHandler::updateStatisticsHandlerControls()
       Q_ASSERT(itemNameCheckBoxes[0].length() == itemArrowCheckboxes[0].length());
 
       // Remove primary controls from the layout
-      ui->gridLayout->removeWidget(itemNameCheckBoxes[0][i]); 
-      ui->gridLayout->removeWidget(itemOpacitySliders[0][i]);
-      ui->gridLayout->removeWidget(itemGridCheckBoxes[0][i]);
+      ui.gridLayout->removeWidget(itemNameCheckBoxes[0][i]);
+      ui.gridLayout->removeWidget(itemOpacitySliders[0][i]);
+      ui.gridLayout->removeWidget(itemGridCheckBoxes[0][i]);
       if (itemArrowCheckboxes[0][i])
-        ui->gridLayout->removeWidget(itemArrowCheckboxes[0][i]);
+        ui.gridLayout->removeWidget(itemArrowCheckboxes[0][i]);
 
       // Delete the controls
       delete itemNameCheckBoxes[0][i];
@@ -691,18 +684,18 @@ void statisticHandler::updateStatisticsHandlerControls()
       if (itemArrowCheckboxes[0][i])
         delete itemArrowCheckboxes[0][i];
 
-      if (ui2)
+      if (ui2.created())
       {
         Q_ASSERT(itemNameCheckBoxes[1].length() == itemOpacitySliders[1].length());
         Q_ASSERT(itemNameCheckBoxes[1].length() == itemGridCheckBoxes[1].length());
         Q_ASSERT(itemNameCheckBoxes[1].length() == itemArrowCheckboxes[1].length());
 
         // Remove secondary controls from the secondary layot
-        ui2->gridLayout->removeWidget(itemNameCheckBoxes[1][i]);
-        ui2->gridLayout->removeWidget(itemOpacitySliders[1][i]);
-        ui2->gridLayout->removeWidget(itemGridCheckBoxes[1][i]);
+        ui2.gridLayout->removeWidget(itemNameCheckBoxes[1][i]);
+        ui2.gridLayout->removeWidget(itemOpacitySliders[1][i]);
+        ui2.gridLayout->removeWidget(itemGridCheckBoxes[1][i]);
         if (itemArrowCheckboxes[1][i])
-          ui2->gridLayout->removeWidget(itemArrowCheckboxes[0][i]);
+          ui2.gridLayout->removeWidget(itemArrowCheckboxes[0][i]);
 
         // Delete the controls
         delete itemNameCheckBoxes[1][i];
@@ -715,7 +708,7 @@ void statisticHandler::updateStatisticsHandlerControls()
 
     // Delete the spacer items at the bottom.
     assert(spacerItems[0] != NULL);
-    ui->gridLayout->removeItem(spacerItems[0]);
+    ui.gridLayout->removeItem(spacerItems[0]);
     delete spacerItems[0];
     spacerItems[0] = NULL;
 
@@ -726,7 +719,7 @@ void statisticHandler::updateStatisticsHandlerControls()
     itemGridCheckBoxes[0].clear();
     itemArrowCheckboxes[0].clear();
 
-    if (ui2)
+    if (ui2.created())
     {
       // Delete all pointers to the widgets. The layout has the ownership and removing the
       // widget should delete it.
@@ -737,7 +730,7 @@ void statisticHandler::updateStatisticsHandlerControls()
 
       // Delete the spacer items at the bottom.
       assert(spacerItems[1] != NULL);
-      ui2->gridLayout->removeItem(spacerItems[1]);
+      ui2.gridLayout->removeItem(spacerItems[1]);
       delete spacerItems[1];
       spacerItems[1] = NULL;
     }
@@ -762,7 +755,7 @@ void statisticHandler::updateStatisticsHandlerControls()
     
     // Create new controls
     createStatisticsHandlerControls(true);
-    if (ui2)
+    if (ui2.created())
       getSecondaryStatisticsHandlerControls(true);
   }
 }

--- a/source/statisticHandler.cpp
+++ b/source/statisticHandler.cpp
@@ -328,16 +328,15 @@ bool statisticHandler::anyStatisticsRendered()
   return false;
 }
 
-QLayout *statisticHandler::createStatisticsHandlerControls(QWidget *widget, bool recreateControlsOnly)
+QLayout *statisticHandler::createStatisticsHandlerControls(bool recreateControlsOnly)
 {
   if (!recreateControlsOnly)
   {
     // Absolutely always only do this once
     Q_ASSERT_X(!ui, "statisticHandler::addPropertiesWidget", "The primary statistics controls must only be created once.");
 
-    ui = new Ui::statisticHandler;
-    ui->setupUi( widget );
-    widget->setLayout( ui->verticalLayout );
+    ui = new SafeUi<Ui::statisticHandler>;
+    ui->setupUi();
   }
 
   // Add the controls to the gridLayer
@@ -400,9 +399,9 @@ QWidget *statisticHandler::getSecondaryStatisticsHandlerControls(bool recreateCo
   {
     if (!recreateControlsOnly)
     {
-      ui2 = new Ui::statisticHandler;
+      ui2 = new SafeUi<Ui::statisticHandler>;
       secondaryControlsWidget = new QWidget;
-      ui2->setupUi( secondaryControlsWidget );
+      ui2->setupUi();
       secondaryControlsWidget->setLayout( ui2->verticalLayout );
     }
 
@@ -762,7 +761,7 @@ void statisticHandler::updateStatisticsHandlerControls()
     }
     
     // Create new controls
-    createStatisticsHandlerControls(NULL, true);
+    createStatisticsHandlerControls(true);
     if (ui2)
       getSecondaryStatisticsHandlerControls(true);
   }

--- a/source/statisticHandler.h
+++ b/source/statisticHandler.h
@@ -102,12 +102,12 @@ private:
   StatisticsTypeList statsTypeListBackup;
 
   // Primary controls for the statistics
-  SafeUi<Ui::statisticHandler> *ui;
+  SafeUi<Ui::statisticHandler> ui;
 
   // Secondary controls. These can be set up it the item is used in an overlay item so that the properties
   // of the statistics item can be controlled from the properties panel of the overlay item. The primary
   // and secondary controls are linked and always show/control the same thing.
-  SafeUi<Ui::statisticHandler> *ui2;
+  SafeUi<Ui::statisticHandler> ui2;
   QWidget *secondaryControlsWidget;
 
   // Pointers to the primary and (if created) secondary controls that we added to the properties panel per item

--- a/source/statisticHandler.h
+++ b/source/statisticHandler.h
@@ -56,7 +56,7 @@ public:
 
   // Create all the checkboxes/spliders and so on. If recreateControlsOnly is set, the ui is assumed to be already
   // initialized. Only all the controls are created.
-  QLayout *createStatisticsHandlerControls(QWidget *parentWidget, bool recreateControlsOnly=false);
+  QLayout *createStatisticsHandlerControls(bool recreateControlsOnly=false);
   // The statsTypeList might have changed. Update the controls. Maybe a statistics type was removed/added
   void updateStatisticsHandlerControls();
   
@@ -102,12 +102,12 @@ private:
   StatisticsTypeList statsTypeListBackup;
 
   // Primary controls for the statistics
-  Ui::statisticHandler *ui;
+  SafeUi<Ui::statisticHandler> *ui;
 
   // Secondary controls. These can be set up it the item is used in an overlay item so that the properties
   // of the statistics item can be controlled from the properties panel of the overlay item. The primary
   // and secondary controls are linked and always show/control the same thing.
-  Ui::statisticHandler *ui2;
+  SafeUi<Ui::statisticHandler> *ui2;
   QWidget *secondaryControlsWidget;
 
   // Pointers to the primary and (if created) secondary controls that we added to the properties panel per item

--- a/source/typedef.cpp
+++ b/source/typedef.cpp
@@ -1,0 +1,48 @@
+/*  YUView - YUV player with advanced analytics toolset
+*   Copyright (C) 2016  Institut für Nachrichtentechnik
+*                       RWTH Aachen University, GERMANY
+*
+*   YUView is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 2 of the License, or
+*   (at your option) any later version.
+*
+*   YUView is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with YUView.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "typedef.h"
+#include <QWidget>
+#include <QLayout>
+
+static void unparentWidgets(QLayout * layout)
+{
+  const int n = layout->count();
+  for (int i = 0; i < n; ++i) {
+    QLayoutItem * item = layout->itemAt(i);
+    if (item->widget()) item->widget()->setParent(0);
+    else if (item->layout()) unparentWidgets(item->layout());
+  }
+}
+
+// See also http://stackoverflow.com/q/40497358/1329652
+void setupUi(void * ui, void(*setupUi)(void * ui, QWidget * widget))
+{
+  QWidget widget;
+  setupUi(ui, &widget);
+  QLayout * wrapperLayout = widget.layout();
+  Q_ASSERT(wrapperLayout);
+  QObjectList const wrapperChildren = wrapperLayout->children();
+  Q_ASSERT(wrapperChildren.size() == 1);
+  QLayout * topLayout = qobject_cast<QLayout *>(wrapperChildren.first());
+  Q_ASSERT(topLayout);
+  topLayout->setParent(0);
+  delete wrapperLayout;
+  unparentWidgets(topLayout);
+  Q_ASSERT(widget.findChildren<QObject*>().isEmpty());
+}

--- a/source/typedef.h
+++ b/source/typedef.h
@@ -27,6 +27,7 @@
 #include <QList>
 #include <QRect>
 #include <QDomElement>
+#include <cstring>
 #include <assert.h>
 
 #define INT_INVALID -1
@@ -234,5 +235,41 @@ public:
 // A index range is just a QPair of ints (minimum and maximum)
 typedef QPair<int,int> indexRange;
 
-#endif // TYPEDEF_H
+class QWidget;
+class QLayout;
+void setupUi(void * ui, void(*setupUi)(void * ui, QWidget * widget));
 
+// A safe wrapper around Ui::Form class, for delayed initialization
+// and in support of widget-less setupUi.
+// The Ui::Form is zeroed out as a way of catching null pointer dereferences
+// before the Ui has been set up.
+template <class Ui> class SafeUi : public Ui {
+  bool m_created;
+  static void setup_ui_helper(void * ui, QWidget * widget)
+  {
+    reinterpret_cast<SafeUi*>(ui)->setupUi(widget);
+  }
+public:
+  SafeUi() { clear(); }
+  void setupUi(QWidget * widget)
+  {
+    Q_ASSERT(!m_created);
+    Ui::setupUi(widget);
+    m_created = true;
+  }
+  void setupUi()
+  {
+    Q_ASSERT(!m_created);
+    ::setupUi(static_cast<void*>(this), &SafeUi::setup_ui_helper);
+    this->wrapperLayout = NULL; // The wrapper was deleted, don't leave a dangling pointer.
+    m_created = true;
+  }
+  void clear()
+  {
+    memset(static_cast<Ui*>(this), 0, sizeof(Ui));
+    m_created = false;
+  }
+  bool created() const { return m_created; }
+};
+
+#endif // TYPEDEF_H

--- a/source/updateHandler.cpp
+++ b/source/updateHandler.cpp
@@ -358,10 +358,9 @@ void updateHandler::downloadFinished(QNetworkReply *reply)
 }
 
 UpdateDialog::UpdateDialog(QWidget *parent) : 
-  QDialog(parent),
-  ui(new Ui::UpdateDialog)
+  QDialog(parent)
 {
-  ui->setupUi(this);
+  ui.setupUi(this);
 
   // Load the update settings from the QSettings
   QSettings settings;
@@ -370,19 +369,19 @@ UpdateDialog::UpdateDialog(QWidget *parent) :
   QString updateBehavior = settings.value("updateBehavior", "ask").toString();
   settings.endGroup();
 
-  ui->checkUpdatesGroupBox->setChecked(checkForUpdates);
+  ui.checkUpdatesGroupBox->setChecked(checkForUpdates);
   if (updateBehavior == "ask")
-    ui->updateSettingComboBox->setCurrentIndex(1);
+    ui.updateSettingComboBox->setCurrentIndex(1);
   else if (updateBehavior == "auto")
-    ui->updateSettingComboBox->setCurrentIndex(0);
+    ui.updateSettingComboBox->setCurrentIndex(0);
 
   // Connect signals/slots
-  connect(ui->updateButton, SIGNAL(clicked()), this, SLOT(onButtonUpdateClicked()));
-  connect(ui->cancelButton, SIGNAL(clicked()), this, SLOT(onButtonCancelClicked()));
+  connect(ui.updateButton, SIGNAL(clicked()), this, SLOT(onButtonUpdateClicked()));
+  connect(ui.cancelButton, SIGNAL(clicked()), this, SLOT(onButtonCancelClicked()));
 
 #if !UPDATE_FEATURE_ENABLE
   // If the update feature is not available, we will grey this out.
-  ui->updateSettingComboBox->setEnabled(false);
+  ui.updateSettingComboBox->setEnabled(false);
 #endif
 }
 
@@ -393,9 +392,9 @@ void UpdateDialog::onButtonUpdateClicked()
   // First save the settings
   QSettings settings;
   settings.beginGroup("updates");
-  settings.setValue("checkForUpdates", ui->checkUpdatesGroupBox->isChecked());
+  settings.setValue("checkForUpdates", ui.checkUpdatesGroupBox->isChecked());
   QString updateBehavior = "ask";
-  if (ui->updateSettingComboBox->currentIndex() == 0)
+  if (ui.updateSettingComboBox->currentIndex() == 0)
     updateBehavior = "auto";
   settings.setValue("updateBehavior", updateBehavior);
 

--- a/source/updateHandler.h
+++ b/source/updateHandler.h
@@ -84,7 +84,7 @@ private slots:
   void onButtonCancelClicked();
 
 private:
-  Ui::UpdateDialog *ui;
+  Ui::UpdateDialog ui;
 };
 
 #endif // UPDATEHANDLER_H

--- a/source/videoHandlerDifference.cpp
+++ b/source/videoHandlerDifference.cpp
@@ -19,13 +19,12 @@
 #include "videoHandlerDifference.h"
 
 videoHandlerDifference::videoHandlerDifference() : videoHandler(),
-  ui(new Ui::videoHandlerDifference)
+  ui(new SafeUi<Ui::videoHandlerDifference>)
 {
   // preset internal values
   inputVideo[0] = NULL;
   inputVideo[1] = NULL;
 
-  controlsCreated = false;
   markDifference = false;
   amplificationFactor = 1;
   codingOrder = CodingOrder_HEVC;
@@ -107,14 +106,13 @@ void videoHandlerDifference::drawPixelValues(QPainter *painter, int frameIdx, QR
   inputVideo[0]->drawPixelValues(painter, frameIdx, videoRect, zoomFactor, inputVideo[1]);
 }
 
-QLayout *videoHandlerDifference::createDifferenceHandlerControls(QWidget *parentWidget)
+QLayout *videoHandlerDifference::createDifferenceHandlerControls()
 {
 
   // Absolutely always only call this function once!
-  assert(!controlsCreated);
-  controlsCreated = true;
+  assert(!ui->created());
 
-  ui->setupUi(parentWidget);
+  ui->setupUi();
 
   // Set all the values of the properties widget to the values of this class
   ui->markDifferenceCheckBox->setChecked( markDifference );

--- a/source/videoHandlerDifference.cpp
+++ b/source/videoHandlerDifference.cpp
@@ -18,8 +18,7 @@
 
 #include "videoHandlerDifference.h"
 
-videoHandlerDifference::videoHandlerDifference() : videoHandler(),
-  ui(new SafeUi<Ui::videoHandlerDifference>)
+videoHandlerDifference::videoHandlerDifference() : videoHandler()
 {
   // preset internal values
   inputVideo[0] = NULL;
@@ -32,7 +31,6 @@ videoHandlerDifference::videoHandlerDifference() : videoHandler(),
 
 videoHandlerDifference::~videoHandlerDifference()
 {
-  delete ui;
 }
 
 void videoHandlerDifference::loadFrame(int frameIndex)
@@ -110,22 +108,22 @@ QLayout *videoHandlerDifference::createDifferenceHandlerControls()
 {
 
   // Absolutely always only call this function once!
-  assert(!ui->created());
+  assert(!ui.created());
 
-  ui->setupUi();
+  ui.setupUi();
 
   // Set all the values of the properties widget to the values of this class
-  ui->markDifferenceCheckBox->setChecked( markDifference );
-  ui->amplificationFactorSpinBox->setValue( amplificationFactor );
-  ui->codingOrderComboBox->addItems( QStringList() << "HEVC" );
-  ui->codingOrderComboBox->setCurrentIndex( (int)codingOrder );
+  ui.markDifferenceCheckBox->setChecked( markDifference );
+  ui.amplificationFactorSpinBox->setValue( amplificationFactor );
+  ui.codingOrderComboBox->addItems( QStringList() << "HEVC" );
+  ui.codingOrderComboBox->setCurrentIndex( (int)codingOrder );
    
   // Connect all the change signals from the controls to "connectWidgetSignals()"
-  connect(ui->markDifferenceCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotDifferenceControlChanged()));
-  connect(ui->codingOrderComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotDifferenceControlChanged()));
-  connect(ui->amplificationFactorSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotDifferenceControlChanged()));
+  connect(ui.markDifferenceCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotDifferenceControlChanged()));
+  connect(ui.codingOrderComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotDifferenceControlChanged()));
+  connect(ui.amplificationFactorSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotDifferenceControlChanged()));
     
-  return ui->topVBoxLayout;
+  return ui.topVBoxLayout;
 }
 
 void videoHandlerDifference::slotDifferenceControlChanged()
@@ -133,24 +131,24 @@ void videoHandlerDifference::slotDifferenceControlChanged()
   // The control that caused the slot to be called
   QObject *sender = QObject::sender();
 
-  if (sender == ui->markDifferenceCheckBox)
+  if (sender == ui.markDifferenceCheckBox)
   {
-    markDifference = ui->markDifferenceCheckBox->isChecked();
+    markDifference = ui.markDifferenceCheckBox->isChecked();
 
     // Set the current frame in the buffer to be invalid and emit the signal that something has changed
     currentFrameIdx = -1;
     emit signalHandlerChanged(true, false);
   }
-  else if (sender == ui->codingOrderComboBox)
+  else if (sender == ui.codingOrderComboBox)
   {
-    codingOrder = (CodingOrder)ui->codingOrderComboBox->currentIndex();
+    codingOrder = (CodingOrder)ui.codingOrderComboBox->currentIndex();
 
      // The calculation of the first difference in coding order changed but no redraw is necessary
     emit signalHandlerChanged(false, false);
   }
-  else if (sender == ui->amplificationFactorSpinBox)
+  else if (sender == ui.amplificationFactorSpinBox)
   {
-    amplificationFactor = ui->amplificationFactorSpinBox->value();
+    amplificationFactor = ui.amplificationFactorSpinBox->value();
 
     // Set the current frame in the buffer to be invalid and emit the signal that something has changed
     currentFrameIdx = -1;

--- a/source/videoHandlerDifference.h
+++ b/source/videoHandlerDifference.h
@@ -76,7 +76,7 @@ private:
   // Recursively scan the LCU
   bool hierarchicalPosition( int x, int y, int blockSize, int &firstX, int &firstY, int &partIndex, const QImage diffImg );
 
-  SafeUi<Ui::videoHandlerDifference> *ui;
+  SafeUi<Ui::videoHandlerDifference> ui;
 
 };
 

--- a/source/videoHandlerDifference.h
+++ b/source/videoHandlerDifference.h
@@ -38,7 +38,7 @@ public:
   bool inputsValid();
 
   // Create the yuv controls and return a pointer to the layout. 
-  virtual QLayout *createDifferenceHandlerControls(QWidget *parentWidget);
+  virtual QLayout *createDifferenceHandlerControls();
 
   // Set the two video inputs. This will also update the number frames, the controls and the frame size.
   // The signal signalHandlerChanged will be emitted if a redraw is required.
@@ -73,12 +73,10 @@ private:
   // The two videos that the difference will be calculated from
   frameHandler *inputVideo[2];
 
-  bool controlsCreated;    ///< Have the controls been created already?
-
   // Recursively scan the LCU
   bool hierarchicalPosition( int x, int y, int blockSize, int &firstX, int &firstY, int &partIndex, const QImage diffImg );
 
-  Ui::videoHandlerDifference *ui;
+  SafeUi<Ui::videoHandlerDifference> *ui;
 
 };
 

--- a/source/videoHandlerRGB.cpp
+++ b/source/videoHandlerRGB.cpp
@@ -178,7 +178,7 @@ qint64 videoHandlerRGB::rgbPixelFormat::bytesPerFrame(QSize frameSize)
 // --------------------- videoHandlerRGB ----------------------------------
 
 videoHandlerRGB::videoHandlerRGB() : videoHandler(),
-  ui(new Ui::videoHandlerRGB)
+  ui(new SafeUi<Ui::videoHandlerRGB>)
 {
   // preset internal values
   setSrcPixelFormat( rgbPixelFormat() );
@@ -192,7 +192,6 @@ videoHandlerRGB::videoHandlerRGB() : videoHandler(),
   componentInvert[1] = false;
   componentInvert[2] = false;
 
-  controlsCreated = false;
   currentFrameRawRGBData_frameIdx = -1;
   rawRGBData_frameIdx = -1;
 
@@ -253,11 +252,10 @@ ValuePairList videoHandlerRGB::getPixelValues(QPoint pixelPos, int frameIdx, fra
   return values;
 }
 
-QLayout *videoHandlerRGB::createRGBVideoHandlerControls(QWidget *parentWidget, bool isSizeFixed)
+QLayout *videoHandlerRGB::createRGBVideoHandlerControls(bool isSizeFixed)
 {
   // Absolutely always only call this function once!
-  assert(!controlsCreated);
-  controlsCreated = true;
+  assert(!ui->created());
 
   QVBoxLayout *newVBoxLayout = NULL;
   if (!isSizeFixed)
@@ -265,16 +263,16 @@ QLayout *videoHandlerRGB::createRGBVideoHandlerControls(QWidget *parentWidget, b
     // Our parent (frameHandler) also has controls to add. Create a new vBoxLayout and append the parent controls
     // and our controls into that layout, seperated by a line. Return that layout
     newVBoxLayout = new QVBoxLayout;
-    newVBoxLayout->addLayout( frameHandler::createFrameHandlerControls(parentWidget, isSizeFixed) );
+    newVBoxLayout->addLayout( frameHandler::createFrameHandlerControls(isSizeFixed) );
   
-    QFrame *line = new QFrame(parentWidget);
+    QFrame *line = new QFrame;
     line->setObjectName(QStringLiteral("line"));
     line->setFrameShape(QFrame::HLine);
     line->setFrameShadow(QFrame::Sunken);
     newVBoxLayout->addWidget(line);
   }
 
-  ui->setupUi(parentWidget);
+  ui->setupUi();
 
   // Set all the values of the properties widget to the values of this class
   ui->rgbFormatComboBox->addItems( rgbPresetList.getFormatedNames() );

--- a/source/videoHandlerRGB.cpp
+++ b/source/videoHandlerRGB.cpp
@@ -177,8 +177,7 @@ qint64 videoHandlerRGB::rgbPixelFormat::bytesPerFrame(QSize frameSize)
 
 // --------------------- videoHandlerRGB ----------------------------------
 
-videoHandlerRGB::videoHandlerRGB() : videoHandler(),
-  ui(new SafeUi<Ui::videoHandlerRGB>)
+videoHandlerRGB::videoHandlerRGB() : videoHandler()
 {
   // preset internal values
   setSrcPixelFormat( rgbPixelFormat() );
@@ -205,7 +204,6 @@ videoHandlerRGB::~videoHandlerRGB()
   // This will cause a "QMutex: destroying locked mutex" warning by Qt.
   // However, here this is on purpose.
   rgbFormatMutex.lock();
-  delete ui;
 }
 
 ValuePairList videoHandlerRGB::getPixelValues(QPoint pixelPos, int frameIdx, frameHandler *item2)
@@ -255,7 +253,7 @@ ValuePairList videoHandlerRGB::getPixelValues(QPoint pixelPos, int frameIdx, fra
 QLayout *videoHandlerRGB::createRGBVideoHandlerControls(bool isSizeFixed)
 {
   // Absolutely always only call this function once!
-  assert(!ui->created());
+  assert(!ui.created());
 
   QVBoxLayout *newVBoxLayout = NULL;
   if (!isSizeFixed)
@@ -272,59 +270,59 @@ QLayout *videoHandlerRGB::createRGBVideoHandlerControls(bool isSizeFixed)
     newVBoxLayout->addWidget(line);
   }
 
-  ui->setupUi();
+  ui.setupUi();
 
   // Set all the values of the properties widget to the values of this class
-  ui->rgbFormatComboBox->addItems( rgbPresetList.getFormatedNames() );
-  ui->rgbFormatComboBox->addItem( "Custom..." );
+  ui.rgbFormatComboBox->addItems( rgbPresetList.getFormatedNames() );
+  ui.rgbFormatComboBox->addItem( "Custom..." );
   int idx = rgbPresetList.indexOf( srcPixelFormat );
   if (idx == -1)
-    ui->rgbFormatComboBox->setCurrentText("Unknown pixel format");
+    ui.rgbFormatComboBox->setCurrentText("Unknown pixel format");
   else if (idx > 0)
-    ui->rgbFormatComboBox->setCurrentIndex( idx );  
+    ui.rgbFormatComboBox->setCurrentIndex( idx );
   else
     // Custom pixel format (but a known pixel format)
-    ui->rgbFormatComboBox->setCurrentText( srcPixelFormat.getName() );
-  ui->rgbFormatComboBox->setEnabled(!isSizeFixed);
+    ui.rgbFormatComboBox->setCurrentText( srcPixelFormat.getName() );
+  ui.rgbFormatComboBox->setEnabled(!isSizeFixed);
 
-  ui->colorComponentsComboBox->addItems( QStringList() << "RGB" << "Red Only" << "Green only" << "Blue only" );
-  ui->colorComponentsComboBox->setCurrentIndex( (int)componentDisplayMode );
+  ui.colorComponentsComboBox->addItems( QStringList() << "RGB" << "Red Only" << "Green only" << "Blue only" );
+  ui.colorComponentsComboBox->setCurrentIndex( (int)componentDisplayMode );
   
-  ui->RScaleSpinBox->setValue(componentScale[0]);
-  ui->RScaleSpinBox->setMaximum(1000);
-  ui->GScaleSpinBox->setValue(componentScale[1]);
-  ui->GScaleSpinBox->setMaximum(1000);
-  ui->BScaleSpinBox->setValue(componentScale[2]);
-  ui->BScaleSpinBox->setMaximum(1000);
+  ui.RScaleSpinBox->setValue(componentScale[0]);
+  ui.RScaleSpinBox->setMaximum(1000);
+  ui.GScaleSpinBox->setValue(componentScale[1]);
+  ui.GScaleSpinBox->setMaximum(1000);
+  ui.BScaleSpinBox->setValue(componentScale[2]);
+  ui.BScaleSpinBox->setMaximum(1000);
 
   // Connect all the change signals from the controls
-  connect(ui->rgbFormatComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotRGBFormatControlChanged()));
-  connect(ui->colorComponentsComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
-  connect(ui->RScaleSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
-  connect(ui->GScaleSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
-  connect(ui->BScaleSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
-  connect(ui->RInvertCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
-  connect(ui->GInvertCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
-  connect(ui->BInvertCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
+  connect(ui.rgbFormatComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotRGBFormatControlChanged()));
+  connect(ui.colorComponentsComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
+  connect(ui.RScaleSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
+  connect(ui.GScaleSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
+  connect(ui.BScaleSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
+  connect(ui.RInvertCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
+  connect(ui.GInvertCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
+  connect(ui.BInvertCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotDisplayOptionsChanged()));
   
   if (!isSizeFixed && newVBoxLayout)
-    newVBoxLayout->addLayout(ui->topVerticalLayout);
+    newVBoxLayout->addLayout(ui.topVerticalLayout);
 
   if (isSizeFixed)
-    return ui->topVerticalLayout;
+    return ui.topVerticalLayout;
   else
     return newVBoxLayout;
 }
 
 void videoHandlerRGB::slotDisplayOptionsChanged()
 {
-  componentDisplayMode = (ComponentDisplayMode)ui->colorComponentsComboBox->currentIndex();
-  componentScale[0] = ui->RScaleSpinBox->value();
-  componentScale[1] = ui->GScaleSpinBox->value();
-  componentScale[2] = ui->BScaleSpinBox->value();
-  componentInvert[0] = ui->RInvertCheckBox->isChecked();
-  componentInvert[1] = ui->GInvertCheckBox->isChecked();
-  componentInvert[2] = ui->BInvertCheckBox->isChecked();
+  componentDisplayMode = (ComponentDisplayMode)ui.colorComponentsComboBox->currentIndex();
+  componentScale[0] = ui.RScaleSpinBox->value();
+  componentScale[1] = ui.GScaleSpinBox->value();
+  componentScale[2] = ui.BScaleSpinBox->value();
+  componentInvert[0] = ui.RInvertCheckBox->isChecked();
+  componentInvert[1] = ui.GInvertCheckBox->isChecked();
+  componentInvert[2] = ui.BInvertCheckBox->isChecked();
     
   // Set the current frame in the buffer to be invalid and clear the cache.
   // Emit that this item needs redraw and the cache needs updating.
@@ -337,7 +335,7 @@ void videoHandlerRGB::slotDisplayOptionsChanged()
 void videoHandlerRGB::slotRGBFormatControlChanged()
 {
   // What is the current selection?
-  int idx = ui->rgbFormatComboBox->currentIndex();
+  int idx = ui.rgbFormatComboBox->currentIndex();
 
   // The old format's nr bytes per frame
   qint64 nrBytesOldFormat = getBytesPerFrame();
@@ -361,18 +359,18 @@ void videoHandlerRGB::slotRGBFormatControlChanged()
     {
       // Valid pixel format with is not in the list. Add it...
       rgbPresetList.append( srcPixelFormat );
-      int nrItems = ui->rgbFormatComboBox->count();
-      disconnect(ui->rgbFormatComboBox, SIGNAL(currentIndexChanged(int)), NULL, NULL);
-      ui->rgbFormatComboBox->insertItem( nrItems - 1, srcPixelFormat.getName() );
-      connect(ui->rgbFormatComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotRGBFormatControlChanged()));
+      int nrItems = ui.rgbFormatComboBox->count();
+      disconnect(ui.rgbFormatComboBox, SIGNAL(currentIndexChanged(int)), NULL, NULL);
+      ui.rgbFormatComboBox->insertItem( nrItems - 1, srcPixelFormat.getName() );
+      connect(ui.rgbFormatComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotRGBFormatControlChanged()));
       idx = rgbPresetList.indexOf( srcPixelFormat );
     }
     
     if (idx > 0)
       // Format found. Set it without another call to this function.
-      disconnect(ui->rgbFormatComboBox, SIGNAL(currentIndexChanged(int)));
-      ui->rgbFormatComboBox->setCurrentIndex( idx );
-      connect(ui->rgbFormatComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotRGBFormatControlChanged()));
+      disconnect(ui.rgbFormatComboBox, SIGNAL(currentIndexChanged(int)));
+      ui.rgbFormatComboBox->setCurrentIndex( idx );
+      connect(ui.rgbFormatComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotRGBFormatControlChanged()));
   }
   else
   {

--- a/source/videoHandlerRGB.h
+++ b/source/videoHandlerRGB.h
@@ -222,7 +222,7 @@ private:
   // the main thread does not change the rgb format while this is happening.
   QMutex rgbFormatMutex;
 
-  SafeUi<Ui::videoHandlerRGB> *ui;
+  SafeUi<Ui::videoHandlerRGB> ui;
 
 private slots:
 

--- a/source/videoHandlerRGB.h
+++ b/source/videoHandlerRGB.h
@@ -32,7 +32,7 @@
 #include "ui_videoHandlerRGB.h"
 #include "ui_videoHandlerRGB_CustomFormatDialog.h"
 
-class videoHandlerRGB_CustomFormatDialog : public QDialog, public Ui::CustomRGBFormatDialog
+class videoHandlerRGB_CustomFormatDialog : public QDialog, private Ui::CustomRGBFormatDialog
 {
   Q_OBJECT
 public:
@@ -71,7 +71,7 @@ public:
   // Create the rgb controls and return a pointer to the layout.
   // rgbFormatFixed: For example a RGB file does not have a fixed format (the user can change this),
   // other sources might provide a fixed format which the user cannot change.
-  virtual QLayout *createRGBVideoHandlerControls(QWidget *parentWidget, bool isSizeFixed=false);
+  virtual QLayout *createRGBVideoHandlerControls(bool isSizeFixed=false);
 
   // Get the name of the currently selected RGB pixel format
   virtual QString getRawRGBPixelFormatName() { return srcPixelFormat.getName(); }
@@ -218,14 +218,11 @@ private:
   QByteArray tmpBufferRawRGBDataCaching;
 #endif
 
-  // Have the controls been created already?
-  bool controlsCreated;
-
   // When a caching job is running in the background it will lock this mutex, so that
   // the main thread does not change the rgb format while this is happening.
   QMutex rgbFormatMutex;
 
-  Ui::videoHandlerRGB *ui;
+  SafeUi<Ui::videoHandlerRGB> *ui;
 
 private slots:
 

--- a/source/videoHandlerYUV.cpp
+++ b/source/videoHandlerYUV.cpp
@@ -115,8 +115,7 @@ videoHandlerYUV::YUVFormatList videoHandlerYUV::yuvFormatList;
 
 // ---------------------- videoHandlerYUV -----------------------------------
 
-videoHandlerYUV::videoHandlerYUV() : videoHandler(),
-  ui(new SafeUi<Ui::videoHandlerYUV>)
+videoHandlerYUV::videoHandlerYUV() : videoHandler()
 {
   // preset internal values
   setSrcPixelFormat( yuvFormatList.getFromName("Unknown Pixel Format") );
@@ -141,7 +140,6 @@ void videoHandlerYUV::loadValues(QSize newFramesize, QString sourcePixelFormat)
 
 videoHandlerYUV::~videoHandlerYUV()
 {
-  delete ui;
 }
 
 /// --- Convert from the current YUV input format to YUV 444
@@ -1115,7 +1113,7 @@ QLayout *videoHandlerYUV::createYUVVideoHandlerControls(bool isSizeFixed)
 {
 
   // Absolutely always only call this function once!
-  assert(!ui->created());
+  assert(!ui.created());
 
   QVBoxLayout *newVBoxLayout = NULL;
   if (!isSizeFixed)
@@ -1132,44 +1130,44 @@ QLayout *videoHandlerYUV::createYUVVideoHandlerControls(bool isSizeFixed)
     newVBoxLayout->addWidget(line);
   }
   
-  ui->setupUi();
+  ui.setupUi();
 
   // Set all the values of the properties widget to the values of this class
-  ui->yuvFileFormatComboBox->addItems( yuvFormatList.getFormatedNames() );
+  ui.yuvFileFormatComboBox->addItems( yuvFormatList.getFormatedNames() );
   int idx = yuvFormatList.indexOf( srcPixelFormat );
-  ui->yuvFileFormatComboBox->setCurrentIndex( idx );
-  ui->yuvFileFormatComboBox->setEnabled(!isSizeFixed);
-  ui->colorComponentsComboBox->addItems( QStringList() << "Y'CbCr" << "Luma Only" << "Cb only" << "Cr only" );
-  ui->colorComponentsComboBox->setCurrentIndex( (int)componentDisplayMode );
-  ui->chromaInterpolationComboBox->addItems( QStringList() << "Nearest neighbour" << "Bilinear" );
-  ui->chromaInterpolationComboBox->setCurrentIndex( (int)interpolationMode );
-  ui->colorConversionComboBox->addItems( QStringList() << "ITU-R.BT709" << "ITU-R.BT601" << "ITU-R.BT202" );
-  ui->colorConversionComboBox->setCurrentIndex( (int)yuvColorConversionType );
-  ui->lumaScaleSpinBox->setValue( lumaScale );
-  ui->lumaOffsetSpinBox->setMaximum(1000);
-  ui->lumaOffsetSpinBox->setValue( lumaOffset );
-  ui->lumaInvertCheckBox->setChecked( lumaInvert );
-  ui->chromaScaleSpinBox->setValue( chromaScale );
-  ui->chromaOffsetSpinBox->setMaximum(1000);
-  ui->chromaOffsetSpinBox->setValue( chromaOffset );
-  ui->chromaInvertCheckBox->setChecked( chromaInvert );
+  ui.yuvFileFormatComboBox->setCurrentIndex( idx );
+  ui.yuvFileFormatComboBox->setEnabled(!isSizeFixed);
+  ui.colorComponentsComboBox->addItems( QStringList() << "Y'CbCr" << "Luma Only" << "Cb only" << "Cr only" );
+  ui.colorComponentsComboBox->setCurrentIndex( (int)componentDisplayMode );
+  ui.chromaInterpolationComboBox->addItems( QStringList() << "Nearest neighbour" << "Bilinear" );
+  ui.chromaInterpolationComboBox->setCurrentIndex( (int)interpolationMode );
+  ui.colorConversionComboBox->addItems( QStringList() << "ITU-R.BT709" << "ITU-R.BT601" << "ITU-R.BT202" );
+  ui.colorConversionComboBox->setCurrentIndex( (int)yuvColorConversionType );
+  ui.lumaScaleSpinBox->setValue( lumaScale );
+  ui.lumaOffsetSpinBox->setMaximum(1000);
+  ui.lumaOffsetSpinBox->setValue( lumaOffset );
+  ui.lumaInvertCheckBox->setChecked( lumaInvert );
+  ui.chromaScaleSpinBox->setValue( chromaScale );
+  ui.chromaOffsetSpinBox->setMaximum(1000);
+  ui.chromaOffsetSpinBox->setValue( chromaOffset );
+  ui.chromaInvertCheckBox->setChecked( chromaInvert );
 
   // Connect all the change signals from the controls to "connectWidgetSignals()"
-  connect(ui->yuvFileFormatComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotYUVControlChanged()));
-  connect(ui->colorComponentsComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotYUVControlChanged()));
-  connect(ui->chromaInterpolationComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotYUVControlChanged()));
-  connect(ui->colorConversionComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotYUVControlChanged()));
-  connect(ui->lumaScaleSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotYUVControlChanged()));
-  connect(ui->lumaOffsetSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotYUVControlChanged()));
-  connect(ui->lumaInvertCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotYUVControlChanged()));
-  connect(ui->chromaScaleSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotYUVControlChanged()));
-  connect(ui->chromaOffsetSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotYUVControlChanged()));
-  connect(ui->chromaInvertCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotYUVControlChanged()));
+  connect(ui.yuvFileFormatComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotYUVControlChanged()));
+  connect(ui.colorComponentsComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotYUVControlChanged()));
+  connect(ui.chromaInterpolationComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotYUVControlChanged()));
+  connect(ui.colorConversionComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotYUVControlChanged()));
+  connect(ui.lumaScaleSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotYUVControlChanged()));
+  connect(ui.lumaOffsetSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotYUVControlChanged()));
+  connect(ui.lumaInvertCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotYUVControlChanged()));
+  connect(ui.chromaScaleSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotYUVControlChanged()));
+  connect(ui.chromaOffsetSpinBox, SIGNAL(valueChanged(int)), this, SLOT(slotYUVControlChanged()));
+  connect(ui.chromaInvertCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotYUVControlChanged()));
 
   if (!isSizeFixed && newVBoxLayout)
-    newVBoxLayout->addLayout(ui->topVBoxLayout);
+    newVBoxLayout->addLayout(ui.topVBoxLayout);
 
-  return (isSizeFixed) ? ui->topVBoxLayout : newVBoxLayout;
+  return (isSizeFixed) ? ui.topVBoxLayout : newVBoxLayout;
 }
 
 void videoHandlerYUV::slotYUVControlChanged()
@@ -1177,25 +1175,25 @@ void videoHandlerYUV::slotYUVControlChanged()
   // The control that caused the slot to be called
   QObject *sender = QObject::sender();
 
-  if (sender == ui->colorComponentsComboBox ||
-           sender == ui->chromaInterpolationComboBox ||
-           sender == ui->colorConversionComboBox ||
-           sender == ui->lumaScaleSpinBox ||
-           sender == ui->lumaOffsetSpinBox ||
-           sender == ui->lumaInvertCheckBox ||
-           sender == ui->chromaScaleSpinBox ||
-           sender == ui->chromaOffsetSpinBox ||
-           sender == ui->chromaInvertCheckBox )
+  if (sender == ui.colorComponentsComboBox ||
+           sender == ui.chromaInterpolationComboBox ||
+           sender == ui.colorConversionComboBox ||
+           sender == ui.lumaScaleSpinBox ||
+           sender == ui.lumaOffsetSpinBox ||
+           sender == ui.lumaInvertCheckBox ||
+           sender == ui.chromaScaleSpinBox ||
+           sender == ui.chromaOffsetSpinBox ||
+           sender == ui.chromaInvertCheckBox )
   {
-    componentDisplayMode = (ComponentDisplayMode)ui->colorComponentsComboBox->currentIndex();
-    interpolationMode = (InterpolationMode)ui->chromaInterpolationComboBox->currentIndex();
-    yuvColorConversionType = (YUVCColorConversionType)ui->colorConversionComboBox->currentIndex();
-    lumaScale = ui->lumaScaleSpinBox->value();
-    lumaOffset = ui->lumaOffsetSpinBox->value();
-    lumaInvert = ui->lumaInvertCheckBox->isChecked();
-    chromaScale = ui->chromaScaleSpinBox->value();
-    chromaOffset = ui->chromaOffsetSpinBox->value();
-    chromaInvert = ui->chromaInvertCheckBox->isChecked();
+    componentDisplayMode = (ComponentDisplayMode)ui.colorComponentsComboBox->currentIndex();
+    interpolationMode = (InterpolationMode)ui.chromaInterpolationComboBox->currentIndex();
+    yuvColorConversionType = (YUVCColorConversionType)ui.colorConversionComboBox->currentIndex();
+    lumaScale = ui.lumaScaleSpinBox->value();
+    lumaOffset = ui.lumaOffsetSpinBox->value();
+    lumaInvert = ui.lumaInvertCheckBox->isChecked();
+    chromaScale = ui.chromaScaleSpinBox->value();
+    chromaOffset = ui.chromaOffsetSpinBox->value();
+    chromaInvert = ui.chromaInvertCheckBox->isChecked();
 
     // Set the current frame in the buffer to be invalid and clear the cache.
     // Emit that this item needs redraw and the cache needs updating.
@@ -1205,12 +1203,12 @@ void videoHandlerYUV::slotYUVControlChanged()
       pixmapCache.clear();
     emit signalHandlerChanged(true, true);
   }
-  else if (sender == ui->yuvFileFormatComboBox)
+  else if (sender == ui.yuvFileFormatComboBox)
   {
     qint64 oldFormatBytesPerFrame = srcPixelFormat.bytesPerFrame(frameSize);
 
     // Set the new YUV format
-    setSrcPixelFormat( yuvFormatList.getFromName( ui->yuvFileFormatComboBox->currentText() ) );
+    setSrcPixelFormat( yuvFormatList.getFromName( ui.yuvFileFormatComboBox->currentText() ) );
 
     // Check if the new format changed the number of frames in the sequence
     emit signalUpdateFrameLimits();
@@ -2336,16 +2334,16 @@ void videoHandlerYUV::setYUVPixelFormatByName(QString name, bool emitSignal)
   yuvPixelFormat newSrcPixelFormat = yuvFormatList.getFromName(name);
   if (newSrcPixelFormat != srcPixelFormat)
   {
-    if (ui->created())
-      disconnect(ui->yuvFileFormatComboBox, SIGNAL(currentIndexChanged(int)), NULL, NULL);
+    if (ui.created())
+      disconnect(ui.yuvFileFormatComboBox, SIGNAL(currentIndexChanged(int)), NULL, NULL);
 
     setSrcPixelFormat( yuvFormatList.getFromName(name) );
     int idx = yuvFormatList.indexOf( srcPixelFormat );
     
-    if (ui->created())
+    if (ui.created())
     {
-      ui->yuvFileFormatComboBox->setCurrentIndex( idx );
-      connect(ui->yuvFileFormatComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotYUVControlChanged()));
+      ui.yuvFileFormatComboBox->setCurrentIndex( idx );
+      connect(ui.yuvFileFormatComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(slotYUVControlChanged()));
     }
 
     // Clear the cache

--- a/source/videoHandlerYUV.h
+++ b/source/videoHandlerYUV.h
@@ -267,7 +267,7 @@ private:
   // the main thread does not change the yuv format while this is happening.
   QMutex yuvFormatMutex;
 
-  SafeUi<Ui::videoHandlerYUV> *ui;
+  SafeUi<Ui::videoHandlerYUV> ui;
 
 private slots:
 

--- a/source/videoHandlerYUV.h
+++ b/source/videoHandlerYUV.h
@@ -72,7 +72,7 @@ public:
   // Create the yuv controls and return a pointer to the layout.
   // yuvFormatFixed: For example a YUV file does not have a fixed format (the user can change this),
   // other sources might provide a fixed format which the user cannot change (HEVC file, ...)
-  virtual QLayout *createYUVVideoHandlerControls(QWidget *parentWidget, bool isSizeFixed=false);
+  virtual QLayout *createYUVVideoHandlerControls(bool isSizeFixed=false);
 
   // Get the name of the currently selected YUV pixel format
   virtual QString getRawYUVPixelFormatName() { return srcPixelFormat.name; }
@@ -263,13 +263,11 @@ private:
                            quint8 *rgb, quint32 srgb );
 #endif
 
-  bool controlsCreated;    ///< Have the controls been created already?
-
   // When a caching job is running in the background it will lock this mutex, so that
   // the main thread does not change the yuv format while this is happening.
   QMutex yuvFormatMutex;
 
-  Ui::videoHandlerYUV *ui;
+  SafeUi<Ui::videoHandlerYUV> *ui;
 
 private slots:
 

--- a/ui/frameHandler.ui
+++ b/ui/frameHandler.ui
@@ -13,36 +13,40 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="frameHandlerLayout" rowstretch="0,0,0,0" columnstretch="0,1,0,1">
-   <item row="3" column="2" colspan="2">
-    <widget class="QComboBox" name="frameSizeComboBox"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="QSpinBox" name="widthSpinBox"/>
-   </item>
-   <item row="1" column="3">
-    <widget class="QSpinBox" name="heightSpinBox"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Width</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Frame Size</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Height</string>
-     </property>
-    </widget>
+  <layout class="QVBoxLayout" name="wrapperLayout">
+   <item>
+    <layout class="QGridLayout" name="frameHandlerLayout" rowstretch="0,0,0,0" columnstretch="0,1,0,1">
+     <item row="3" column="2" colspan="2">
+      <widget class="QComboBox" name="frameSizeComboBox"/>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="widthSpinBox"/>
+     </item>
+     <item row="1" column="3">
+      <widget class="QSpinBox" name="heightSpinBox"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Width</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="2">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Frame Size</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Height</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/ui/playlistItemIndexed.ui
+++ b/ui/playlistItemIndexed.ui
@@ -13,46 +13,50 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0,1">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Start</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QSpinBox" name="startSpinBox"/>
-   </item>
-   <item row="0" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>End</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="3">
-    <widget class="QSpinBox" name="endSpinBox"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Rate</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QDoubleSpinBox" name="rateSpinBox"/>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Sampling</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="3">
-    <widget class="QSpinBox" name="samplingSpinBox"/>
+  <layout class="QVBoxLayout" name="wrapperLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0,1">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Start</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QSpinBox" name="startSpinBox"/>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>End</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QSpinBox" name="endSpinBox"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Rate</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QDoubleSpinBox" name="rateSpinBox"/>
+     </item>
+     <item row="1" column="2">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Sampling</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QSpinBox" name="samplingSpinBox"/>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/ui/playlistItemStatic.ui
+++ b/ui/playlistItemStatic.ui
@@ -13,16 +13,20 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QHBoxLayout" name="wrapperLayout">
    <item>
-    <widget class="QLabel" name="durationLabel">
-     <property name="text">
-      <string>Duration (seconds)</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QDoubleSpinBox" name="durationSpinBox"/>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="durationLabel">
+       <property name="text">
+        <string>Duration (seconds)</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="durationSpinBox"/>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/ui/playlistItemText.ui
+++ b/ui/playlistItemText.ui
@@ -13,45 +13,49 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="topVBoxLayout">
+  <layout class="QVBoxLayout" name="wrapperLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="1">
-      <widget class="QPushButton" name="selectColorButton">
-       <property name="text">
-        <string>Select Color</string>
-       </property>
-      </widget>
+    <layout class="QVBoxLayout" name="topVBoxLayout">
+     <item>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="1" column="1">
+        <widget class="QPushButton" name="selectColorButton">
+         <property name="text">
+          <string>Select Color</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QPushButton" name="selectFontButton">
+         <property name="text">
+          <string>Select Font</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Color</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Font</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
-     <item row="0" column="1">
-      <widget class="QPushButton" name="selectFontButton">
-       <property name="text">
-        <string>Select Font</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Color</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Font</string>
+     <item>
+      <widget class="QPlainTextEdit" name="textEdit">
+       <property name="plainText">
+        <string>Text</string>
        </property>
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QPlainTextEdit" name="textEdit">
-     <property name="plainText">
-      <string>Text</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/ui/statisticHandler.ui
+++ b/ui/statisticHandler.ui
@@ -19,75 +19,79 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="wrapperLayout">
    <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>153</width>
-        <height>52</height>
-       </rect>
-      </property>
-      <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="1">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Opacity</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="3">
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>Arrows</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Name</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Grid</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0" colspan="4">
-        <widget class="Line" name="line">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QScrollArea" name="scrollArea">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="widgetResizable">
+        <bool>true</bool>
+       </property>
+       <widget class="QWidget" name="scrollAreaWidgetContents">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>153</width>
+          <height>52</height>
+         </rect>
+        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="1">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Opacity</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Arrows</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Name</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Grid</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0" colspan="4">
+          <widget class="Line" name="line">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/ui/videoHandlerDifference.ui
+++ b/ui/videoHandlerDifference.ui
@@ -13,69 +13,73 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="topVBoxLayout">
+  <layout class="QVBoxLayout" name="wrapperLayout">
    <item>
-    <widget class="QCheckBox" name="markDifferenceCheckBox">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Highlight all differences in red&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Mark Differences</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+    <layout class="QVBoxLayout" name="topVBoxLayout">
      <item>
-      <widget class="QLabel" name="label_2">
+      <widget class="QCheckBox" name="markDifferenceCheckBox">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Highlight all differences in red&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
        <property name="text">
-        <string>Amplify</string>
+        <string>Mark Differences</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QSpinBox" name="amplificationFactorSpinBox">
-       <property name="minimum">
-        <number>1</number>
+      <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Amplify</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="amplificationFactorSpinBox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>1000</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="title">
+        <string>First difference position</string>
        </property>
-       <property name="maximum">
-        <number>1000</number>
-       </property>
+       <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Coding order</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="codingOrderComboBox"/>
+        </item>
+       </layout>
       </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>First difference position</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Coding order</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="codingOrderComboBox"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/ui/videoHandlerRGB.ui
+++ b/ui/videoHandlerRGB.ui
@@ -13,106 +13,110 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="topVerticalLayout">
+  <layout class="QVBoxLayout" name="wrapperLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+    <layout class="QVBoxLayout" name="topVerticalLayout">
      <item>
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>RGB Format</string>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+       <item>
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>RGB Format</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="rgbFormatComboBox">
+         <property name="editable">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
-      <widget class="QComboBox" name="rgbFormatComboBox">
-       <property name="editable">
-        <bool>false</bool>
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="title">
+        <string>RGB Display</string>
        </property>
+       <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Scale B</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QSpinBox" name="BScaleSpinBox">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QSpinBox" name="GScaleSpinBox">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="QCheckBox" name="BInvertCheckBox">
+          <property name="text">
+           <string>Invert</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="RScaleSpinBox">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QCheckBox" name="GInvertCheckBox">
+          <property name="text">
+           <string>Invert</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Scale G</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QCheckBox" name="RInvertCheckBox">
+          <property name="text">
+           <string>Invert</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Scale R</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Components</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1" colspan="2">
+         <widget class="QComboBox" name="colorComponentsComboBox"/>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>RGB Display</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Scale B</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QSpinBox" name="BScaleSpinBox">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QSpinBox" name="GScaleSpinBox">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QCheckBox" name="BInvertCheckBox">
-        <property name="text">
-         <string>Invert</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="RScaleSpinBox">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QCheckBox" name="GInvertCheckBox">
-        <property name="text">
-         <string>Invert</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Scale G</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QCheckBox" name="RInvertCheckBox">
-        <property name="text">
-         <string>Invert</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Scale R</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Components</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QComboBox" name="colorComponentsComboBox"/>
-      </item>
-     </layout>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/ui/videoHandlerYUV.ui
+++ b/ui/videoHandlerYUV.ui
@@ -13,124 +13,128 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="topVBoxLayout">
+  <layout class="QVBoxLayout" name="wrapperLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QVBoxLayout" name="topVBoxLayout">
      <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string>Luma</string>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
-        <item row="1" column="1">
-         <widget class="QSpinBox" name="lumaOffsetSpinBox"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_6">
-          <property name="text">
-           <string>Offset</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QSpinBox" name="lumaScaleSpinBox"/>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Scale</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0" colspan="2">
-         <widget class="QCheckBox" name="lumaInvertCheckBox">
-          <property name="text">
-           <string>Invert</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Luma</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="lumaOffsetSpinBox"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Offset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="lumaScaleSpinBox"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Scale</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="lumaInvertCheckBox">
+            <property name="text">
+             <string>Invert</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>Chroma</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,1">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Offset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="chromaScaleSpinBox"/>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="chromaOffsetSpinBox"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Scale</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="chromaInvertCheckBox">
+            <property name="text">
+             <string>Invert</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_2">
-       <property name="title">
-        <string>Chroma</string>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,1">
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Offset</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QSpinBox" name="chromaScaleSpinBox"/>
-        </item>
-        <item row="1" column="1">
-         <widget class="QSpinBox" name="chromaOffsetSpinBox"/>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Scale</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0" colspan="2">
-         <widget class="QCheckBox" name="chromaInvertCheckBox">
-          <property name="text">
-           <string>Invert</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-     <item row="1" column="1">
-      <widget class="QComboBox" name="colorComponentsComboBox"/>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Chroma Interpolation</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Color Components</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Color Conversion</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="chromaInterpolationComboBox"/>
-     </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="colorConversionComboBox"/>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_8">
-       <property name="text">
-        <string>YUV Format</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="yuvFileFormatComboBox"/>
+      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+       <item row="1" column="1">
+        <widget class="QComboBox" name="colorComponentsComboBox"/>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Chroma Interpolation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Color Components</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Color Conversion</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="chromaInterpolationComboBox"/>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="colorConversionComboBox"/>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>YUV Format</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="yuvFileFormatComboBox"/>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
1. The `Ui::Form::setupUi` calls were used on widgets that already had layouts. This happened to work, but relied on undocumented failure paths within Qt and produced runtime warnings.

   To remedy it, a `SafeUi<Ui::Form>` wrapper is implemented. It derives from `Ui::Form` and adds a `setupUi()` method that doesn't require a widget. The `.ui` file has to be modified to add a top-level `wrapperLayout` that is discarded during the setup process.

2. Use the `SafeUi` wrapper to track lifetime of controls. This removes the need for a separate `controlsCreated` member.  The wrapper also bit-clears the base `Ui::Form` class to ensure that any there are no uninitialized pointer members, and that any reference to an uninstantiated Ui item is a  null pointer dereference.

3. Hold all `Ui::Form` instances by value.

Please test, so far using YUV, JPEG and HEVC files works as expected. I'm not sure how to test split views: I couldn't get them to do anything on the right-hand side.