### PR TITLE
Safety 3

### DIFF
--- a/source/fileInfoWidget.cpp
+++ b/source/fileInfoWidget.cpp
@@ -28,9 +28,6 @@ FileInfoWidget::FileInfoWidget(QWidget *parent) :
   QWidget(parent),
   infoLayout(this)
 {
-  currentItem1 = NULL;
-  currentItem2 = NULL;
-
   // Load the warning icon
   warningIcon = QPixmap(":img_warning.png");
 

--- a/source/fileInfoWidget.h
+++ b/source/fileInfoWidget.h
@@ -23,6 +23,7 @@
 #include <QLabel>
 #include <QFontMetrics>
 #include <QResizeEvent>
+#include <QPointer>
 #include "typedef.h"
 
 class playlistItem;
@@ -103,7 +104,7 @@ private:
   int nrLabelPairs;
 
   // Pointers to the currently selected items
-  playlistItem *currentItem1, *currentItem2;
+  QPointer<playlistItem> currentItem1, currentItem2;
 
   QPixmap warningIcon;
 };

--- a/source/playbackController.cpp
+++ b/source/playbackController.cpp
@@ -52,11 +52,6 @@ PlaybackController::PlaybackController()
   timerFPSCounter = 0;
   timerLastFPSTime = QTime::currentTime();
 
-  currentItem = NULL;
-
-  splitViewPrimary = NULL;
-  splitViewSeparate = NULL;
-
   // Initial state is disabled (until an item is selected in the playlist)
   enableControls(false);
 }

--- a/source/playbackController.h
+++ b/source/playbackController.h
@@ -130,16 +130,16 @@ private:
   virtual void timerEvent(QTimerEvent * event) Q_DECL_OVERRIDE; // Overloaded from QObject. Called when the timer fires.
 
   // We keep a pointer to the currently selected item (only the first)
-  playlistItem *currentItem;
+  QPointer<playlistItem> currentItem;
 
   // The playback controller has a pointer to the split view so it can toggle a redraw event when a new frame is selected.
   // This could also be done using signals/slots but the problem is that signals/slots have a small overhead. 
   // So when we are using the QTimer for high framerates, this is the faster option.
-  splitViewWidget *splitViewPrimary;
-  splitViewWidget *splitViewSeparate;
+  QPointer<splitViewWidget> splitViewPrimary;
+  QPointer<splitViewWidget> splitViewSeparate;
 
   // We keep a pointer to the playlist tree so we can select the next item, see if there is a next item and so on.
-  PlaylistTreeWidget *playlist;
+  QPointer<PlaylistTreeWidget> playlist;
 };
 
 #endif // PLAYBACKCONTROLLER_H

--- a/source/playlistItem.cpp
+++ b/source/playlistItem.cpp
@@ -23,7 +23,6 @@ unsigned int playlistItem::idCounter = 0;
 playlistItem::playlistItem(QString itemNameOrFileName)  
 {
   setName(itemNameOrFileName);
-  propertiesWidget = NULL;
   cachingEnabled = false;
 
   // Whenever a playlistItem is created, we give it an ID (which is unique for this instance of YUView)
@@ -39,8 +38,6 @@ playlistItem::~playlistItem()
     playlistItem *plItem = dynamic_cast<playlistItem*>(QTreeWidgetItem::takeChild(0));
     delete plItem;
   }
-
-  delete propertiesWidget;
 }
 
 // Delete the item later but disable caching of this item before, so that the video cache ignores it
@@ -74,4 +71,10 @@ QList<playlistItem*> playlistItem::getItemAndAllChildren()
       returnList.append(childItem->getItemAndAllChildren());
   }
   return returnList;
+}
+
+void playlistItem::preparePropertiesWidget(const QString & name) {
+  Q_ASSERT(!propertiesWidget);
+  propertiesWidget.reset(new QWidget);
+  propertiesWidget->setObjectName(name);
 }

