### PR TITLE
Cleanup Part 1

### DIFF
--- a/source/fileInfoWidget.cpp
+++ b/source/fileInfoWidget.cpp
@@ -35,10 +35,6 @@ FileInfoWidget::FileInfoWidget(QWidget *parent) :
   setFileInfo();
 }
 
-FileInfoWidget::~FileInfoWidget()
-{
-}
-
 void FileInfoWidget::updateFileInfo(bool redraw)
 {
   Q_UNUSED(redraw);

--- a/source/fileInfoWidget.h
+++ b/source/fileInfoWidget.h
@@ -48,7 +48,6 @@ class FileInfoWidget : public QWidget
 
 public:
   FileInfoWidget(QWidget *parent = 0);
-  ~FileInfoWidget();
 
 public slots:
   // Accept the signal from the playlisttreewidget that signals if a new (or two) item was selected.

--- a/source/fileInfoWidget.h
+++ b/source/fileInfoWidget.h
@@ -36,7 +36,7 @@ class playlistItem;
 class infoItem
 {
 public:
-  infoItem(QString infoName, QString infoText, QString infoToolTip="") : name(infoName), text(infoText), toolTip(infoToolTip) {};
+  infoItem(QString infoName, QString infoText, QString infoToolTip=QString()) : name(infoName), text(infoText), toolTip(infoToolTip) {};
   QString name;
   QString text;
   QString toolTip;

--- a/source/fileSource.cpp
+++ b/source/fileSource.cpp
@@ -124,7 +124,7 @@ void fileSource::formatFromFilename(int &width, int &height, int &frameRate, int
   height = -1;
   frameRate = -1;
   bitDepth = -1;
-  subFormat = "";
+  subFormat.clear();
   
   QString name = fileInfo.fileName();
 
@@ -308,7 +308,7 @@ QString fileSource::getAbsPathFromAbsAndRel(QString currentPath, QString absolut
     return QDir::cleanPath(combinePath);
   }
 
-  return "";
+  return QString();
 }
 
 void fileSource::updateFileWatchSetting()

--- a/source/fileSourceHEVCAnnexBFile.h
+++ b/source/fileSourceHEVCAnnexBFile.h
@@ -137,7 +137,7 @@ protected:
       nuh_layer_id = layer;
       nuh_temporal_id_plus1 = temporalID;
     }
-    virtual ~nal_unit() {};
+    virtual ~nal_unit() {} // This class is meant to be derived from.
 
     bool isIRAP() { return (nal_type == BLA_W_LP       || nal_type == BLA_W_RADL ||
                             nal_type == BLA_N_LP       || nal_type == IDR_W_RADL ||
@@ -181,8 +181,7 @@ protected:
   {
   public:
     parameter_set_nal(quint64 filePos, nal_unit_type type, int layer, int temporalID) :
-      nal_unit(filePos, type, layer, temporalID) {};
-    virtual ~parameter_set_nal() {};
+      nal_unit(filePos, type, layer, temporalID) {}
 
     QByteArray getParameterSetData() { return getNALHeader() + parameter_set_data; }
     bool parse_profile_tier_level(sub_byte_reader &reader, bool profilePresentFlag, int maxNumSubLayersMinus1);
@@ -201,8 +200,7 @@ protected:
     {
       vps_timing_info_present_flag = false;
       frameRate = 0.0;
-    };
-    virtual ~vps() {};
+    }
 
     bool parse_vps(QByteArray parameterSetData);
 
@@ -223,8 +221,7 @@ protected:
     {
       vui_timing_info_present_flag = false;
       frameRate = 0.0;
-    };
-    virtual ~sps() {};
+    }
     bool parse_sps(QByteArray parameterSetData);
 
     int sps_max_sub_layers_minus1;
@@ -262,8 +259,7 @@ protected:
   {
   public:
     pps(quint64 filePos, nal_unit_type type, int layer, int temporalID) :
-      parameter_set_nal(filePos, type, layer, temporalID) {};
-    virtual ~pps() {};
+      parameter_set_nal(filePos, type, layer, temporalID) {}
     bool parse_pps(QByteArray parameterSetData);
     
     int pps_pic_parameter_set_id;
@@ -283,8 +279,7 @@ protected:
     {
       PicOrderCntVal = -1;
       PicOrderCntMsb = -1;
-    };
-    virtual ~slice() {};
+    }
     bool parse_slice(QByteArray sliceHeaderData,
                      QMap<int, sps*> p_active_SPS_list,
                      QMap<int, pps*> p_active_PPS_list );

--- a/source/frameHandler.cpp
+++ b/source/frameHandler.cpp
@@ -54,10 +54,6 @@ frameHandler::frameHandler()
 {
 }
 
-frameHandler::~frameHandler()
-{
-}
-
 QLayout *frameHandler::createFrameHandlerControls(bool isSizeFixed)
 {
   // Absolutely always only call this function once!

--- a/source/frameHandler.h
+++ b/source/frameHandler.h
@@ -37,7 +37,6 @@ public:
   /*
   */
   frameHandler();
-  virtual ~frameHandler();
 
   // Get the size of the (current) frame
   QSize getFrameSize() { return frameSize; }

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -202,10 +202,6 @@ void MainWindow::updateRecentFileActions()
     recentFileActs[j]->setVisible(false);
 }
 
-MainWindow::~MainWindow()
-{
-}
-
 void MainWindow::closeEvent(QCloseEvent *event)
 {
   if (!p_playlistWidget->getIsSaved())

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -51,7 +51,6 @@ class MainWindow : public QMainWindow
 
 public:
   explicit MainWindow(QWidget *parent = 0);
-  ~MainWindow();
 
   void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
   

--- a/source/playbackController.h
+++ b/source/playbackController.h
@@ -45,7 +45,6 @@ public:
   /*
   */
   PlaybackController();
-  virtual ~PlaybackController() {};
 
   void setSplitViews(splitViewWidget *primary, splitViewWidget *separate) { splitViewPrimary = primary; splitViewSeparate = separate; }
   void setPlaylist (PlaylistTreeWidget *playlistWidget) { playlist = playlistWidget; }

--- a/source/playlistItem.h
+++ b/source/playlistItem.h
@@ -86,7 +86,7 @@ public:
 
   // Return the info title and info list to be shown in the fileInfo groupBox.
   // The default implementations will return empty strings/list.
-  virtual QString getInfoTitel() { return ""; }
+  virtual QString getInfoTitel() { return QString(); }
   virtual QList<infoItem> getInfoList() { return QList<infoItem>(); }
 
   /* Get the title of the properties panel. The child class has to overload this.

--- a/source/playlistItemDifference.h
+++ b/source/playlistItemDifference.h
@@ -27,7 +27,6 @@ class playlistItemDifference :
 {
 public:
   playlistItemDifference();
-  ~playlistItemDifference() {};
 
   // The difference item accepts drops of items that provide video
   virtual bool acceptDrops(playlistItem *draggingItem) Q_DECL_OVERRIDE;

--- a/source/playlistItemHEVCFile.cpp
+++ b/source/playlistItemHEVCFile.cpp
@@ -119,10 +119,6 @@ playlistItemHEVCFile::playlistItemHEVCFile(QString hevcFilePath)
   cachingEnabled = false;
 }
 
-playlistItemHEVCFile::~playlistItemHEVCFile()
-{
-}
-
 void playlistItemHEVCFile::savePlaylist(QDomElement &root, QDir playlistDir)
 {
   // Determine the relative path to the hevc file. We save both in the playlist.

--- a/source/playlistItemHEVCFile.h
+++ b/source/playlistItemHEVCFile.h
@@ -42,7 +42,6 @@ public:
    * addPropertiesWidget to add the custom properties panel.
   */
   playlistItemHEVCFile(QString fileName);
-  virtual ~playlistItemHEVCFile();
 
   // Save the HEVC file element to the given xml structure.
   virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;

--- a/source/playlistItemImageFile.h
+++ b/source/playlistItemImageFile.h
@@ -32,7 +32,6 @@ class playlistItemImageFile :
 
 public:
   playlistItemImageFile(QString imagePath);
-  ~playlistItemImageFile() {};
 
   // ------ Overload from playlistItem
 

--- a/source/playlistItemImageFileSequence.h
+++ b/source/playlistItemImageFileSequence.h
@@ -38,7 +38,7 @@ class playlistItemImageFileSequence :
   Q_OBJECT
 
 public:
-  playlistItemImageFileSequence(QString rawFilePath = "");
+  playlistItemImageFileSequence(QString rawFilePath = QString());
 
   // Overload from playlistItem. Save the raw file item to playlist.
   virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;

--- a/source/playlistItemImageFileSequence.h
+++ b/source/playlistItemImageFileSequence.h
@@ -39,7 +39,6 @@ class playlistItemImageFileSequence :
 
 public:
   playlistItemImageFileSequence(QString rawFilePath = "");
-  ~playlistItemImageFileSequence() {};
 
   // Overload from playlistItem. Save the raw file item to playlist.
   virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;

--- a/source/playlistItemOverlay.cpp
+++ b/source/playlistItemOverlay.cpp
@@ -124,7 +124,7 @@ void playlistItemOverlay::drawItem(QPainter *painter, int frameIdx, double zoomF
   updateLayout();
 
   // Translate to the center of this overlay item
-  painter->translate( boundingRect.centerRoundTL() * zoomFactor * -1 );
+  painter->translate( centerRoundTL(boundingRect) * zoomFactor * -1 );
 
   // Draw all child items at their positions
   for (int i = 0; i < childCount(); i++)
@@ -132,7 +132,7 @@ void playlistItemOverlay::drawItem(QPainter *painter, int frameIdx, double zoomF
     playlistItem *childItem = dynamic_cast<playlistItem*>(child(i));
     if (childItem)
     {
-      QPoint center = childItems[i].centerRoundTL();
+      QPoint center = centerRoundTL(childItems[i]);
       painter->translate( center * zoomFactor );
       childItem->drawItem(painter, frameIdx, zoomFactor, playback);
       painter->translate( center * zoomFactor * -1 );
@@ -140,7 +140,7 @@ void playlistItemOverlay::drawItem(QPainter *painter, int frameIdx, double zoomF
   }
   
   // Reverse translation to the center of this overlay item
-  painter->translate( boundingRect.centerRoundTL() * zoomFactor );
+  painter->translate( centerRoundTL(boundingRect) * zoomFactor );
 }
 
 QSize playlistItemOverlay::getSize()
@@ -162,7 +162,7 @@ void playlistItemOverlay::updateLayout(bool checkNumber)
   if (childCount() == 0)
   {
     childItems.clear();
-    boundingRect = Rect();
+    boundingRect = QRect();
     return;
   }
 
@@ -175,7 +175,7 @@ void playlistItemOverlay::updateLayout(bool checkNumber)
     childItems.clear();
     for (int i = 0; i < childCount(); i++)
     {
-      childItems.append( Rect() );
+      childItems.append( QRect() );
     }
   }
 
@@ -183,7 +183,7 @@ void playlistItemOverlay::updateLayout(bool checkNumber)
   boundingRect.setSize(firstItem->getSize());
   boundingRect.moveCenter( QPoint(0,0) );
 
-  Rect firstItemRect;
+  QRect firstItemRect;
   firstItemRect.setSize(firstItem->getSize());
   firstItemRect.moveCenter( QPoint(0,0) );
   childItems[0] = firstItemRect;
@@ -196,7 +196,7 @@ void playlistItemOverlay::updateLayout(bool checkNumber)
     if (childItem)
     {
       QSize childSize = childItem->getSize();
-      Rect targetRect;
+      QRect targetRect;
       targetRect.setSize( childSize );
       targetRect.moveCenter( QPoint(0,0) );
 

--- a/source/playlistItemOverlay.h
+++ b/source/playlistItemOverlay.h
@@ -90,8 +90,8 @@ private:
   QPoint manualAlignment;
 
   // The layout of the child items
-  Rect boundingRect;
-  QList<Rect> childItems;
+  QRect boundingRect;
+  QList<QRect> childItems;
 
   // Update the child item layout and this item's bounding rect. If checkNumber is true the values
   // will be updated only if the number of items in childItems and childCount() disagree (if new items

--- a/source/playlistItemOverlay.h
+++ b/source/playlistItemOverlay.h
@@ -29,7 +29,6 @@ class playlistItemOverlay :
 
 public:
   playlistItemOverlay();
-  ~playlistItemOverlay() {};
 
   // The overlay item accepts drops of items that provide video
   virtual bool acceptDrops(playlistItem *draggingItem) Q_DECL_OVERRIDE { Q_UNUSED(draggingItem); return true; }

--- a/source/playlistItemRawFile.cpp
+++ b/source/playlistItemRawFile.cpp
@@ -57,7 +57,7 @@ playlistItemRawFile::playlistItemRawFile(QString rawFilePath, QSize frameSize, Q
   else
     Q_ASSERT_X(false, "playlistItemRawFile()", "No video handler for the raw file format found.");
 
-  if (frameSize == QSize(-1,-1) && sourcePixelFormat == "")
+  if (frameSize == QSize(-1,-1) && sourcePixelFormat.isEmpty())
   {
     // Try to get the frame format from the file name. The fileSource can guess this.
     setFormatFromFileName();

--- a/source/playlistItemRawFile.cpp
+++ b/source/playlistItemRawFile.cpp
@@ -92,10 +92,6 @@ playlistItemRawFile::playlistItemRawFile(QString rawFilePath, QSize frameSize, Q
   cachingEnabled = true;
 }
 
-playlistItemRawFile::~playlistItemRawFile()
-{
-}
-
 qint64 playlistItemRawFile::getNumberFrames()
 {
   if (!dataSource.isOk() || !video->isFormatValid())

--- a/source/playlistItemRawFile.h
+++ b/source/playlistItemRawFile.h
@@ -42,7 +42,6 @@ class playlistItemRawFile :
 
 public:
   playlistItemRawFile(QString rawFilePath, QSize frameSize=QSize(-1,-1), QString sourcePixelFormat="");
-  ~playlistItemRawFile();
 
   // Overload from playlistItem. Save the raw file item to playlist.
   virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;

--- a/source/playlistItemRawFile.h
+++ b/source/playlistItemRawFile.h
@@ -41,7 +41,7 @@ class playlistItemRawFile :
   Q_OBJECT
 
 public:
-  playlistItemRawFile(QString rawFilePath, QSize frameSize=QSize(-1,-1), QString sourcePixelFormat="");
+  playlistItemRawFile(QString rawFilePath, QSize frameSize=QSize(-1,-1), QString sourcePixelFormat=QString());
 
   // Overload from playlistItem. Save the raw file item to playlist.
   virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;

--- a/source/playlistItemStatisticsFile.cpp
+++ b/source/playlistItemStatisticsFile.cpp
@@ -37,7 +37,6 @@ playlistItemStatisticsFile::playlistItemStatisticsFile(QString itemNameOrFileNam
   fileSortedByPOC = false;
   blockOutsideOfFrame_idx = -1;
   backgroundParserProgress = 0.0;
-  parsingError = "";
   currentDrawnFrameIdx = -1;
   maxPOC = 0;
 
@@ -519,7 +518,7 @@ void playlistItemStatisticsFile::loadStatisticToCache(int frameIdx, int typeID)
 QStringList playlistItemStatisticsFile::parseCSVLine(QString line, char delimiter)
 {
   // first, trim newline and whitespaces from both ends of line
-  line = line.trimmed().replace(" ", "");
+  line = line.trimmed().remove(" ");
 
   // now split string with delimiter
   return line.split(delimiter);
@@ -623,7 +622,7 @@ void playlistItemStatisticsFile::reloadItemSource()
   fileSortedByPOC = false;
   blockOutsideOfFrame_idx = -1;
   backgroundParserProgress = 0.0;
-  parsingError = "";
+  parsingError.clear();
   currentDrawnFrameIdx = -1;
   maxPOC = 0;
 

--- a/source/playlistItemText.cpp
+++ b/source/playlistItemText.cpp
@@ -60,10 +60,6 @@ playlistItemText::playlistItemText(playlistItemText *cloneFromTxt)
   duration = cloneFromTxt->duration;
 }
 
-playlistItemText::~playlistItemText()
-{
-}
-
 void playlistItemText::createPropertiesWidget()
 {
   // Absolutely always only call this once

--- a/source/playlistItemText.h
+++ b/source/playlistItemText.h
@@ -36,7 +36,6 @@ class playlistItemText :
 public:
   playlistItemText(QString initialText = PLAYLISTITEMTEXT_DEFAULT_TEXT);
   playlistItemText(playlistItemText *cloneFromTxt);
-  ~playlistItemText();
 
   // ------ Overload from playlistItem
 

--- a/source/playlistitemIndexed.h
+++ b/source/playlistitemIndexed.h
@@ -34,7 +34,6 @@ class playlistItemIndexed :
 public:
 
   playlistItemIndexed(QString itemNameOrFileName);
-  virtual ~playlistItemIndexed() {}
 
   // An indexed playlist item is indexed by frame (duh)
   virtual bool       isIndexedByFrame()   Q_DECL_OVERRIDE Q_DECL_FINAL { return true;          }

--- a/source/playlistitemStatic.h
+++ b/source/playlistitemStatic.h
@@ -36,7 +36,6 @@ class playlistItemStatic :
 public:
 
   playlistItemStatic(QString itemNameOrFileName);
-  virtual ~playlistItemStatic() {}
 
   // This is a static item and it is not indexed by frame.
   virtual bool isIndexedByFrame() Q_DECL_OVERRIDE Q_DECL_FINAL { return false; }

--- a/source/propertiesWidget.cpp
+++ b/source/propertiesWidget.cpp
@@ -36,10 +36,6 @@ PropertiesWidget::PropertiesWidget(QWidget *parent) :
   stack.setCurrentWidget(&emptyWidget);
 }
 
-PropertiesWidget::~PropertiesWidget()
-{
-}
-
 void PropertiesWidget::currentSelectedItemsChanged(playlistItem *item1, playlistItem *item2)
 {
   // The properties are always just shown for the first item

--- a/source/propertiesWidget.h
+++ b/source/propertiesWidget.h
@@ -33,7 +33,6 @@ class PropertiesWidget : public QWidget
 
 public:
   PropertiesWidget(QWidget *parent = 0);
-  ~PropertiesWidget();
 
 public slots:
   // Accept the signal from the playlisttreewidget that signals if a new (or two) item was selected.

--- a/source/settingswindow.cpp
+++ b/source/settingswindow.cpp
@@ -75,10 +75,6 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
   loadSettings();
 }
 
-SettingsWindow::~SettingsWindow()
-{
-}
-
 unsigned int SettingsWindow::getCacheSizeInMB()
 {
   unsigned int useMem = 0;

--- a/source/settingswindow.h
+++ b/source/settingswindow.h
@@ -29,7 +29,6 @@ class SettingsWindow : public QWidget
 
 public:
   explicit SettingsWindow(QWidget *parent = 0);
-  ~SettingsWindow();
 
   // Get settings
   unsigned int getCacheSizeInMB();

--- a/source/statisticHandler.cpp
+++ b/source/statisticHandler.cpp
@@ -350,7 +350,7 @@ QLayout *statisticHandler::createStatisticsHandlerControls(bool recreateControls
     itemOpacitySliders[0].append(opacitySlider);
 
     // Append the grid checkbox
-    QCheckBox *gridCheckbox = new QCheckBox( "", ui.scrollAreaWidgetContents );
+    QCheckBox *gridCheckbox = new QCheckBox;
     gridCheckbox->setChecked( statsTypeList[row].renderGrid );
     ui.gridLayout->addWidget(gridCheckbox, row+2, 2);
     connect(gridCheckbox, SIGNAL(stateChanged(int)), this, SLOT(onStatisticsControlChanged()));
@@ -359,7 +359,7 @@ QLayout *statisticHandler::createStatisticsHandlerControls(bool recreateControls
     if (statsTypeList[row].visualizationType==vectorType)
     {
       // Append the arrow checkbox
-      QCheckBox *arrowCheckbox = new QCheckBox( "", ui.scrollAreaWidgetContents );
+      QCheckBox *arrowCheckbox = new QCheckBox;
       arrowCheckbox->setChecked( statsTypeList[row].showArrow );
       ui.gridLayout->addWidget(arrowCheckbox, row+2, 3);
       connect(arrowCheckbox, SIGNAL(stateChanged(int)), this, SLOT(onStatisticsControlChanged()));
@@ -415,7 +415,7 @@ QWidget *statisticHandler::getSecondaryStatisticsHandlerControls(bool recreateCo
       itemOpacitySliders[1].append(opacitySlider);
 
       // Append the grid checkbox
-      QCheckBox *gridCheckbox = new QCheckBox( "", ui2.scrollAreaWidgetContents );
+      QCheckBox *gridCheckbox = new QCheckBox;
       gridCheckbox->setChecked( statsTypeList[row].renderGrid );
       ui2.gridLayout->addWidget(gridCheckbox, row+2, 2);
       connect(gridCheckbox, SIGNAL(stateChanged(int)), this, SLOT(onSecondaryStatisticsControlChanged()));
@@ -424,7 +424,7 @@ QWidget *statisticHandler::getSecondaryStatisticsHandlerControls(bool recreateCo
       if (statsTypeList[row].visualizationType==vectorType)
       {
         // Append the arrow checkbox
-        QCheckBox *arrowCheckbox = new QCheckBox( "", ui2.scrollAreaWidgetContents );
+        QCheckBox *arrowCheckbox = new QCheckBox;
         arrowCheckbox->setChecked( statsTypeList[row].showArrow );
         ui2.gridLayout->addWidget(arrowCheckbox, row+2, 3);
         connect(arrowCheckbox, SIGNAL(stateChanged(int)), this, SLOT(onSecondaryStatisticsControlChanged()));

--- a/source/statisticHandler.cpp
+++ b/source/statisticHandler.cpp
@@ -670,19 +670,11 @@ void statisticHandler::updateStatisticsHandlerControls()
       Q_ASSERT(itemNameCheckBoxes[0].length() == itemGridCheckBoxes[0].length());
       Q_ASSERT(itemNameCheckBoxes[0].length() == itemArrowCheckboxes[0].length());
 
-      // Remove primary controls from the layout
-      ui.gridLayout->removeWidget(itemNameCheckBoxes[0][i]);
-      ui.gridLayout->removeWidget(itemOpacitySliders[0][i]);
-      ui.gridLayout->removeWidget(itemGridCheckBoxes[0][i]);
-      if (itemArrowCheckboxes[0][i])
-        ui.gridLayout->removeWidget(itemArrowCheckboxes[0][i]);
-
-      // Delete the controls
+      // Delete primary controls
       delete itemNameCheckBoxes[0][i];
       delete itemOpacitySliders[0][i];
       delete itemGridCheckBoxes[0][i];
-      if (itemArrowCheckboxes[0][i])
-        delete itemArrowCheckboxes[0][i];
+      delete itemArrowCheckboxes[0][i];
 
       if (ui2.created())
       {
@@ -690,19 +682,11 @@ void statisticHandler::updateStatisticsHandlerControls()
         Q_ASSERT(itemNameCheckBoxes[1].length() == itemGridCheckBoxes[1].length());
         Q_ASSERT(itemNameCheckBoxes[1].length() == itemArrowCheckboxes[1].length());
 
-        // Remove secondary controls from the secondary layot
-        ui2.gridLayout->removeWidget(itemNameCheckBoxes[1][i]);
-        ui2.gridLayout->removeWidget(itemOpacitySliders[1][i]);
-        ui2.gridLayout->removeWidget(itemGridCheckBoxes[1][i]);
-        if (itemArrowCheckboxes[1][i])
-          ui2.gridLayout->removeWidget(itemArrowCheckboxes[0][i]);
-
-        // Delete the controls
+        // Delete secondary controls
         delete itemNameCheckBoxes[1][i];
         delete itemOpacitySliders[1][i];
         delete itemGridCheckBoxes[1][i];
-        if (itemArrowCheckboxes[1][i])
-          delete itemArrowCheckboxes[1][i];
+        delete itemArrowCheckboxes[1][i];
       }
     }
 

--- a/source/statisticHandler.cpp
+++ b/source/statisticHandler.cpp
@@ -55,10 +55,6 @@ statisticHandler::statisticHandler()
   spacerItems[1] = NULL;
 }
 
-statisticHandler::~statisticHandler()
-{
-}
-
 void statisticHandler::paintStatistics(QPainter *painter, int frameIdx, double zoomFactor)
 {
   // Save the state of the painter. This is restored when the function is done.

--- a/source/statisticHandler.h
+++ b/source/statisticHandler.h
@@ -42,7 +42,6 @@ class statisticHandler : public QObject
 
 public:
   statisticHandler();
-  virtual ~statisticHandler();
 
   // Get the statistics values under the curso pos (if they are visible)
   ValuePairList getValuesAt(QPoint pos);

--- a/source/statisticsExtensions.h
+++ b/source/statisticsExtensions.h
@@ -57,7 +57,7 @@ public:
     unsigned char maxColorA = row[11].toInt();
     maxColor = QColor( maxColorR, maxColorG, maxColorB, maxColorA );
   }
-  virtual ~ColorRange() {}
+  virtual ~ColorRange() {} // This class is meant to be derived from.
 
   virtual QColor getColor(float value)
   {

--- a/source/typedef.h
+++ b/source/typedef.h
@@ -218,7 +218,7 @@ public:
         }
         return n.toElement().text();
       }
-    return "";
+    return QString();
   }
   // Append a new child to this element with the given type, and name (as text node).
   // All QString pairs in ValuePairList are appended as attributes.

--- a/source/typedef.h
+++ b/source/typedef.h
@@ -169,30 +169,11 @@ public:
   }
 };
 
-class Rect : public QRect
+Q_DECL_CONSTEXPR inline QPoint centerRoundTL(const QRect & r) Q_DECL_NOTHROW
 {
-public:
-  Rect()
-  {
-    // Init an empty rect
-    setLeft(0);
-    setRight(-1);
-    setTop(0);
-    setBottom(-1);
-  }
-  Rect(QRect rect) 
-  {
-    // Just copy the rect
-    setLeft(rect.left());
-    setRight(rect.right());
-    setTop(rect.top());
-    setBottom(rect.bottom());
-  }
-  QPoint centerRoundTL()
-  { 
-    return QPoint( (left()+right()-1)/2, (top()+bottom()-1)/2 );
-  }
-};
+  // cast avoids overflow on addition
+  return QPoint(int((qint64(r.left())+r.right()-1)/2), int((qint64(r.top())+r.bottom()-1)/2));
+}
 
 // Identical to a QDomElement, but we add some convenience functions (findChildValue and appendProperiteChild)
 // for putting values into the playlist and reading them from the playlist.

--- a/source/videoCache.cpp
+++ b/source/videoCache.cpp
@@ -67,11 +67,6 @@ videoCache::videoCache(PlaylistTreeWidget *playlistTreeWidget, PlaybackControlle
   workerState = workerIdle;
 }
 
-videoCache::~videoCache()
-{
-  //clearCache();
-}
-
 void videoCache::playlistChanged()
 {
   // The playlist changed. We have to rethink what to cache next.

--- a/source/videoCache.h
+++ b/source/videoCache.h
@@ -59,7 +59,6 @@ public:
   // The video cache interfaces with the playlist to see which items are going to be played next and the
   // playback controller to get the position in the video and the current state (playback/stop).
   videoCache(PlaylistTreeWidget *playlistTreeWidget, PlaybackController *playbackController, QObject *parent = 0);
-  virtual ~videoCache();
 
 private slots:
 

--- a/source/videoHandler.h
+++ b/source/videoHandler.h
@@ -44,10 +44,7 @@ class videoHandler : public frameHandler
 
 public:
 
-  /*
-  */
   videoHandler();
-  virtual ~videoHandler() {};
     
   virtual void drawFrame(QPainter *painter, int frameIdx, double zoomFactor) Q_DECL_OVERRIDE;
 

--- a/source/videoHandlerDifference.cpp
+++ b/source/videoHandlerDifference.cpp
@@ -25,10 +25,6 @@ videoHandlerDifference::videoHandlerDifference() : videoHandler()
   codingOrder = CodingOrder_HEVC;
 }
 
-videoHandlerDifference::~videoHandlerDifference()
-{
-}
-
 void videoHandlerDifference::loadFrame(int frameIndex)
 {
   //qDebug() << "videoHandlerDifference::loadFrame " << frameIndex;

--- a/source/videoHandlerDifference.h
+++ b/source/videoHandlerDifference.h
@@ -29,7 +29,6 @@ class videoHandlerDifference : public videoHandler
 public:
 
   explicit videoHandlerDifference();
-  virtual ~videoHandlerDifference();
 
   virtual void loadFrame(int frameIndex) Q_DECL_OVERRIDE;
   virtual void loadFrameForCaching(int frameIndex, QPixmap &frameToCache) Q_DECL_OVERRIDE { Q_UNUSED(frameIndex); Q_UNUSED(frameToCache); };

--- a/source/videoHandlerRGB.cpp
+++ b/source/videoHandlerRGB.cpp
@@ -96,7 +96,7 @@ void videoHandlerRGB::rgbPixelFormat::setFromName(QString name)
 
 QString videoHandlerRGB::rgbPixelFormat::getRGBFormatString() const
 {
-  QString name = "";
+  QString name;
   for (int i = 0; i < 3; i++)
   {
     if (posR == i)

--- a/source/videoHandlerYUV.cpp
+++ b/source/videoHandlerYUV.cpp
@@ -138,10 +138,6 @@ void videoHandlerYUV::loadValues(QSize newFramesize, QString sourcePixelFormat)
   setSrcPixelFormat( yuvFormatList.getFromName(sourcePixelFormat) );
 }
 
-videoHandlerYUV::~videoHandlerYUV()
-{
-}
-
 /// --- Convert from the current YUV input format to YUV 444
 
 inline quint32 SwapInt32(quint32 arg) {

--- a/source/videoHandlerYUV.cpp
+++ b/source/videoHandlerYUV.cpp
@@ -357,9 +357,8 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
     unsigned char *dstU = dstY + componentLength;
     unsigned char *dstV = dstU + componentLength;
 
-    int y;
 #pragma omp parallel for default(none) shared(dstY,dstU,dstV,srcY)
-    for (y = 0; y < componentHeight; y++) {
+    for (int y = 0; y < componentHeight; y++) {
       for (int x = 0; x < componentWidth; x++) {
         dstY[x + y*componentWidth] = srcY[((x + y*componentWidth) << 1) + 1];
         dstU[x + y*componentWidth] = srcY[((((x >> 1) << 1) + y*componentWidth) << 1)];
@@ -373,10 +372,9 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
     quint16 *dstU = dstY + componentLength;
     quint16 *dstV = dstU + componentLength;
 
-    int i;
 #define BIT_INCREASE 6
 #pragma omp parallel for default(none) shared(dstY,dstU,dstV,srcY)
-    for (i = 0; i < ((componentLength + 5) / 6); i++) {
+    for (int i = 0; i < ((componentLength + 5) / 6); i++) {
       const int srcPos = i * 4;
       const int dstPos = i * 6;
       quint32 srcVal;
@@ -404,10 +402,9 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
     quint16 *dstU = dstY + componentLength;
     quint16 *dstV = dstU + componentLength;
 
-    int i;
 #define BIT_INCREASE 6
 #pragma omp parallel for default(none) shared(dstY,dstU,dstV,srcY)
-    for (i = 0; i < ((componentLength + 5) / 6); i++) {
+    for (int i = 0; i < ((componentLength + 5) / 6); i++) {
       const int srcPos = i * 4;
       const int dstPos = i * 6;
       quint32 srcVal;
@@ -450,17 +447,15 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
       //NSLog(@"%i", omp_get_num_threads());
       // first line
       dstUV[c][0] = srcUV[c][0];
-      int i;
 #pragma omp parallel for default(none) shared(dstUV,srcUV) firstprivate(c)
-      for (i = 0; i < chromaWidth - 1; i++) {
+      for (int i = 0; i < chromaWidth - 1; i++) {
         dstUV[c][i * 2 + 1] = (((int)(srcUV[c][i]) + (int)(srcUV[c][i + 1]) + 1) >> 1);
         dstUV[c][i * 2 + 2] = srcUV[c][i + 1];
       }
       dstUV[c][componentWidth - 1] = dstUV[c][componentWidth - 2];
 
-      int j;
 #pragma omp parallel for default(none) shared(dstUV,srcUV) firstprivate(c)
-      for (j = 0; j < chromaHeight - 1; j++) {
+      for (int j = 0; j < chromaHeight - 1; j++) {
         const int dstTop = (j * 2 + 1)*componentWidth;
         const int dstBot = (j * 2 + 2)*componentWidth;
         const int srcTop = j*chromaWidth;
@@ -483,7 +478,7 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
 
       dstUV[c][dstLastLine] = srcUV[c][srcLastLine];
 #pragma omp parallel for default(none) shared(dstUV,srcUV) firstprivate(c)
-      for (i = 0; i < chromaWidth - 1; i++) {
+      for (int i = 0; i < chromaWidth - 1; i++) {
         dstUV[c][dstLastLine + i * 2 + 1] = (((int)(srcUV[c][srcLastLine + i]) + (int)(srcUV[c][srcLastLine + i + 1]) + 1) >> 1);
         dstUV[c][dstLastLine + i * 2 + 2] = srcUV[c][srcLastLine + i + 1];
       }
@@ -511,17 +506,15 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
       // first line
       dstUV[c][0] = srcUV[c][0];
 
-      int i;
 #pragma omp parallel for default(none) shared(dstUV,srcUV) firstprivate(c)
-      for (i = 0; i < chromaWidth - 1; i++) {
+      for (int i = 0; i < chromaWidth - 1; i++) {
         dstUV[c][2 * i + 1] = ((3 * (int)(srcUV[c][i]) + (int)(srcUV[c][i + 1]) + 2) >> 2);
         dstUV[c][2 * i + 2] = (((int)(srcUV[c][i]) + 3 * (int)(srcUV[c][i + 1]) + 2) >> 2);
       }
       dstUV[c][componentWidth - 1] = srcUV[c][chromaWidth - 1];
 
-      int j;
 #pragma omp parallel for default(none) shared(dstUV,srcUV) firstprivate(c)
-      for (j = 0; j < chromaHeight - 1; j++) {
+      for (int j = 0; j < chromaHeight - 1; j++) {
         const int dstTop = (j * 2 + 1)*componentWidth;
         const int dstBot = (j * 2 + 2)*componentWidth;
         const int srcTop = j*chromaWidth;
@@ -544,7 +537,7 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
 
       dstUV[c][dstLastLine] = srcUV[c][srcLastLine];
 #pragma omp parallel for default(none) shared(dstUV,srcUV) firstprivate(c)
-      for (i = 0; i < chromaWidth - 1; i++) {
+      for (int i = 0; i < chromaWidth - 1; i++) {
         dstUV[c][dstLastLine + i * 2 + 1] = ((3 * (int)(srcUV[c][srcLastLine + i]) + (int)(srcUV[c][srcLastLine + i + 1]) + 2) >> 2);
         dstUV[c][dstLastLine + i * 2 + 2] = (((int)(srcUV[c][srcLastLine + i]) + 3 * (int)(srcUV[c][srcLastLine + i + 1]) + 2) >> 2);
       }
@@ -632,9 +625,8 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
     memcpy(dstY, srcY, componentLength);
 
     if (2 == horiSubsampling && 2 == vertSubsampling) {
-      int y;
 #pragma omp parallel for default(none) shared(dstV,dstU,srcV,srcU)
-      for (y = 0; y < chromaHeight; y++) {
+      for (int y = 0; y < chromaHeight; y++) {
         for (int x = 0; x < chromaWidth; x++) {
           dstU[2 * x + 2 * y*componentWidth] = dstU[2 * x + 1 + 2 * y*componentWidth] = srcU[x + y*chromaWidth];
           dstV[2 * x + 2 * y*componentWidth] = dstV[2 * x + 1 + 2 * y*componentWidth] = srcV[x + y*chromaWidth];
@@ -644,9 +636,8 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
       }
     }
     else if ((1 << horiShift) == horiSubsampling && (1 << vertShift) == vertSubsampling) {
-      int y;
 #pragma omp parallel for default(none) shared(dstV,dstU,srcV,srcU)
-      for (y = 0; y < componentHeight; y++) {
+      for (int y = 0; y < componentHeight; y++) {
         for (int x = 0; x < componentWidth; x++) {
           //dstY[x + y*componentWidth] = srcY[x + y*componentWidth];
           dstU[x + y*componentWidth] = srcU[(x >> horiShift) + (y >> vertShift)*chromaWidth];
@@ -655,9 +646,8 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
       }
     }
     else {
-      int y;
 #pragma omp parallel for default(none) shared(dstV,dstU,srcV,srcU)
-      for (y = 0; y < componentHeight; y++) {
+      for (int y = 0; y < componentHeight; y++) {
         for (int x = 0; x < componentWidth; x++) {
           //dstY[x + y*componentWidth] = srcY[x + y*componentWidth];
           dstU[x + y*componentWidth] = srcU[x / horiSubsampling + y / vertSubsampling*chromaWidth];
@@ -675,9 +665,8 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
       unsigned short *dstU = dstY + componentLength;
       unsigned short *dstV = dstU + componentLength;
 
-      int y;
 #pragma omp parallel for default(none) shared(dstY,dstV,dstU,srcY,srcV,srcU)
-      for (y = 0; y < componentHeight; y++) {
+      for (int y = 0; y < componentHeight; y++) {
         for (int x = 0; x < componentWidth; x++) {
           //dstY[x + y*componentWidth] = MIN(1023, CFSwapInt16LittleToHost(srcY[x + y*componentWidth])) << 6; // clip value for data which exceeds the 2^10-1 range
           //     dstY[x + y*componentWidth] = SwapInt16LittleToHost(srcY[x + y*componentWidth])<<6;
@@ -697,9 +686,8 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
       // BADC -> ABCD
       const char *src = (char*)sourceBuffer.data();
       char *dst = (char*)targetBuffer.data();
-      int i;
 #pragma omp parallel for default(none) shared(src,dst)
-      for (i = 0; i < srcPixelFormat.bytesPerFrame( QSize(componentWidth, componentHeight) ); i+=2)
+      for (int i = 0; i < srcPixelFormat.bytesPerFrame( QSize(componentWidth, componentHeight) ); i+=2)
       {
         dst[i] = src[i + 1];
         dst[i + 1] = src[i];
@@ -713,9 +701,8 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
       unsigned short *dstY = (unsigned short*)targetBuffer.data();
       unsigned short *dstU = dstY + componentLength;
       unsigned short *dstV = dstU + componentLength;
-      int y;
 #pragma omp parallel for default(none) shared(dstY,dstV,dstU,srcY,srcV,srcU)
-      for (y = 0; y < componentHeight; y++)
+      for (int y = 0; y < componentHeight; y++)
       {
         for (int x = 0; x < componentWidth; x++)
         {
@@ -734,9 +721,8 @@ void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targe
       unsigned short *dstY = (unsigned short*)targetBuffer.data();
       unsigned short *dstU = dstY + componentLength;
       unsigned short *dstV = dstU + componentLength;
-      int y;
 #pragma omp parallel for default(none) shared(dstY,dstV,dstU,srcY,srcV,srcU)
-      for (y = 0; y < componentHeight; y++)
+      for (int y = 0; y < componentHeight; y++)
       {
         for (int x = 0; x < componentWidth; x++)
         {
@@ -812,9 +798,8 @@ void videoHandlerYUV::applyYUVTransformation(QByteArray &sourceBuffer)
     else if (colorMode == YUVMathDefaultColors || colorMode == YUVMathLumaOnly)
     {
       // The Y component is displayed and a Y transformation has to be applied
-      int i;
 #pragma omp parallel for default(none) shared(src,dst)
-      for (i = 0; i < lumaLength; i++)
+      for (int i = 0; i < lumaLength; i++)
       {
         int newVal = lumaInvert ? (maxVal-(int)(src[i])):((int)(src[i]));
         newVal = (newVal - lumaOffset) * lumaScale + lumaOffset;
@@ -841,10 +826,9 @@ void videoHandlerYUV::applyYUVTransformation(QByteArray &sourceBuffer)
                )
       {
         // This chroma component needs to be transformed
-        int i;
         int cMultiplier = (c==0) ? chromaUScale : chromaVScale;
 #pragma omp parallel for default(none) shared(src,dst,cMultiplier)
-        for (i = 0; i < singleChromaLength; i++)
+        for (int i = 0; i < singleChromaLength; i++)
         {
           int newVal = chromaInvert ? (maxVal-(int)(src[i])):((int)(src[i]));
           newVal = (newVal - chromaOffset) * cMultiplier + chromaOffset;
@@ -872,9 +856,8 @@ void videoHandlerYUV::applyYUVTransformation(QByteArray &sourceBuffer)
     else if (colorMode == YUVMathDefaultColors || colorMode == YUVMathLumaOnly)
     {
       // The Y component is displayed and a Y transformation has to be applied
-      int i;
 #pragma omp parallel for default(none) shared(src,dst)
-      for (i = 0; i < lumaLength; i++) {
+      for (int i = 0; i < lumaLength; i++) {
         int newVal = lumaInvert ? (maxVal-(int)(src[i])):((int)(src[i]));
         newVal = (newVal - lumaOffset) * lumaScale + lumaOffset;
         newVal = MAX( 0, MIN( maxVal, newVal ) );
@@ -899,10 +882,9 @@ void videoHandlerYUV::applyYUVTransformation(QByteArray &sourceBuffer)
          )
       {
         // This chroma component needs to be transformed
-        int i;
         int cMultiplier = (c==0) ? chromaUScale : chromaVScale;
 #pragma omp parallel for default(none) shared(src,dst,cMultiplier)
-        for (i = 0; i < singleChromaLength; i++)
+        for (int i = 0; i < singleChromaLength; i++)
         {
           int newVal = chromaInvert ? (maxVal-(int)(src[i])):((int)(src[i]));
           newVal = (newVal - chromaOffset) * cMultiplier + chromaOffset;
@@ -1017,9 +999,8 @@ void videoHandlerYUV::convertYUV4442RGB(QByteArray &sourceBuffer, QByteArray &ta
     const unsigned char * restrict srcV = srcU + componentLength;
     unsigned char * restrict dstMem = dst;
 
-    int i;
-#pragma omp parallel for default(none) private(i) shared(srcY,srcU,srcV,dstMem,yMult,rvMult,guMult,gvMult,buMult,clip_buf,componentLength)// num_threads(2)
-    for (i = 0; i < componentLength; ++i)
+#pragma omp parallel for default(none) shared(srcY,srcU,srcV,dstMem,yMult,rvMult,guMult,gvMult,buMult,clip_buf,componentLength)// num_threads(2)
+    for (int i = 0; i < componentLength; ++i)
     {
       const int Y_tmp = ((int)srcY[i] - yOffset) * yMult;
       const int U_tmp = (int)srcU[i] - cZero;
@@ -1067,9 +1048,8 @@ void videoHandlerYUV::convertYUV4442RGB(QByteArray &sourceBuffer, QByteArray &ta
     const unsigned short *srcV = srcU + componentLength;
     unsigned char *dstMem = dst;
 
-    int i;
-#pragma omp parallel for default(none) private(i) shared(srcY,srcU,srcV,dstMem,yMult,rvMult,guMult,gvMult,buMult,componentLength) // num_threads(2)
-    for (i = 0; i < componentLength; ++i)
+#pragma omp parallel for default(none) shared(srcY,srcU,srcV,dstMem,yMult,rvMult,guMult,gvMult,buMult,componentLength) // num_threads(2)
+    for (int i = 0; i < componentLength; ++i)
     {
       qint64 Y_tmp = ((qint64)srcY[i] - yOffset)*yMult;
       qint64 U_tmp = (qint64)srcU[i]- cZero ;
@@ -2243,13 +2223,12 @@ void videoHandlerYUV::convertYUV420ToRGB(QByteArray &sourceBuffer, QByteArray &t
   const unsigned char * restrict srcV = srcU + componentLengthUV;
   unsigned char * restrict dstMem = dst;
 
-  int yh;
 #if __MINGW32__ || __GNUC__
-#pragma omp parallel for default(none) private(yh) shared(srcY,srcU,srcV,dstMem,yMult,rvMult,guMult,gvMult,buMult,clip_buf,frameWidth,frameHeight)// num_threads(2)
+#pragma omp parallel for default(none) shared(srcY,srcU,srcV,dstMem,yMult,rvMult,guMult,gvMult,buMult,clip_buf,frameWidth,frameHeight)// num_threads(2)
 #else
-#pragma omp parallel for default(none) private(yh) shared(srcY,srcU,srcV,dstMem,yMult,rvMult,guMult,gvMult,buMult,clip_buf,frameWidth,frameHeight)// num_threads(2)
+#pragma omp parallel for default(none) shared(srcY,srcU,srcV,dstMem,yMult,rvMult,guMult,gvMult,buMult,clip_buf,frameWidth,frameHeight)// num_threads(2)
 #endif
-  for (yh=0; yh < frameHeight / 2; yh++)
+  for (int yh=0; yh < frameHeight / 2; yh++)
   {
     // Process two lines at once, always 4 RGB values at a time (they have the same U/V components)
 

--- a/source/videoHandlerYUV.h
+++ b/source/videoHandlerYUV.h
@@ -41,7 +41,6 @@ class videoHandlerYUV : public videoHandler
 
 public:
   videoHandlerYUV();
-  virtual ~videoHandlerYUV();
 
   // The format is valid if the frame width/height/pixel format are set
   virtual bool isFormatValid() Q_DECL_OVERRIDE { return (frameHandler::isFormatValid() && srcPixelFormat != "Unknown Pixel Format"); }


### PR DESCRIPTION
1. Delete the widgets without removing them from the layout first.

    The layout tracks managed widget lifetimes.

2. Remove redundant empty-body destructors. A few of them that aren't redundant were marked so.

3. Make loop variables local to the parallelized loops. This prevents the unused variable warning under MSVC 2015.

4. Use default-constructed QString instead of "". Check for empty strings using QString::isEmpty().

5. Get rid of the Rect type. Fix centerRoundTL not to overflow.