--- a/source/playlistItem.h
+++ b/source/playlistItem.h
@@ -94,8 +94,8 @@ public:
    * For example a playlistItemYUVFile will return "YUV File properties".
   */
   virtual QString getPropertiesTitle() = 0;
-  QWidget *getPropertiesWidget() { if (!propertiesWidget) createPropertiesWidget(); return propertiesWidget; }
-  bool propertiesWidgetCreated() { return propertiesWidget; }
+  QWidget *getPropertiesWidget() { if (!propertiesWidget) createPropertiesWidget(); return propertiesWidget.data(); }
+  bool propertiesWidgetCreated() const { return propertiesWidget; }
 
   // Does the playlist item currently accept drops of the given item?
   virtual bool acceptDrops(playlistItem *draggingItem) { Q_UNUSED(draggingItem); return false; }
@@ -171,12 +171,14 @@ protected:
   QString plItemNameOrFileName;
 
   // The widget which is put into the stack.
-  QWidget *propertiesWidget;
+  QScopedPointer<QWidget> propertiesWidget;
 
   // Create the properties widget and set propertiesWidget to point to it.
-  // Overload this function in a child class to create a custom widget. The default
-  // implementation here will add an empty widget.
-  virtual void createPropertiesWidget( ) { propertiesWidget = new QWidget; }
+  // Overload this function in a child class to create a custom widget.
+  virtual void createPropertiesWidget() = 0;
+
+  // Create a named default propertiesWidget
+  void preparePropertiesWidget(const QString & name);
 
   // This mutex is locked while caching is running in the background. When deleting the item, we have to wait until
   // this mutex is unlocked. Make shure to lock/unlock this mutex in your subclass

--- a/source/playlistItemDifference.cpp
+++ b/source/playlistItemDifference.cpp
@@ -110,17 +110,14 @@ QSize playlistItemDifference::getSize()
 void playlistItemDifference::createPropertiesWidget( )
 {
   // Absolutely always only call this once
-  assert( propertiesWidget == NULL );
+  assert(!propertiesWidget);
 
-  // Create a new widget and populate it with controls
-  propertiesWidget = new QWidget;
-  if (propertiesWidget->objectName().isEmpty())
-    propertiesWidget->setObjectName(QStringLiteral("playlistItemDifference"));
+  preparePropertiesWidget(QStringLiteral("playlistItemDifference"));
 
   // On the top level everything is layout vertically
-  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget);
+  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget.data());
 
-  QFrame *line = new QFrame(propertiesWidget);
+  QFrame *line = new QFrame(propertiesWidget.data());
   line->setObjectName(QStringLiteral("line"));
   line->setFrameShape(QFrame::HLine);
   line->setFrameShadow(QFrame::Sunken);
@@ -133,9 +130,6 @@ void playlistItemDifference::createPropertiesWidget( )
   // Insert a stretch at the bottom of the vertical global layout so that everything
   // gets 'pushed' to the top
   vAllLaout->insertStretch(3, 1);
-
-  // Set the layout and add widget
-  propertiesWidget->setLayout( vAllLaout );
 }
 
 void playlistItemDifference::updateChildItems()

--- a/source/playlistItemHEVCFile.cpp
+++ b/source/playlistItemHEVCFile.cpp
@@ -532,17 +532,14 @@ void playlistItemHEVCFile::copyImgToByteArray(const de265_image *src, QByteArray
 void playlistItemHEVCFile::createPropertiesWidget( )
 {
   // Absolutely always only call this once
-  assert( propertiesWidget == NULL );
+  assert(!propertiesWidget);
 
-  // Create a new widget and populate it with controls
-  propertiesWidget = new QWidget;
-  if (propertiesWidget->objectName().isEmpty())
-    propertiesWidget->setObjectName(QStringLiteral("playlistItemHEVCFile"));
+  preparePropertiesWidget(QStringLiteral("playlistItemHEVCFile"));
 
   // On the top level everything is layout vertically
-  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget);
+  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget.data());
 
-  QFrame *lineOne = new QFrame(propertiesWidget);
+  QFrame *lineOne = new QFrame(propertiesWidget.data());
   lineOne->setObjectName(QStringLiteral("line"));
   lineOne->setFrameShape(QFrame::HLine);
   lineOne->setFrameShadow(QFrame::Sunken);
@@ -568,9 +565,6 @@ void playlistItemHEVCFile::createPropertiesWidget( )
     // gets 'pushed' to the top.
     vAllLaout->insertStretch(5, 1);
   }
-
-  // Set the layout and add widget
-  propertiesWidget->setLayout( vAllLaout );
 }
 
 void playlistItemHEVCFile::loadDecoderLibrary()

--- a/source/playlistItemImageFileSequence.cpp
+++ b/source/playlistItemImageFileSequence.cpp
@@ -119,15 +119,12 @@ void playlistItemImageFileSequence::fillImageFileList(QStringList &imageFiles, Q
 void playlistItemImageFileSequence::createPropertiesWidget()
 {
   // Absolutely always only call this once
-  assert( propertiesWidget == NULL );
+  assert(!propertiesWidget);
 
-  // Create a new widget and populate it with controls
-  propertiesWidget = new QWidget;
-  if (propertiesWidget->objectName().isEmpty())
-    propertiesWidget->setObjectName(QStringLiteral("playlistItemRawFile"));
+  preparePropertiesWidget(QStringLiteral("playlistItemRawFile"));
 
   // On the top level everything is layout vertically
-  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget);
+  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget.data());
 
   // First add the parents controls (first video controls (width/height...)
   vAllLaout->addLayout( createIndexControllers() );
@@ -135,9 +132,6 @@ void playlistItemImageFileSequence::createPropertiesWidget()
   // Insert a stretch at the bottom of the vertical global layout so that everything
   // gets 'pushed' to the top
   vAllLaout->insertStretch(2, 1);
-
-  // Set the layout and add widget
-  propertiesWidget->setLayout( vAllLaout );
 }
 
 QList<infoItem> playlistItemImageFileSequence::getInfoList()

--- a/source/playlistItemOverlay.cpp
+++ b/source/playlistItemOverlay.cpp
@@ -302,9 +302,8 @@ void playlistItemOverlay::createPropertiesWidget( )
   Q_ASSERT_X(!propertiesWidget, "playlistItemOverlay::createPropertiesWidget", "Always create the properties only once!");
   
   // Create a new widget and populate it with controls
-  propertiesWidget = new QWidget;
-  ui.setupUi( propertiesWidget );
-  propertiesWidget->setLayout( ui.verticalLayout );
+  propertiesWidget.reset(new QWidget);
+  ui.setupUi(propertiesWidget.data());
 
   // Alignment mode
   ui.alignmentMode->addItems( QStringList() << "Top Left" << "Top Center" << "Top Right" );

--- a/source/playlistItemRawFile.h
+++ b/source/playlistItemRawFile.h
@@ -61,7 +61,7 @@ public:
   
   // A raw file can be used in a difference
   virtual bool canBeUsedInDifference() Q_DECL_OVERRIDE { return true; }
-  virtual frameHandler *getFrameHandler() Q_DECL_OVERRIDE { return video; }
+  virtual frameHandler *getFrameHandler() Q_DECL_OVERRIDE { return video.data(); }
 
   virtual ValuePairListSets getPixelValues(QPoint pixelPos, int frameIdx) Q_DECL_OVERRIDE;
 
@@ -118,10 +118,10 @@ private:
   
   fileSource dataSource;
 
-  videoHandler *video;
+  QScopedPointer<videoHandler> video;
 
-  videoHandlerYUV *getYUVVideo() { return dynamic_cast<videoHandlerYUV*>(video); }
-  videoHandlerRGB *getRGBVideo() { return dynamic_cast<videoHandlerRGB*>(video); }
+  videoHandlerYUV *getYUVVideo() { return dynamic_cast<videoHandlerYUV*>(video.data()); }
+  videoHandlerRGB *getRGBVideo() { return dynamic_cast<videoHandlerRGB*>(video.data()); }
 
   qint64 getBytesPerFrame();
 

--- a/source/playlistItemStatisticsFile.cpp
+++ b/source/playlistItemStatisticsFile.cpp
@@ -544,18 +544,16 @@ void playlistItemStatisticsFile::timerEvent(QTimerEvent * event)
 
 void playlistItemStatisticsFile::createPropertiesWidget()
 {
-  // Absolutely always only call this once// 
-  assert (propertiesWidget == NULL);
+  // Absolutely always only call this once
+  assert(!propertiesWidget);
   
   // Create a new widget and populate it with controls
-  propertiesWidget = new QWidget;
-  if (propertiesWidget->objectName().isEmpty())
-    propertiesWidget->setObjectName(QStringLiteral("playlistItemStatisticsFile"));
+  preparePropertiesWidget(QStringLiteral("playlistItemStatisticsFile"));
 
   // On the top level everything is layout vertically
-  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget);
+  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget.data());
 
-  QFrame *line = new QFrame(propertiesWidget);
+  QFrame *line = new QFrame(propertiesWidget.data());
   line->setObjectName(QStringLiteral("lineOne"));
   line->setFrameShape(QFrame::HLine);
   line->setFrameShadow(QFrame::Sunken);
@@ -566,9 +564,6 @@ void playlistItemStatisticsFile::createPropertiesWidget()
 
   // Do not add any stretchers at the bottom because the statistics handler controls will
   // expand to take up as much space as there is available  
-
-  // Set the layout and add widget
-  propertiesWidget->setLayout( vAllLaout );
 }
 
 void playlistItemStatisticsFile::savePlaylist(QDomElement &root, QDir playlistDir)

--- a/source/playlistItemText.cpp
+++ b/source/playlistItemText.cpp
@@ -66,18 +66,16 @@ playlistItemText::~playlistItemText()
 
 void playlistItemText::createPropertiesWidget()
 {
-  // Absolutely always only call this once// 
-  assert (propertiesWidget == NULL);
+  // Absolutely always only call this once
+  assert(!propertiesWidget);
   
   // Create a new widget and populate it with controls
-  propertiesWidget = new QWidget;
-  if (propertiesWidget->objectName().isEmpty())
-    propertiesWidget->setObjectName(QStringLiteral("playlistItemText"));
+  preparePropertiesWidget(QStringLiteral("playlistItemText"));
 
   // On the top level everything is layout vertically
-  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget);
+  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget.data());
 
-  QFrame *line = new QFrame(propertiesWidget);
+  QFrame *line = new QFrame(propertiesWidget.data());
   line->setObjectName(QStringLiteral("line"));
   line->setFrameShape(QFrame::HLine);
   line->setFrameShadow(QFrame::Sunken);
@@ -90,9 +88,6 @@ void playlistItemText::createPropertiesWidget()
   // Insert a stretch at the bottom of the vertical global layout so that everything
   // gets 'pushed' to the top
   vAllLaout->insertStretch(3, 1);
-
-  // Set the layout and add widget
-  propertiesWidget->setLayout( vAllLaout );
 }
 
 QLayout *playlistItemText::createTextController()

--- a/source/playlistTreeWidget.h
+++ b/source/playlistTreeWidget.h
@@ -19,6 +19,7 @@
 #ifndef PLAYLISTTREEWIDGET_H
 #define PLAYLISTTREEWIDGET_H
 
+#include <QPointer>
 #include <QTreeWidget>
 #include <QDockWidget>
 #include "QMouseEvent"
@@ -159,7 +160,7 @@ private:
   void cloneSelectedItem();
 
   // We have a pointer to the viewStateHandler to load/save the view states to playlist
-  viewStateHandler *stateHandler;
+  QPointer<viewStateHandler> stateHandler;
 };
 
 #endif // PLAYLISTTREEWIDGET_H

--- a/source/playlistitemStatic.cpp
+++ b/source/playlistitemStatic.cpp
@@ -57,18 +57,16 @@ void playlistItemStatic::loadPropertiesFromPlaylist(QDomElementYUView root, play
 
 void playlistItemStatic::createPropertiesWidget()
 {
-  // Absolutely always only call this once// 
-  assert (propertiesWidget == NULL);
+  // Absolutely always only call this once
+  assert(!propertiesWidget);
   
   // Create a new widget and populate it with controls
-  propertiesWidget = new QWidget;
-  if (propertiesWidget->objectName().isEmpty())
-    propertiesWidget->setObjectName(QStringLiteral("playlistItemIndexed"));
+  preparePropertiesWidget(QStringLiteral("playlistItemIndexed"));
 
   // On the top level everything is layout vertically
-  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget);
+  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget.data());
 
-  QFrame *line = new QFrame(propertiesWidget);
+  QFrame *line = new QFrame(propertiesWidget.data());
   line->setObjectName(QStringLiteral("line"));
   line->setFrameShape(QFrame::HLine);
   line->setFrameShadow(QFrame::Sunken);
@@ -80,7 +78,4 @@ void playlistItemStatic::createPropertiesWidget()
   // Insert a stretch at the bottom of the vertical global layout so that everything
   // gets 'pushed' to the top
   vAllLaout->insertStretch(2, 1);
-
-  // Set the layout and add widget
-  propertiesWidget->setLayout( vAllLaout );
 }

--- a/source/splitViewWidget.cpp
+++ b/source/splitViewWidget.cpp
@@ -34,7 +34,6 @@ splitViewWidget::splitViewWidget(QWidget *parent, bool separateView)
 {
   setFocusPolicy(Qt::NoFocus);
   isSeparateWidget = separateView;
-  otherWidget = NULL;
 
   linkViews = false;
   playbackPrimary = false;
@@ -50,9 +49,6 @@ splitViewWidget::splitViewWidget(QWidget *parent, bool separateView)
   drawRegularGrid = false;
   regularGridSize = 64;
   zoomBoxMousePosition = QPoint();
-
-  playlist = NULL;
-  playback = NULL;
 
   updateSettings();
 

--- a/source/splitViewWidget.h
+++ b/source/splitViewWidget.h
@@ -23,6 +23,8 @@
 #include <QDockWidget>
 #include <QMouseEvent>
 #include "ui_splitViewWidgetControls.h"
+#include "playlistTreeWidget.h"
+#include "playbackController.h"
 #include "playlistItem.h"
 
 // The splitter can be grabbed at +-SPLITTER_MARGIN pixels
@@ -202,12 +204,12 @@ protected:
   void paintRegularGrid(QPainter *painter, playlistItem *item);  //!< paint the grid
 
                                                                  // Pointers to the playlist tree widget and to the playback controller
-  PlaylistTreeWidget *playlist;
-  PlaybackController *playback;
+  QPointer<PlaylistTreeWidget> playlist;
+  QPointer<PlaybackController> playback;
 
   // Primary/Separate widget handeling
   bool isSeparateWidget;          //!< Is this the primary widget in the main windows or the one in the separate window
-  splitViewWidget *otherWidget;   //!< Pointer to the other (primary or separate) widget
+  QPointer<splitViewWidget> otherWidget;   //!< Pointer to the other (primary or separate) widget
   bool linkViews;                 //!< Link the two widgets (link zoom factor, position and split position)
   bool playbackPrimary;           //!< When playback is running and this is the primary view and the secondary view is shown, don't run playback for this view.
 

--- a/source/updateHandler.h
+++ b/source/updateHandler.h
@@ -20,6 +20,7 @@
 #define UPDATEHANDLER_H
 
 #include <QDialog>
+#include <QPointer>
 #include <QProgressDialog>
 #include <QWidget>
 #include <QNetworkAccessManager>
@@ -54,10 +55,10 @@ private:
 
   bool userCheckRequest;  //< The request has been issued by the user.
 
-  QWidget *mainWidget;
+  QPointer<QWidget> mainWidget;
   QNetworkAccessManager networkManager;
 
-  QProgressDialog *downloadProgress;
+  QPointer<QProgressDialog> downloadProgress;
 
   enum updaterStatusEnum
   {

--- a/source/videoCache.h
+++ b/source/videoCache.h
@@ -87,9 +87,9 @@ private:
   class cacheJob
   {
   public:
-    cacheJob() { plItem = NULL; }
+    cacheJob() {}
     cacheJob(playlistItem *item, indexRange range) { plItem = item; frameRange = range; }
-    playlistItem *plItem;
+    QPointer<playlistItem> plItem;
     indexRange frameRange;
   };
 

--- a/source/videoHandlerDifference.cpp
+++ b/source/videoHandlerDifference.cpp
@@ -20,10 +20,6 @@
 
 videoHandlerDifference::videoHandlerDifference() : videoHandler()
 {
-  // preset internal values
-  inputVideo[0] = NULL;
-  inputVideo[1] = NULL;
-
   markDifference = false;
   amplificationFactor = 1;
   codingOrder = CodingOrder_HEVC;

--- a/source/videoHandlerDifference.h
+++ b/source/videoHandlerDifference.h
@@ -71,7 +71,7 @@ private:
   CodingOrder codingOrder;
 
   // The two videos that the difference will be calculated from
-  frameHandler *inputVideo[2];
+  QPointer<frameHandler> inputVideo[2];
 
   // Recursively scan the LCU
   bool hierarchicalPosition( int x, int y, int blockSize, int &firstX, int &firstY, int &partIndex, const QImage diffImg );

--- a/source/viewStateHandler.h
+++ b/source/viewStateHandler.h
@@ -20,6 +20,7 @@
 #define VIEWSTATEHANDLER_H
 
 #include <QPoint>
+#include <QPointer>
 #include <QObject>
 #include <QKeyEvent>
 #include <QDomElement>
@@ -52,20 +53,20 @@ public:
   void savePlaylist(QDomElement plist);
   void loadPlaylist(QDomElement viewStateNode);
 
-private slots:
-  void itemAboutToBeDeleted(playlistItem *plItem);
-
 private:
 
   void saveViewState(int slot, bool saveOnSeparateView);
   void loadViewState(int slot, bool loadOnSeparateView);
 
+  int playbackStateFrameIdxData[8];
+
   // For the playbackController save the current frame index. This also indicates if a slot is valid or not.
   // If the frame index is -1, the slot is not valid.
-  int playbackStateFrameIdx[8];
+  int playbackStateFrameIdx(int index) const;
+  int & playbackStateFrameIdx(int index);
 
   // For the playlistTreeWidget, we save a list of the currently selected items
-  playlistItem *selectionStates[8][2];
+  QPointer<playlistItem> selectionStates[8][2];
 
   // Class to save the current view state of the splitViewWidget
   class splitViewWidgetState
@@ -80,9 +81,9 @@ private:
   splitViewWidgetState viewStates[8];
 
   // Save pointers to the controls
-  PlaybackController *playback;
-  splitViewWidget *splitView[2];
-  PlaylistTreeWidget *playlist;
+  QPointer<PlaybackController> playback;
+  QPointer<splitViewWidget> splitView[2];
+  QPointer<PlaylistTreeWidget> playlist;
 };
 
 #endif // VIEWSTATEHANDLER_H


### PR DESCRIPTION
1. Use `QPointer` to track `playlistItem` lifetime in `viewStateHandler`. This removes the need for the `itemAboutToBeDeleted` signal and the slot.

2. Hold a few other members either by value or by owning smart pointers.

3. Hold other weak `QObject` pointers using `QPointer`. A `QPointer` tracks the underlying object's lifetime and automatically resets itself to nullptr when the object is destroyed. This prevents dereferencing dangling pointers.

Please test the functionality related to Ctrl-1...8 view state saving. I'm not sure how it's supposed to work and don't want to miss anything important there.