### PR TITLE
Const-correctness & cleanups

### DIFF
--- a/YUView.pro
+++ b/YUView.pro
@@ -48,6 +48,7 @@ HEADERS += source/fileInfoWidget.h \
     source/fileSource.h \
     source/fileSourceHEVCAnnexBFile.h \
     source/frameHandler.h \
+    source/labelElided.h \
     source/mainwindow.h \
     source/playbackController.h \
     source/playlistItem.h \

--- a/YUView.pro
+++ b/YUView.pro
@@ -10,7 +10,9 @@ TARGET = YUView
 TEMPLATE = app
 CONFIG += c++11
 
-SOURCES += source/fileInfoWidget.cpp \
+SOURCES += \
+    source/de265Wrapper.cpp \
+    source/fileInfoWidget.cpp \
     source/fileSource.cpp \
     source/fileSourceHEVCAnnexBFile.cpp \
     source/frameHandler.cpp \
@@ -44,7 +46,9 @@ SOURCES += source/fileInfoWidget.cpp \
 	source/viewStateHandler.cpp \
     source/yuviewapp.cpp
 
-HEADERS += source/fileInfoWidget.h \
+HEADERS += \
+    source/de265Wrapper.h \
+    source/fileInfoWidget.h \
     source/fileSource.h \
     source/fileSourceHEVCAnnexBFile.h \
     source/frameHandler.h \

--- a/YUView.pro
+++ b/YUView.pro
@@ -1,10 +1,4 @@
-#-------------------------------------------------
-#
-# Project created by QtCreator 2010-10-28T14:12:12
-#
-#-------------------------------------------------
-
-QT       += core gui opengl xml concurrent network
+QT += gui opengl xml concurrent network
 
 TARGET = YUView
 TEMPLATE = app
@@ -37,13 +31,13 @@ SOURCES += \
     source/splitViewWidget.cpp \
     source/statisticHandler.cpp \
     source/typedef.cpp \
-	source/updateHandler.cpp \
+    source/updateHandler.cpp \
     source/videoCache.cpp \
     source/videoHandler.cpp \
     source/videoHandlerDifference.cpp \
     source/videoHandlerRGB.cpp \
     source/videoHandlerYUV.cpp \
-	source/viewStateHandler.cpp \
+    source/viewStateHandler.cpp \
     source/yuviewapp.cpp
 
 HEADERS += \
@@ -75,16 +69,17 @@ HEADERS += \
     source/statisticHandler.h \
     source/statisticsExtensions.h \
     source/typedef.h \
-	source/updateHandler.h \
+    source/updateHandler.h \
     source/videoCache.h \
     source/videoHandler.h \
     source/videoHandlerDifference.h \
     source/videoHandlerRGB.h \
     source/videoHandlerYUV.h \
-	source/viewStateHandler.h \
+    source/viewStateHandler.h \
     source/yuviewapp.h
 
-FORMS    += ui/frameHandler.ui \
+FORMS += \
+    ui/frameHandler.ui \
     ui/frameobjectdialog.ui \
     ui/mainwindow.ui \
     ui/playbackController.ui \
@@ -95,7 +90,7 @@ FORMS    += ui/frameHandler.ui \
     ui/settingswindow.ui \
     ui/splitViewWidgetControls.ui \
     ui/statisticHandler.ui \
-	ui/updateDialog.ui \
+    ui/updateDialog.ui \
     ui/videoHandlerDifference.ui \
     ui/videoHandlerRGB.ui \
     ui/videoHandlerRGB_CustomFormatDialog.ui \
@@ -105,8 +100,9 @@ RESOURCES += \
     images/images.qrc \
     docs/resources.qrc
 
-INCLUDEPATH += "libde265" \
-                source
+INCLUDEPATH += \
+    libde265 \
+    source
 
 target.path = /usr/bin/
 

--- a/source/de265wrapper.cpp
+++ b/source/de265wrapper.cpp
@@ -1,0 +1,129 @@
+/*  YUView - YUV player with advanced analytics toolset
+*   Copyright (C) 2016  Institut für Nachrichtentechnik
+*                       RWTH Aachen University, GERMANY
+*
+*   YUView is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 2 of the License, or
+*   (at your option) any later version.
+*
+*   YUView is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with YUView.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "de265wrapper.h"
+#include <cstring>
+#include <QDir>
+#include <QCoreApplication>
+
+de265Functions::de265Functions() { memset(this, 0, sizeof(*this)); }
+
+de265Wrapper::de265Wrapper() :
+  error(false),
+  internalsSupported(false)
+{
+}
+
+void de265Wrapper::setError(const QString & reason)
+{
+  error = true;
+  errorString = reason;
+}
+
+QFunctionPointer de265Wrapper::resolve(const char *symbol)
+{
+  QFunctionPointer ptr = library.resolve(symbol);
+  if (!ptr) setError(QStringLiteral("Error loading the libde265 library: Can't find function %1.").arg(symbol));
+  return ptr;
+}
+
+template <typename T> T de265Wrapper::resolve(T & fun, const char * symbol)
+{
+  return fun = reinterpret_cast<T>(resolve(symbol));
+}
+
+template <typename T> T de265Wrapper::resolveInternals(T & fun, const char * symbol)
+{
+  return fun = reinterpret_cast<T>(library.resolve(symbol));
+}
+
+void de265Wrapper::loadDecoderLibrary()
+{
+  // Try to load the libde265 library from the current working directory
+  // Unfortunately relative paths like this do not work: (at least on windows)
+  // library.setFileName(".\\libde265");
+
+#ifdef Q_OS_MAC
+  // If the file name is not set explicitly, QLibrary will try to open
+  // the libde265.so file first. Since this has been compiled for linux
+  // it will fail and not even try to open the libde265.dylib
+  QStringList libNames = QStringList() << "libde265-internals.dylib" << "libde265.dylib";
+#else
+  // On windows and linux ommitting the extension works
+  QStringList libNames = QStringList() << "libde265-internals" << "libde265";
+#endif
+  QStringList libPaths = QStringList()
+      << QDir::currentPath() + "/%1"
+      << QDir::currentPath() + "/libde265/%1"
+      << QCoreApplication::applicationDirPath() + "/%1"
+      << QCoreApplication::applicationDirPath() + "/libde265/%1"
+      << "%1"; // Try the system directories.
+
+  bool libLoaded = false;
+  Q_FOREACH(QString libName, libNames)
+  {
+    Q_FOREACH(QString libPath, libPaths)
+    {
+      library.setFileName(libPath.arg(libName));
+      libLoaded = library.load();
+      if (libLoaded)
+        break;
+    }
+    if (libLoaded)
+      break;
+  }
+
+  if (!libLoaded)
+    return setError(library.errorString());
+
+  // Get/check function pointers
+  if (!resolve(de265_new_decoder, "de265_new_decoder")) return;
+  if (!resolve(de265_set_parameter_bool, "de265_set_parameter_bool")) return;
+  if (!resolve(de265_set_parameter_int, "de265_set_parameter_int")) return;
+  if (!resolve(de265_disable_logging, "de265_disable_logging")) return;
+  if (!resolve(de265_set_verbosity, "de265_set_verbosity")) return;
+  if (!resolve(de265_start_worker_threads, "de265_start_worker_threads")) return;
+  if (!resolve(de265_set_limit_TID, "de265_set_limit_TID")) return;
+  if (!resolve(de265_get_error_text, "de265_get_error_text")) return;
+  if (!resolve(de265_get_chroma_format, "de265_get_chroma_format")) return;
+  if (!resolve(de265_get_image_width, "de265_get_image_width")) return;
+  if (!resolve(de265_get_image_height, "de265_get_image_height")) return;
+  if (!resolve(de265_get_image_plane, "de265_get_image_plane")) return;
+  if (!resolve(de265_get_bits_per_pixel,"de265_get_bits_per_pixel")) return;
+  if (!resolve(de265_decode, "de265_decode")) return;
+  if (!resolve(de265_push_data, "de265_push_data")) return;
+  if (!resolve(de265_flush_data, "de265_flush_data")) return;
+  if (!resolve(de265_get_next_picture, "de265_get_next_picture")) return;
+  if (!resolve(de265_free_decoder, "de265_free_decoder")) return;
+
+  // Get pointers to the internals/statistics functions (if present)
+  // If not, disable the statistics extraction. Normal decoding of the video will still work.
+
+  if (!resolveInternals(de265_internals_get_CTB_Info_Layout, "de265_internals_get_CTB_Info_Layout")) return;
+  if (!resolveInternals(de265_internals_get_CTB_sliceIdx, "de265_internals_get_CTB_sliceIdx")) return;
+  if (!resolveInternals(de265_internals_get_CB_Info_Layout, "de265_internals_get_CB_Info_Layout")) return;
+  if (!resolveInternals(de265_internals_get_CB_info, "de265_internals_get_CB_info")) return;
+  if (!resolveInternals(de265_internals_get_PB_Info_layout, "de265_internals_get_PB_Info_layout")) return;
+  if (!resolveInternals(de265_internals_get_PB_info, "de265_internals_get_PB_info")) return;
+  if (!resolveInternals(de265_internals_get_IntraDir_Info_layout, "de265_internals_get_IntraDir_Info_layout")) return;
+  if (!resolveInternals(de265_internals_get_intraDir_info, "de265_internals_get_intraDir_info")) return;
+  if (!resolveInternals(de265_internals_get_TUInfo_Info_layout, "de265_internals_get_TUInfo_Info_layout")) return;
+  if (!resolveInternals(de265_internals_get_TUInfo_info, "de265_internals_get_TUInfo_info")) return;
+
+  internalsSupported = true;
+}

--- a/source/de265wrapper.h
+++ b/source/de265wrapper.h
@@ -1,0 +1,87 @@
+/*  YUView - YUV player with advanced analytics toolset
+*   Copyright (C) 2016  Institut für Nachrichtentechnik
+*                       RWTH Aachen University, GERMANY
+*
+*   YUView is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 2 of the License, or
+*   (at your option) any later version.
+*
+*   YUView is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with YUView.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DE265WRAPPER_H
+#define DE265WRAPPER_H
+
+#include "de265.h"
+#include <QLibrary>
+
+struct de265Functions {
+  de265Functions();
+
+  de265_decoder_context *(*de265_new_decoder)          ();
+  void                   (*de265_set_parameter_bool)   (de265_decoder_context*, de265_param, int);
+  void                   (*de265_set_parameter_int)    (de265_decoder_context*, de265_param, int);
+  void                   (*de265_disable_logging)      ();
+  void                   (*de265_set_verbosity)        (int);
+  de265_error            (*de265_start_worker_threads) (de265_decoder_context*, int);
+  void                   (*de265_set_limit_TID)        (de265_decoder_context*, int);
+  const char*            (*de265_get_error_text)       (de265_error);
+  de265_chroma           (*de265_get_chroma_format)    (const de265_image*);
+  int                    (*de265_get_image_width)      (const de265_image*, int);
+  int                    (*de265_get_image_height)     (const de265_image*, int);
+  const uint8_t*         (*de265_get_image_plane)      (const de265_image*, int, int*);
+  int                    (*de265_get_bits_per_pixel)   (const de265_image*, int);
+  de265_error            (*de265_decode)               (de265_decoder_context*, int*);
+  de265_error            (*de265_push_data)            (de265_decoder_context*, const void*, int, de265_PTS, void*);
+  de265_error            (*de265_flush_data)           (de265_decoder_context*);
+  const de265_image*     (*de265_get_next_picture)     (de265_decoder_context*);
+  de265_error            (*de265_free_decoder)         (de265_decoder_context*);
+
+  // libde265 decoder library function pointers for internals
+  void (*de265_internals_get_CTB_Info_Layout)		   (const de265_image*, int*, int*, int*);
+  void (*de265_internals_get_CTB_sliceIdx)			   (const de265_image*, uint16_t*);
+  void (*de265_internals_get_CB_Info_Layout)		   (const de265_image*, int*, int*, int*);
+  void (*de265_internals_get_CB_info)				       (const de265_image*, uint16_t*);
+  void (*de265_internals_get_PB_Info_layout)		   (const de265_image*, int*, int*, int*);
+  void (*de265_internals_get_PB_info)				       (const de265_image*, int16_t*, int16_t*, int16_t*, int16_t*, int16_t*, int16_t*);
+  void (*de265_internals_get_IntraDir_Info_layout) (const de265_image*, int*, int*, int*);
+  void (*de265_internals_get_intraDir_info)			   (const de265_image*, uint8_t*, uint8_t*);
+  void (*de265_internals_get_TUInfo_Info_layout)	 (const de265_image*, int*, int*, int*);
+  void (*de265_internals_get_TUInfo_info)			     (const de265_image*, uint8_t*);
+
+  static const int abc = 5;
+};
+
+// This class wraps the de265 library in a demand-load fashion.
+// To easily access the functions, one can use protected inheritance:
+// class de265User : ..., protected de265Wrapper
+// This API is similar to the QOpenGLFunctions API family.
+class de265Wrapper : public de265Functions {
+public:
+  de265Wrapper();
+
+  void loadDecoderLibrary();
+  bool wrapperError() const { return error; }
+  QString wrapperErrorString() const { return errorString; }
+  bool wrapperInternalsSupported() const { return internalsSupported; } ///< does the loaded library support the extraction of internals/statistics?
+
+private:
+  void setError(const QString & reason);
+  QFunctionPointer resolve(const char * symbol);
+  template <typename T> T resolve(T & ptr, const char * symbol);
+  template <typename T> T resolveInternals(T & ptr, const char * symbol);
+
+  QLibrary library;
+  bool error;
+  bool internalsSupported;
+  QString errorString;
+};
+
+#endif // DE265WRAPPER_H

--- a/source/fileInfoWidget.cpp
+++ b/source/fileInfoWidget.cpp
@@ -43,7 +43,7 @@ void FileInfoWidget::updateFileInfo(bool redraw)
   // Only show the info of the first selection
   // TODO: why not show both?
   if (currentItem1)
-    setFileInfo( currentItem1->getInfoTitel(), currentItem1->getInfoList() );
+    setFileInfo( currentItem1->getInfoTitle(), currentItem1->getInfoList() );
   else
     setFileInfo();
 }
@@ -62,7 +62,7 @@ void FileInfoWidget::setFileInfo()
 {
   // Clear the title of the dock widget (our parent)
   if (parentWidget())
-    parentWidget()->setWindowTitle(FILEINFOWIDGET_DEFAULT_WINDOW_TITEL);
+    parentWidget()->setWindowTitle(FILEINFOWIDGET_DEFAULT_WINDOW_TITLE);
 
   // Clear the grid layout
   foreach(QLabel *l, labelList)

--- a/source/fileInfoWidget.cpp
+++ b/source/fileInfoWidget.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "fileInfoWidget.h"
+#include "labelElided.h"
 #include "playlistItem.h"
 #include <assert.h>
 
@@ -117,7 +118,7 @@ void FileInfoWidget::setFileInfo(const QString &fileInfoTitle, const QList<infoI
         newTextLabel->setText(info.name);
       if (!fileInfoList[i].toolTip.isEmpty())
         newTextLabel->setToolTip(fileInfoList[i].toolTip);
-      QLabelElided *newValueLabel = new QLabelElided(info.text);
+      labelElided *newValueLabel = new labelElided(info.text);
       newValueLabel->setWordWrap(true);
 
       // Add to grid

--- a/source/fileInfoWidget.cpp
+++ b/source/fileInfoWidget.cpp
@@ -70,7 +70,7 @@ void FileInfoWidget::setFileInfo()
   nrLabelPairs = 0;
 }
 
-void FileInfoWidget::setFileInfo(QString fileInfoTitle, QList<infoItem> fileInfoList)
+void FileInfoWidget::setFileInfo(const QString &fileInfoTitle, const QList<infoItem> &fileInfoList)
 {
   // Set the title of the dock widget (our parent)
   if (parentWidget())

--- a/source/fileInfoWidget.h
+++ b/source/fileInfoWidget.h
@@ -36,7 +36,8 @@ class playlistItem;
 class infoItem
 {
 public:
-  infoItem(QString infoName, QString infoText, QString infoToolTip=QString()) : name(infoName), text(infoText), toolTip(infoToolTip) {};
+  infoItem(const QString &infoName, const QString &infoText, const QString &infoToolTip = QString()) :
+    name(infoName), text(infoText), toolTip(infoToolTip) {}
   QString name;
   QString text;
   QString toolTip;
@@ -67,9 +68,9 @@ private:
   public:
     // The constructor will set the label to a very small size. If you want the label
     // to be bigger by default, you have to set the minimum size manually.
-    QLabelElided() : QLabel() { resize( QSize(20,1) ); };
-    QLabelElided(QString newText) : QLabel() { resize( QSize(20,1) ); setText( newText ); }
-    void setText(QString newText) { text = newText; setElidedText(); }
+    QLabelElided() { resize( 20, 1 ); }
+    QLabelElided(const QString &newText) { resize( 20,1 ); setText( newText ); }
+    void setText(const QString &newText) { text = newText; setElidedText(); }
   protected:
     void setElidedText()
     {
@@ -88,7 +89,7 @@ private:
    * the given list of infoItems (Qpai<QString,QString>) will be added as labels into 
    * the QGridLayout infoLayout.
   */
-  void setFileInfo(QString fileInfoTitle, QList<infoItem> fileInfoList);
+  void setFileInfo(const QString &fileInfoTitle, const QList<infoItem> &fileInfoList);
 
   // Clear the QGridLayout infoLayout. 
   void setFileInfo();

--- a/source/fileInfoWidget.h
+++ b/source/fileInfoWidget.h
@@ -29,7 +29,7 @@
 class playlistItem;
 
 // This is the text that will be shown in the dockWidgets title if no playlistitem is selected
-#define FILEINFOWIDGET_DEFAULT_WINDOW_TITEL "Info"
+#define FILEINFOWIDGET_DEFAULT_WINDOW_TITLE "Info"
 
 // An info item has a name, a text and an optional toolTip. These are used to show them in the fileInfoWidget.
 // For example: ["File Name", "file.yuv"] or ["Number Frames", "123"]

--- a/source/fileInfoWidget.h
+++ b/source/fileInfoWidget.h
@@ -59,32 +59,6 @@ public slots:
   void updateFileInfo(bool redraw=false);
 
 private:
-
-  // A custom minimum size QLabel that elides text if necessary (add ...  in the middle of the text).
-  // The lable initializes with a minimum width of 20pixels. However, it can get as big as the text
-  // is wide. The QLabelElided will also show the full text as tooltip if it was elided.
-  class QLabelElided : public QLabel
-  {
-  public:
-    // The constructor will set the label to a very small size. If you want the label
-    // to be bigger by default, you have to set the minimum size manually.
-    QLabelElided() { resize( 20, 1 ); }
-    QLabelElided(const QString &newText) { resize( 20,1 ); setText( newText ); }
-    void setText(const QString &newText) { text = newText; setElidedText(); }
-  protected:
-    void setElidedText()
-    {
-      // Set elided text and tooltip (if the text was elided)
-      QFontMetrics metrics( font() );
-      QString textElided = metrics.elidedText(text, Qt::ElideMiddle, size().width());
-      if (textElided != text)
-        setToolTip( text );
-      QLabel::setText( textElided );
-    }
-    void resizeEvent(QResizeEvent * event) { Q_UNUSED(event); setElidedText(); }
-    QString text;
-  };
-  
   /* Set the file info. The title of the dock widget will be set to fileInfoTitle and
    * the given list of infoItems (Qpai<QString,QString>) will be added as labels into 
    * the QGridLayout infoLayout.

--- a/source/fileSource.cpp
+++ b/source/fileSource.cpp
@@ -34,7 +34,7 @@ fileSource::fileSource()
   connect(&fileWatcher, SIGNAL(fileChanged(const QString)), this, SLOT(fileSystemWatcherFileChanged(const QString)));
 }
 
-bool fileSource::openFile(QString filePath)
+bool fileSource::openFile(const QString &filePath)
 {
   // Check if the file exists
   fileInfo.setFile(filePath);
@@ -294,7 +294,7 @@ void fileSource::formatFromFilename(int &width, int &height, int &frameRate, int
 // If you are loading a playlist and you have an absolut path and a relative path, this function will return
 // the absolute path (if a file with that absolute path exists) or convert the relative path to an absolute
 // one and return that (if that file exists). If neither exists the empty string is returned.
-QString fileSource::getAbsPathFromAbsAndRel(QString currentPath, QString absolutePath, QString relativePath)
+QString fileSource::getAbsPathFromAbsAndRel(const QString &currentPath, const QString &absolutePath, const QString &relativePath)
 {
   QFileInfo checkAbsoluteFile(absolutePath);
   if (checkAbsoluteFile.exists())

--- a/source/fileSource.cpp
+++ b/source/fileSource.cpp
@@ -92,7 +92,7 @@ qint64 fileSource::readBytes(QByteArray &targetBuffer, qint64 startPos, qint64 n
   return srcFile.read(targetBuffer.data(), nrBytes);
 }
 
-QList<infoItem> fileSource::getFileInfoList()
+QList<infoItem> fileSource::getFileInfoList() const
 {
   QList<infoItem> infoList;
 
@@ -117,7 +117,7 @@ QList<infoItem> fileSource::getFileInfoList()
   return infoList;
 }
 
-void fileSource::formatFromFilename(int &width, int &height, int &frameRate, int &bitDepth, QString &subFormat)
+void fileSource::formatFromFilename(int &width, int &height, int &frameRate, int &bitDepth, QString &subFormat) const
 {
   // preset return values first
   width = -1;

--- a/source/fileSource.h
+++ b/source/fileSource.h
@@ -41,7 +41,7 @@ public:
   fileSource();
 
   // Try to open the given file and install a watcher for the file.
-  virtual bool openFile(QString filePath);
+  virtual bool openFile(const QString &filePath);
 
   // Return information on this file (like path, date created file Size ...)
   virtual QList<infoItem> getFileInfoList();
@@ -75,7 +75,7 @@ public:
   QString getAbsoluteFilePath() { return fileInfo.absoluteFilePath(); }
 
   // Get the absolut path to the file (from absolute or relative path)
-  static QString getAbsPathFromAbsAndRel(QString currentPath, QString absolutePath, QString relativePath);
+  static QString getAbsPathFromAbsAndRel(const QString &currentPath, const QString &absolutePath, const QString &relativePath);
 
   // Was the file changed by some other application?
   bool isFileChanged() { bool b = fileChanged; fileChanged = false; return b; }
@@ -83,7 +83,7 @@ public:
   void updateFileWatchSetting();
 
 private slots:
-  void fileSystemWatcherFileChanged(const QString path) { Q_UNUSED(path); fileChanged = true; }
+  void fileSystemWatcherFileChanged(const QString &path) { Q_UNUSED(path); fileChanged = true; }
 
 protected:
   // Info on the source file. 

--- a/source/fileSource.h
+++ b/source/fileSource.h
@@ -44,26 +44,26 @@ public:
   virtual bool openFile(const QString &filePath);
 
   // Return information on this file (like path, date created file Size ...)
-  virtual QList<infoItem> getFileInfoList();
+  virtual QList<infoItem> getFileInfoList() const;
 
-  QString absoluteFilePath() { return srcFile.isOpen() ? fileInfo.absoluteFilePath() : QString(); }
+  QString absoluteFilePath() const { return srcFile.isOpen() ? fileInfo.absoluteFilePath() : QString(); }
 
   // Return true if the file could be opened and is ready for use.
-  bool isOk() { return srcFile.isOpen(); }
+  bool isOk() const { return srcFile.isOpen(); }
 
   QFile *getQFile() { return &srcFile; }
 
   // Pass on to srcFile
-  virtual bool atEnd() { return !srcFile.isOpen() ? true : srcFile.atEnd(); }
+  virtual bool atEnd() const { return !srcFile.isOpen() ? true : srcFile.atEnd(); }
   QByteArray readLine() { return !srcFile.isOpen() ? QByteArray() : srcFile.readLine(); }
   bool seek(qint64 pos) { return !srcFile.isOpen() ? false : srcFile.seek(pos); }
 
   // Guess the format (width, height, frameTate...) from the file name.
   // Certain patterns are recognized. E.g: "something_352x288_24.yuv"
-  void formatFromFilename(int &width, int &height, int &frameRate, int &bitDepth, QString &subFormat);
+  void formatFromFilename(int &width, int &height, int &frameRate, int &bitDepth, QString &subFormat) const;
 
   // Get the file size in bytes
-  qint64 getFileSize() { return !srcFile.isOpen() ? -1 : fileInfo.size(); }
+  qint64 getFileSize() const { return !srcFile.isOpen() ? -1 : fileInfo.size(); }
 
   // Read the given number of bytes starting at startPos into the QByteArray out
   // Resize the QByteArray if necessary. Return how many bytes were read.
@@ -72,7 +72,7 @@ public:
   void readBytes(byteArrayAligned &data, qint64 startPos, qint64 nrBytes);
 #endif
 
-  QString getAbsoluteFilePath() { return fileInfo.absoluteFilePath(); }
+  QString getAbsoluteFilePath() const { return fileInfo.absoluteFilePath(); }
 
   // Get the absolut path to the file (from absolute or relative path)
   static QString getAbsPathFromAbsAndRel(const QString &currentPath, const QString &absolutePath, const QString &relativePath);

--- a/source/fileSourceHEVCAnnexBFile.cpp
+++ b/source/fileSourceHEVCAnnexBFile.cpp
@@ -140,7 +140,7 @@ bool fileSourceHEVCAnnexBFile::sub_byte_reader::p_gotoNextByte()
 // Read an UEV code and ignore the value. Return false if -1 was returned by the reading function.
 #define IGNOREUEV() {int into = reader.readUE_V(); if (into==-1) return false;}
 
-bool fileSourceHEVCAnnexBFile::parameter_set_nal::parse_profile_tier_level(sub_byte_reader &reader, bool profilePresentFlag, int maxNumSubLayersMinus1)
+bool fileSourceHEVCAnnexBFile::parameter_set_nal::parse_profile_tier_level(sub_byte_reader &reader, bool profilePresentFlag, int maxNumSubLayersMinus1) const
 {
   /// Profile tier level
   if (profilePresentFlag) {
@@ -1103,7 +1103,7 @@ bool fileSourceHEVCAnnexBFile::addPOCToList(int poc)
 
 // Look through the random access points and find the closest one before (or equal)
 // the given frameIdx where we can start decoding
-int fileSourceHEVCAnnexBFile::getClosestSeekableFrameNumber(int frameIdx)
+int fileSourceHEVCAnnexBFile::getClosestSeekableFrameNumber(int frameIdx) const
 {
   // Get the POC for the frame number
   int iPOC = POC_List[frameIdx];
@@ -1196,7 +1196,7 @@ bool fileSourceHEVCAnnexBFile::seekToFilePos(quint64 pos)
   return updateBuffer();
 }
 
-QSize fileSourceHEVCAnnexBFile::getSequenceSize()
+QSize fileSourceHEVCAnnexBFile::getSequenceSize() const
 {
   // Find the first SPS and return the size
   foreach(nal_unit *nal, nalUnitList) {
@@ -1209,7 +1209,7 @@ QSize fileSourceHEVCAnnexBFile::getSequenceSize()
   return QSize(-1,-1);
 }
 
-double fileSourceHEVCAnnexBFile::getFramerate()
+double fileSourceHEVCAnnexBFile::getFramerate() const
 {
   // First try to get the framerate from the parameter sets themselves
   foreach(nal_unit *nal, nalUnitList) {

--- a/source/fileSourceHEVCAnnexBFile.cpp
+++ b/source/fileSourceHEVCAnnexBFile.cpp
@@ -267,7 +267,7 @@ bool fileSourceHEVCAnnexBFile::parameter_set_nal::parse_profile_tier_level(sub_b
   return true;
 } 
 
-bool fileSourceHEVCAnnexBFile::vps::parse_vps(QByteArray parameterSetData)
+bool fileSourceHEVCAnnexBFile::vps::parse_vps(const QByteArray &parameterSetData)
 {
   parameter_set_data = parameterSetData;
   
@@ -334,7 +334,7 @@ bool fileSourceHEVCAnnexBFile::vps::parse_vps(QByteArray parameterSetData)
   return true;
 }
 
-bool fileSourceHEVCAnnexBFile::sps::parse_sps(QByteArray parameterSetData)
+bool fileSourceHEVCAnnexBFile::sps::parse_sps(const QByteArray &parameterSetData)
 {
   parameter_set_data = parameterSetData;
   
@@ -660,7 +660,7 @@ bool fileSourceHEVCAnnexBFile::sps::parse_sps(QByteArray parameterSetData)
   return true;
 }
 
-bool fileSourceHEVCAnnexBFile::pps::parse_pps(QByteArray parameterSetData)
+bool fileSourceHEVCAnnexBFile::pps::parse_pps(const QByteArray &parameterSetData)
 {
   parameter_set_data = parameterSetData;
   
@@ -683,9 +683,9 @@ int fileSourceHEVCAnnexBFile::slice::prevTid0Pic_slice_pic_order_cnt_lsb = 0;
 int fileSourceHEVCAnnexBFile::slice::prevTid0Pic_PicOrderCntMsb = 0;
 
 // T-REC-H.265-201410 - 7.3.6.1 slice_segment_header()
-bool fileSourceHEVCAnnexBFile::slice::parse_slice(QByteArray sliceHeaderData,
-                        QMap<int, sps*> p_active_SPS_list,
-                        QMap<int, pps*> p_active_PPS_list )
+bool fileSourceHEVCAnnexBFile::slice::parse_slice(const QByteArray &sliceHeaderData,
+                        const QMap<int, sps *> &p_active_SPS_list,
+                        const QMap<int, pps *> &p_active_PPS_list )
 {
   sub_byte_reader reader(sliceHeaderData);
 
@@ -818,7 +818,7 @@ fileSourceHEVCAnnexBFile::fileSourceHEVCAnnexBFile()
 
 // Open the file and fill the read buffer. 
 // Then scan the file for NAL units and save the start of every NAL unit in the file.
-bool fileSourceHEVCAnnexBFile::openFile(QString fileName)
+bool fileSourceHEVCAnnexBFile::openFile(const QString &fileName)
 {
   if (srcFile.isOpen())
   {

--- a/source/fileSourceHEVCAnnexBFile.h
+++ b/source/fileSourceHEVCAnnexBFile.h
@@ -32,7 +32,7 @@ class fileSourceHEVCAnnexBFile :
 public:
   fileSourceHEVCAnnexBFile();
 
-  virtual bool openFile(QString filePath) Q_DECL_OVERRIDE;
+  virtual bool openFile(const QString &filePath) Q_DECL_OVERRIDE;
 
   // Is the file at the end?
   virtual bool atEnd() Q_DECL_OVERRIDE { return fileBufferSize == 0; }
@@ -77,7 +77,7 @@ public:
 
   // For the current file position get all active parameter sets that will be
   // needed to start decoding from the current file position on.
-  QByteArray getActiveParameterSetsBitstream();
+  QByteArray getActiveParameterSetsBitstream() { Q_ASSERT(false); } // TODO
 
   // Read the remaining bytes from the buffer and return them. Then load the next buffer.
   QByteArray getRemainingBuffer_Update() { QByteArray retArr = fileBuffer.mid(posInBuffer, fileBufferSize-posInBuffer); updateBuffer(); return retArr; }
@@ -100,7 +100,7 @@ protected:
   class sub_byte_reader
   {
   public:
-    sub_byte_reader(QByteArray inArr)
+    sub_byte_reader(const QByteArray &inArr)
     { 
       posInBuffer_bytes = 0;
       posInBuffer_bits = 0;
@@ -202,7 +202,7 @@ protected:
       frameRate = 0.0;
     }
 
-    bool parse_vps(QByteArray parameterSetData);
+    bool parse_vps(const QByteArray &parameterSetData);
 
     int vps_video_parameter_set_id; /// vps ID
     int vps_max_layers_minus1;		  /// How many layers are there. Is this a scalable bitstream?
@@ -222,7 +222,7 @@ protected:
       vui_timing_info_present_flag = false;
       frameRate = 0.0;
     }
-    bool parse_sps(QByteArray parameterSetData);
+    bool parse_sps(const QByteArray &parameterSetData);
 
     int sps_max_sub_layers_minus1;
     int sps_video_parameter_set_id;
@@ -260,7 +260,7 @@ protected:
   public:
     pps(quint64 filePos, nal_unit_type type, int layer, int temporalID) :
       parameter_set_nal(filePos, type, layer, temporalID) {}
-    bool parse_pps(QByteArray parameterSetData);
+    bool parse_pps(const QByteArray &parameterSetData);
     
     int pps_pic_parameter_set_id;
     int pps_seq_parameter_set_id;
@@ -280,9 +280,9 @@ protected:
       PicOrderCntVal = -1;
       PicOrderCntMsb = -1;
     }
-    bool parse_slice(QByteArray sliceHeaderData,
-                     QMap<int, sps*> p_active_SPS_list,
-                     QMap<int, pps*> p_active_PPS_list );
+    bool parse_slice(const QByteArray &sliceHeaderData,
+                     const QMap<int, sps*> &p_active_SPS_list,
+                     const QMap<int, pps*> &p_active_PPS_list );
 
     bool first_slice_segment_in_pic_flag;
     int slice_pic_parameter_set_id;

--- a/source/fileSourceHEVCAnnexBFile.h
+++ b/source/fileSourceHEVCAnnexBFile.h
@@ -35,7 +35,7 @@ public:
   virtual bool openFile(const QString &filePath) Q_DECL_OVERRIDE;
 
   // Is the file at the end?
-  virtual bool atEnd() Q_DECL_OVERRIDE { return fileBufferSize == 0; }
+  virtual bool atEnd() const Q_DECL_OVERRIDE { return fileBufferSize == 0; }
 
   // Seek to the first byte of the payload data of the next NAL unit
   // Return false if not successfull (eg. file ended)
@@ -51,24 +51,24 @@ public:
   bool gotoNextByte();
 
   // Get the current byte in the buffer
-  char getCurByte() { return fileBuffer.at(posInBuffer); }
+  char getCurByte() const { return fileBuffer.at(posInBuffer); }
 
   // Get if the current position is the one byte of a start code
-  bool curPosAtStartCode() { return numZeroBytes >= 2 && getCurByte() == (char)1; }
+  bool curPosAtStartCode() const { return numZeroBytes >= 2 && getCurByte() == (char)1; }
 
   // The current absolut position in the file (byte precise)
-  quint64 tell() { return bufferStartPosInFile + posInBuffer; }
+  quint64 tell() const { return bufferStartPosInFile + posInBuffer; }
 
   // How many POC's have been found in the file
-  int getNumberPOCs() { return POC_List.size(); }
+  int getNumberPOCs() const { return POC_List.size(); }
   // What is the width and height in pixels of the sequence?
-  QSize getSequenceSize();
+  QSize getSequenceSize() const;
   // What it the framerate?
-  double getFramerate();
+  double getFramerate() const;
 
   // Calculate the closest random access point (RAP) before the given frame number.
   // Return the frame number of that random access point.
-  int getClosestSeekableFrameNumber(int frameIdx);
+  int getClosestSeekableFrameNumber(int frameIdx) const;
 
   // Seek the file to the given frame number. The given frame number has to be a random 
   // access point. We can start decoding the file from here. Use getClosestSeekableFrameNumber to find a random access point.
@@ -77,7 +77,7 @@ public:
 
   // For the current file position get all active parameter sets that will be
   // needed to start decoding from the current file position on.
-  QByteArray getActiveParameterSetsBitstream() { Q_ASSERT(false); } // TODO
+  QByteArray getActiveParameterSetsBitstream() const { Q_ASSERT(false); } // TODO
 
   // Read the remaining bytes from the buffer and return them. Then load the next buffer.
   QByteArray getRemainingBuffer_Update() { QByteArray retArr = fileBuffer.mid(posInBuffer, fileBufferSize-posInBuffer); updateBuffer(); return retArr; }
@@ -97,7 +97,7 @@ protected:
 
   /* This class provides the ability to read a byte array bit wise. Reading of ue(v) symbols is also supported.
   */
-  class sub_byte_reader
+  class sub_byte_reader Q_DECL_FINAL
   {
   public:
     sub_byte_reader(const QByteArray &inArr)
@@ -139,31 +139,31 @@ protected:
     }
     virtual ~nal_unit() {} // This class is meant to be derived from.
 
-    bool isIRAP() { return (nal_type == BLA_W_LP       || nal_type == BLA_W_RADL ||
-                            nal_type == BLA_N_LP       || nal_type == IDR_W_RADL ||
-                            nal_type == IDR_N_LP       || nal_type == CRA_NUT    ||
-                            nal_type == RSV_IRAP_VCL22 || nal_type == RSV_IRAP_VCL23); }
+    bool isIRAP() const { return (nal_type == BLA_W_LP       || nal_type == BLA_W_RADL ||
+                                  nal_type == BLA_N_LP       || nal_type == IDR_W_RADL ||
+                                  nal_type == IDR_N_LP       || nal_type == CRA_NUT    ||
+                                  nal_type == RSV_IRAP_VCL22 || nal_type == RSV_IRAP_VCL23); }
 
-    bool isSLNR() { return (nal_type == TRAIL_N     || nal_type == TSA_N       ||
-                            nal_type == STSA_N      || nal_type == RADL_N      ||
-                            nal_type == RASL_N      || nal_type == RSV_VCL_N10 ||
-                            nal_type == RSV_VCL_N12 || nal_type == RSV_VCL_N14); }
+    bool isSLNR() const { return (nal_type == TRAIL_N     || nal_type == TSA_N       ||
+                                  nal_type == STSA_N      || nal_type == RADL_N      ||
+                                  nal_type == RASL_N      || nal_type == RSV_VCL_N10 ||
+                                  nal_type == RSV_VCL_N12 || nal_type == RSV_VCL_N14); }
 
-    bool isRADL() { return (nal_type == RADL_N || nal_type == RADL_R); }
-    bool isRASL() { return (nal_type == RASL_N || nal_type == RASL_R); }
+    bool isRADL() const { return (nal_type == RADL_N || nal_type == RADL_R); }
+    bool isRASL() const { return (nal_type == RASL_N || nal_type == RASL_R); }
 
-    bool isSlice() { return nal_type == IDR_W_RADL || nal_type == IDR_N_LP   || nal_type == CRA_NUT  ||
-                            nal_type == BLA_W_LP   || nal_type == BLA_W_RADL || nal_type == BLA_N_LP ||
-                            nal_type == TRAIL_N    || nal_type == TRAIL_R    || nal_type == TSA_N    ||
-                            nal_type == TSA_R      || nal_type == STSA_N     || nal_type == STSA_R   ||
-                            nal_type == RADL_N     || nal_type == RADL_R     || nal_type == RASL_N   ||
-                            nal_type == RASL_R; }
+    bool isSlice() const { return nal_type == IDR_W_RADL || nal_type == IDR_N_LP   || nal_type == CRA_NUT  ||
+          nal_type == BLA_W_LP   || nal_type == BLA_W_RADL || nal_type == BLA_N_LP ||
+          nal_type == TRAIL_N    || nal_type == TRAIL_R    || nal_type == TSA_N    ||
+          nal_type == TSA_R      || nal_type == STSA_N     || nal_type == STSA_R   ||
+          nal_type == RADL_N     || nal_type == RADL_R     || nal_type == RASL_N   ||
+          nal_type == RASL_R; }
 
     /// Pointer to the first byte of the start code of the NAL unit
     quint64 filePos;
 
     //( Get the NAL header including the start code
-    QByteArray getNALHeader() { 
+    QByteArray getNALHeader() const {
       int out = ((int)nal_type << 9) + (nuh_layer_id << 3) + nuh_temporal_id_plus1;
       char c[6] = { 0, 0, 0, 1,  (char)(out >> 8), (char)out };
       return QByteArray(c, 6);
@@ -183,8 +183,8 @@ protected:
     parameter_set_nal(quint64 filePos, nal_unit_type type, int layer, int temporalID) :
       nal_unit(filePos, type, layer, temporalID) {}
 
-    QByteArray getParameterSetData() { return getNALHeader() + parameter_set_data; }
-    bool parse_profile_tier_level(sub_byte_reader &reader, bool profilePresentFlag, int maxNumSubLayersMinus1);
+    QByteArray getParameterSetData() const { return getNALHeader() + parameter_set_data; }
+    bool parse_profile_tier_level(sub_byte_reader &reader, bool profilePresentFlag, int maxNumSubLayersMinus1) const;
   
     // The payload of the parameter set
     QByteArray parameter_set_data;
@@ -249,8 +249,8 @@ protected:
     int SubWidthC, SubHeightC;
   
     // Get the actual size of the image that will be returned. Internally the image might be bigger.
-    int get_conformance_cropping_width() {return (pic_width_in_luma_samples - (SubWidthC * conf_win_right_offset) - SubWidthC * conf_win_left_offset); }
-    int get_conformance_cropping_height() {return (pic_height_in_luma_samples - (SubHeightC * conf_win_bottom_offset) - SubHeightC * conf_win_top_offset); }
+    int get_conformance_cropping_width() const {return (pic_width_in_luma_samples - (SubWidthC * conf_win_right_offset) - SubWidthC * conf_win_left_offset); }
+    int get_conformance_cropping_height() const {return (pic_height_in_luma_samples - (SubHeightC * conf_win_bottom_offset) - SubHeightC * conf_win_top_offset); }
   };
 
   /* The picture parameter set. 

--- a/source/frameHandler.cpp
+++ b/source/frameHandler.cpp
@@ -28,7 +28,7 @@ public:
   // Constructor. Fill the names and sizes lists
   frameSizePresetList();
   // Get all presets in a displayable format ("Name (xxx,yyy)")
-  QStringList getFormattedNames();
+  QStringList getFormattedNames() const;
   // Return the index of a certain size (0 (Custom Size) if not found)
   int findSize(const QSize &size) { int idx = sizes.indexOf( size ); return (idx == -1) ? 0 : idx; }
   // Get the size with the given index.
@@ -47,7 +47,7 @@ frameHandler::frameSizePresetList::frameSizePresetList()
 /* Get all the names of the preset frame sizes in the form "Name (xxx,yyy)" in a QStringList.
  * This can be used to directly fill the combo box.
  */
-QStringList frameHandler::frameSizePresetList::getFormattedNames()
+QStringList frameHandler::frameSizePresetList::getFormattedNames() const
 {
   QStringList presetList;
   presetList.append( "Custom Size" );

--- a/source/frameHandler.cpp
+++ b/source/frameHandler.cpp
@@ -81,7 +81,7 @@ QLayout *frameHandler::createFrameHandlerControls(bool isSizeFixed)
   return ui.frameHandlerLayout;
 }
 
-void frameHandler::setFrameSize(QSize newSize, bool emitSignal)
+void frameHandler::setFrameSize(const QSize &newSize, bool emitSignal)
 {
   if (newSize == frameSize)
     // Nothing to update
@@ -113,7 +113,7 @@ void frameHandler::setFrameSize(QSize newSize, bool emitSignal)
   }
 }
 
-bool frameHandler::loadCurrentImageFromFile(QString filePath)
+bool frameHandler::loadCurrentImageFromFile(const QString &filePath)
 {
   // Load the image and return if loading was successfull.
   currentImage = QImage(filePath);
@@ -171,7 +171,7 @@ void frameHandler::drawFrame(QPainter *painter, int frameIdx, double zoomFactor)
   }
 }
 
-void frameHandler::drawPixelValues(QPainter *painter, int frameIdx, QRect videoRect, double zoomFactor, frameHandler *item2)
+void frameHandler::drawPixelValues(QPainter *painter, int frameIdx, const QRect &videoRect, double zoomFactor, frameHandler *item2)
 {
   // Draw the pixel values onto the pixels
   Q_UNUSED(frameIdx);
@@ -302,13 +302,13 @@ QPixmap frameHandler::calculateDifference(frameHandler *item2, int frame, QList<
   return QPixmap::fromImage(diffImg);
 }
 
-bool frameHandler::isPixelDark(QPoint pixelPos)
+bool frameHandler::isPixelDark(const QPoint &pixelPos)
 {
   QRgb pixVal = getPixelVal(pixelPos);
   return (qRed(pixVal) < 128 && qGreen(pixVal) < 128 && qBlue(pixVal) < 128);
 }
 
-ValuePairList frameHandler::getPixelValues(QPoint pixelPos, int frameIdx, frameHandler *item2)
+ValuePairList frameHandler::getPixelValues(const QPoint &pixelPos, int frameIdx, frameHandler *item2)
 {
   Q_UNUSED(frameIdx);
 

--- a/source/frameHandler.cpp
+++ b/source/frameHandler.cpp
@@ -28,7 +28,7 @@ public:
   // Constructor. Fill the names and sizes lists
   frameSizePresetList();
   // Get all presets in a displayable format ("Name (xxx,yyy)")
-  QStringList getFormatedNames();
+  QStringList getFormattedNames();
   // Return the index of a certain size (0 (Custom Size) if not found)
   int findSize(const QSize &size) { int idx = sizes.indexOf( size ); return (idx == -1) ? 0 : idx; }
   // Get the size with the given index.
@@ -47,7 +47,7 @@ frameHandler::frameSizePresetList::frameSizePresetList()
 /* Get all the names of the preset frame sizes in the form "Name (xxx,yyy)" in a QStringList.
  * This can be used to directly fill the combo box.
  */
-QStringList frameHandler::frameSizePresetList::getFormatedNames()
+QStringList frameHandler::frameSizePresetList::getFormattedNames()
 {
   QStringList presetList;
   presetList.append( "Custom Size" );
@@ -83,7 +83,7 @@ QLayout *frameHandler::createFrameHandlerControls(bool isSizeFixed)
   ui.heightSpinBox->setMaximum(100000);
   ui.heightSpinBox->setValue( frameSize.height() );
   ui.heightSpinBox->setEnabled( !isSizeFixed );
-  ui.frameSizeComboBox->addItems( presetFrameSizes.getFormatedNames() );
+  ui.frameSizeComboBox->addItems( presetFrameSizes.getFormattedNames() );
   int idx = presetFrameSizes.findSize( frameSize );
   ui.frameSizeComboBox->setCurrentIndex(idx);
   ui.frameSizeComboBox->setEnabled( !isSizeFixed );

--- a/source/frameHandler.cpp
+++ b/source/frameHandler.cpp
@@ -22,6 +22,22 @@
 
 // ------ Initialize the static list of frame size presets ----------
 
+class frameHandler::frameSizePresetList
+{
+public:
+  // Constructor. Fill the names and sizes lists
+  frameSizePresetList();
+  // Get all presets in a displayable format ("Name (xxx,yyy)")
+  QStringList getFormatedNames();
+  // Return the index of a certain size (0 (Custom Size) if not found)
+  int findSize(const QSize &size) { int idx = sizes.indexOf( size ); return (idx == -1) ? 0 : idx; }
+  // Get the size with the given index.
+  QSize getSize(int index) { return sizes[index]; }
+private:
+  QList<QString> names;
+  QList<QSize>   sizes;
+};
+
 frameHandler::frameSizePresetList::frameSizePresetList()
 {
   names << "Custom Size" << "QCIF" << "QVGA" << "WQVGA" << "CIF" << "VGA" << "WVGA" << "4CIF" << "ITU R.BT601" << "720i/p" << "1080i/p" << "4k" << "XGA" << "XGA+";
@@ -45,7 +61,6 @@ QStringList frameHandler::frameSizePresetList::getFormatedNames()
   return presetList;
 }
 
-// Initialize the static list of frame size presets
 frameHandler::frameSizePresetList frameHandler::presetFrameSizes;
 
 // ---------------- frameHandler ---------------------------------

--- a/source/frameHandler.h
+++ b/source/frameHandler.h
@@ -99,21 +99,7 @@ protected:
 private:
 
   // A list of all frame size presets. Only used privately in this class. Defined in the .cpp file.
-  class frameSizePresetList
-  {
-  public:
-    // Constructor. Fill the names and sizes lists
-    frameSizePresetList();
-    // Get all presets in a displayable format ("Name (xxx,yyy)")
-    QStringList getFormatedNames();
-    // Return the index of a certain size (0 (Custom Size) if not found)
-    int findSize(const QSize &size) { int idx = sizes.indexOf( size ); return (idx == -1) ? 0 : idx; }
-    // Get the size with the given index.
-    QSize getSize(int index) { return sizes[index]; }
-  private:
-    QList<QString> names;
-    QList<QSize>   sizes;
-  };
+  class frameSizePresetList;
 
   // The (static) list of frame size presets (like CIF, QCIF, 4k ...)
   static frameSizePresetList presetFrameSizes;

--- a/source/frameHandler.h
+++ b/source/frameHandler.h
@@ -39,7 +39,7 @@ public:
   frameHandler();
 
   // Get the size of the (current) frame
-  QSize getFrameSize() { return frameSize; }
+  QSize getFrameSize() const { return frameSize; }
   
   // Draw the (current) frame with the given zoom factor
   virtual void drawFrame(QPainter *painter, int frameIdx, double zoomFactor);
@@ -55,7 +55,7 @@ public:
   // Is the current format of the frameHandler valid? The default implementation will check if the frameSize is
   // valid but more specialized implementations may also check other thigs: For example the videoHandlerYUV also
   // checks if a valid YUV format is set.
-  virtual bool isFormatValid() { return frameSize.width() > 0 && frameSize.height() > 0; }
+  virtual bool isFormatValid() const { return frameSize.width() > 0 && frameSize.height() > 0; }
 
   // Calculate the difference of this frameHandler to another frameHandler. This
   // function can be overloaded by more specialized video items. For example the videoHandlerYUV
@@ -76,7 +76,7 @@ public:
   // If a second frameHandler item is provided, the difference values will be drawn.
   virtual void drawPixelValues(QPainter *painter, int frameIdx, const QRect &videoRect, double zoomFactor, frameHandler *item2=NULL);
   
-  QImage getCurrentFrameAsImage() { return currentImage; }
+  QImage getCurrentFrameAsImage() const { return currentImage; }
 
   // Load the current image from file and set the correct size.
   bool loadCurrentImageFromFile(const QString &filePath);
@@ -91,7 +91,7 @@ protected:
 
   // Get the pixel value from currentImage. Make sure that currentImage is the correct image.
   QRgb getPixelVal(const QPoint &pixelPos) { return getPixelVal(pixelPos.x(), pixelPos.y()); }
-  virtual QRgb getPixelVal(int x, int y)    { return currentImage.pixel(x, y); }
+  virtual QRgb getPixelVal(int x, int y) { return currentImage.pixel(x, y); }
 
   // The frame size must not change while caching is running so when changing the file size this mutex must be locked.
   QMutex cachingFrameSizeMutex;

--- a/source/frameHandler.h
+++ b/source/frameHandler.h
@@ -45,12 +45,12 @@ public:
   virtual void drawFrame(QPainter *painter, int frameIdx, double zoomFactor);
 
   // Set the values and update the controls. Only emit an event if emitSignal is set.
-  virtual void setFrameSize(QSize size, bool emitSignal = false);
+  virtual void setFrameSize(const QSize &size, bool emitSignal = false);
 
   // Return the RGB values of the given pixel. If a second item is provided, return the difference values to that item.
-  virtual ValuePairList getPixelValues(QPoint pixelPos, int frameIdx, frameHandler *item2=NULL);
+  virtual ValuePairList getPixelValues(const QPoint &pixelPos, int frameIdx, frameHandler *item2=NULL);
   // Is the pixel under the cursor brighter or darker than the middle brightness level?
-  virtual bool isPixelDark(QPoint pixelPos);
+  virtual bool isPixelDark(const QPoint &pixelPos);
 
   // Is the current format of the frameHandler valid? The default implementation will check if the frameSize is
   // valid but more specialized implementations may also check other thigs: For example the videoHandlerYUV also
@@ -74,12 +74,12 @@ public:
   // The playlistItemVideo implememntation of this function will draw the RGB vales. However, if a derived class knows other
   // source values to show it can overload this function (like the playlistItemYUVSource).
   // If a second frameHandler item is provided, the difference values will be drawn.
-  virtual void drawPixelValues(QPainter *painter, int frameIdx, QRect videoRect, double zoomFactor, frameHandler *item2=NULL);
+  virtual void drawPixelValues(QPainter *painter, int frameIdx, const QRect &videoRect, double zoomFactor, frameHandler *item2=NULL);
   
   QImage getCurrentFrameAsImage() { return currentImage; }
 
   // Load the current image from file and set the correct size.
-  bool loadCurrentImageFromFile(QString filePath);
+  bool loadCurrentImageFromFile(const QString &filePath);
  
 signals:
   void signalHandlerChanged(bool redrawNeeded, bool cacheChanged);
@@ -90,8 +90,8 @@ protected:
   QSize  frameSize;
 
   // Get the pixel value from currentImage. Make sure that currentImage is the correct image.
-  virtual QRgb getPixelVal(QPoint pixelPos) { return currentImage.pixel(pixelPos); }
-  virtual QRgb getPixelVal(int x, int y)    { return currentImage.pixel(x, y);     }
+  QRgb getPixelVal(const QPoint &pixelPos) { return getPixelVal(pixelPos.x(), pixelPos.y()); }
+  virtual QRgb getPixelVal(int x, int y)    { return currentImage.pixel(x, y); }
 
   // The frame size must not change while caching is running so when changing the file size this mutex must be locked.
   QMutex cachingFrameSizeMutex;
@@ -107,7 +107,7 @@ private:
     // Get all presets in a displayable format ("Name (xxx,yyy)")
     QStringList getFormatedNames();
     // Return the index of a certain size (0 (Custom Size) if not found)
-    int findSize(QSize size) { int idx = sizes.indexOf( size ); return (idx == -1) ? 0 : idx; }
+    int findSize(const QSize &size) { int idx = sizes.indexOf( size ); return (idx == -1) ? 0 : idx; }
     // Get the size with the given index.
     QSize getSize(int index) { return sizes[index]; }
   private:
@@ -117,7 +117,6 @@ private:
 
   // The (static) list of frame size presets (like CIF, QCIF, 4k ...)
   static frameSizePresetList presetFrameSizes;
-  QStringList getFrameSizePresetNames();
  
   SafeUi<Ui::frameHandler> ui;
 

--- a/source/labelelided.h
+++ b/source/labelelided.h
@@ -1,0 +1,60 @@
+/*  YUView - YUV player with advanced analytics toolset
+*   Copyright (C) 2015  Institut für Nachrichtentechnik
+*                       RWTH Aachen University, GERMANY
+*
+*   YUView is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 2 of the License, or
+*   (at your option) any later version.
+*
+*   YUView is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with YUView.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef LABELELIDED_H
+#define LABELELIDED_H
+
+#include <QLabel>
+
+// A custom minimum size QLabel that elides text if necessary (add ...  in the middle of the text).
+// The label initializes with a minimum width of 20pixels. However, it can get as big as the text
+// is wide. The QLabelElided will also show the full text as tooltip if it was elided.
+// See http://stackoverflow.com/q/21284720/1329652 for alternate implementation using styles.
+class labelElided : public QLabel
+{
+  Q_OBJECT
+  Q_PROPERTY(QString text READ text WRITE setText)
+public:
+  // The constructor will set the label to a very small size. If you want the label
+  // to be bigger by default, you have to set the minimum size manually.
+  explicit labelElided(QWidget * parent = 0) : QLabel(parent) { resize( 20, 1 ); }
+  explicit labelElided(const QString &newText, QWidget * parent = 0) : QLabel(parent) { resize( 20,1 ); setText( newText ); }
+  QString text() const { return m_text; }
+  void setText(const QString &newText) {
+    if (m_text == newText) return;
+    m_text = newText;
+    setElidedText();
+  }
+protected:
+  void resizeEvent(QResizeEvent * event) Q_DECL_OVERRIDE { Q_UNUSED(event); setElidedText(); }
+private:
+  void setElidedText()
+  {
+    // Set elided text and tooltip (if the text was elided)
+    QFontMetrics metrics( font() );
+    QString textElided = metrics.elidedText(m_text, Qt::ElideMiddle, size().width());
+    if (textElided != m_text)
+      setToolTip( m_text );
+    QLabel::setText( textElided );
+  }
+  using QLabel::setPicture; // This widget only supports displaying text
+  using QLabel::setPixmap;
+  QString m_text;
+};
+
+#endif // LABELELIDED_H

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -67,7 +67,7 @@ private:
   QMenu* helpMenu;
 
 public:
-  void loadFiles(QStringList files) { p_playlistWidget->loadFiles( files ); }
+  void loadFiles(const QStringList &files) { p_playlistWidget->loadFiles( files ); }
 
   // Check for a new update (if we do this automatically)
   void autoUpdateCheck() { updater->startCheckForNewVersion(false); }

--- a/source/playbackController.h
+++ b/source/playbackController.h
@@ -53,10 +53,10 @@ public:
   void pausePlayback() { if (playing()) on_playPauseButton_clicked(); }
 
   // Is the playback running?
-  bool playing() { return timerId != -1; }
+  bool playing() const { return timerId != -1; }
 
   // Get the currently shown frame index
-  int getCurrentFrame() { return currentFrameIdx; }
+  int getCurrentFrame() const { return currentFrameIdx; }
   // Set the current frame in the controls and update the splitView without invoking more events from the controls.
   void setCurrentFrame(int frame);
 

--- a/source/playlistItem.cpp
+++ b/source/playlistItem.cpp
@@ -50,7 +50,7 @@ void playlistItem::disableCaching()
   cachingMutex.unlock();
 }
 
-void playlistItem::appendPropertiesToPlaylist(QDomElementYUView &d)
+void playlistItem::appendPropertiesToPlaylist(QDomElementYUView &d) const
 {
   d.appendProperiteChild("id", QString::number(id));
 }
@@ -60,10 +60,10 @@ void playlistItem::loadPropertiesFromPlaylist(const QDomElementYUView &root, pla
   newItem->playlistID = root.findChildValue("id").toInt();
 }
 
-QList<playlistItem*> playlistItem::getItemAndAllChildren()
+QList<playlistItem*> playlistItem::getItemAndAllChildren() const
 {
   QList<playlistItem*> returnList;
-  returnList.append(this);
+  returnList.append(const_cast<playlistItem*>(this));
   for (int i = 0; i < childCount(); i++)
   {
     playlistItem *childItem = dynamic_cast<playlistItem*>(child(i));

--- a/source/playlistItem.cpp
+++ b/source/playlistItem.cpp
@@ -20,7 +20,7 @@
 
 unsigned int playlistItem::idCounter = 0;
 
-playlistItem::playlistItem(QString itemNameOrFileName)  
+playlistItem::playlistItem(const QString &itemNameOrFileName)
 {
   setName(itemNameOrFileName);
   cachingEnabled = false;
@@ -55,7 +55,7 @@ void playlistItem::appendPropertiesToPlaylist(QDomElementYUView &d)
   d.appendProperiteChild("id", QString::number(id));
 }
 
-void playlistItem::loadPropertiesFromPlaylist(QDomElementYUView root, playlistItem *newItem)
+void playlistItem::loadPropertiesFromPlaylist(const QDomElementYUView &root, playlistItem *newItem)
 {
   newItem->playlistID = root.findChildValue("id").toInt();
 }
@@ -73,7 +73,7 @@ QList<playlistItem*> playlistItem::getItemAndAllChildren()
   return returnList;
 }
 
-void playlistItem::preparePropertiesWidget(const QString & name) {
+void playlistItem::preparePropertiesWidget(const QString &name) {
   Q_ASSERT(!propertiesWidget);
   propertiesWidget.reset(new QWidget);
   propertiesWidget->setObjectName(name);

--- a/source/playlistItem.h
+++ b/source/playlistItem.h
@@ -44,7 +44,7 @@ public:
    * provide a pointer to the widget stack for the properties panels. The constructor will then call
    * addPropertiesWidget to add the custom properties panel.
   */
-  playlistItem(QString itemNameOrFileName);
+  playlistItem(const QString &itemNameOrFileName);
   virtual ~playlistItem();
 
   // Delete the item later but disable caching of this item before, so that the video cache ignores it
@@ -53,7 +53,7 @@ public:
 
   // Set/Get the name of the item. This is also the name that is shown in the tree view
   QString getName() { return plItemNameOrFileName; }
-  void setName(QString name) { plItemNameOrFileName = name; setText(0, name); }
+  void setName(const QString &name) { plItemNameOrFileName = name; setText(0, name); }
 
   // Every playlist item has a unique (within the playlist) ID
   unsigned int getID() { return id; }
@@ -68,7 +68,7 @@ public:
 
   // Save the element to the given xml structure. Has to be overloaded by the child classes which should
   // know how to load/save themselves.
-  virtual void savePlaylist(QDomElement &root, QDir playlistDir) = 0;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) = 0;
 
   /* Is this item indexed by a frame number or by a duration
    *
@@ -117,7 +117,7 @@ public:
   // Return the source values under the given pixel position.
   // For example a YUV source will provide Y,U and V values. An RGB source might provide RGB values,
   // A difference item will return values from both items and the differences.
-  virtual ValuePairListSets getPixelValues(QPoint pixelPos, int frameIdx) { Q_UNUSED(pixelPos); Q_UNUSED(frameIdx); return ValuePairListSets(); }
+  virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) { Q_UNUSED(pixelPos); Q_UNUSED(frameIdx); return ValuePairListSets(); }
 
   // If you want your item to be droppable onto a difference object, return true here and return a valid video handler.
   virtual bool canBeUsedInDifference() { return false; }
@@ -178,7 +178,7 @@ protected:
   virtual void createPropertiesWidget() = 0;
 
   // Create a named default propertiesWidget
-  void preparePropertiesWidget(const QString & name);
+  void preparePropertiesWidget(const QString &name);
 
   // This mutex is locked while caching is running in the background. When deleting the item, we have to wait until
   // this mutex is unlocked. Make shure to lock/unlock this mutex in your subclass
@@ -188,7 +188,7 @@ protected:
   // When saving the playlist, append the properties of the playlist item (the id)
   void appendPropertiesToPlaylist(QDomElementYUView &d);
   // Load the properties (the playlist ID)
-  static void loadPropertiesFromPlaylist(QDomElementYUView root, playlistItem *newItem);
+  static void loadPropertiesFromPlaylist(const QDomElementYUView &root, playlistItem *newItem);
 
 private:
   // Every playlist item we create gets an id (automatically). This is saved to the playlist so we can match

--- a/source/playlistItem.h
+++ b/source/playlistItem.h
@@ -82,11 +82,11 @@ public:
 
   // Is this a containter item (can it have children)? If yes this function will be called when the number of children changes.
   virtual void updateChildItems() {};
-  virtual void itemAboutToBeDeleter(playlistItem *item) { Q_UNUSED(item); }
+  virtual void itemAboutToBeDeleted(playlistItem *item) { Q_UNUSED(item); }
 
   // Return the info title and info list to be shown in the fileInfo groupBox.
   // The default implementations will return empty strings/list.
-  virtual QString getInfoTitel() { return QString(); }
+  virtual QString getInfoTitle() { return QString(); }
   virtual QList<infoItem> getInfoList() { return QList<infoItem>(); }
 
   /* Get the title of the properties panel. The child class has to overload this.

--- a/source/playlistItem.h
+++ b/source/playlistItem.h
@@ -52,23 +52,23 @@ public:
   void disableCaching();
 
   // Set/Get the name of the item. This is also the name that is shown in the tree view
-  QString getName() { return plItemNameOrFileName; }
+  QString getName() const { return plItemNameOrFileName; }
   void setName(const QString &name) { plItemNameOrFileName = name; setText(0, name); }
 
   // Every playlist item has a unique (within the playlist) ID
-  unsigned int getID() { return id; }
+  unsigned int getID() const { return id; }
   // If an item is loaded from a playlist, it also has a palylistID (which it was given when the playlist was saved)
-  unsigned int getPlaylistID() { return playlistID; }
+  unsigned int getPlaylistID() const { return playlistID; }
   // After loading the playlist, this playlistID has to be reset because it is only valid within this playlist. If another 
   // playlist is loaded later on, the value has to be invalid.
   void resetPlaylistID() { playlistID = -1; }
 
   // Get the parent playlistItem (if any)
-  playlistItem *parentPlaylistItem() { return dynamic_cast<playlistItem*>(QTreeWidgetItem::parent()); }
+  playlistItem *parentPlaylistItem() const { return dynamic_cast<playlistItem*>(QTreeWidgetItem::parent()); }
 
   // Save the element to the given xml structure. Has to be overloaded by the child classes which should
   // know how to load/save themselves.
-  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) = 0;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) const = 0;
 
   /* Is this item indexed by a frame number or by a duration
    *
@@ -76,9 +76,9 @@ public:
    * for a set amount of time.
    * TODO: Add more info here or in the class description
   */
-  virtual bool isIndexedByFrame() = 0;
-  virtual indexRange getFrameIndexRange() { return indexRange(-1,-1); }   // range -1,-1 is returend if the item cannot be drawn
-  virtual QSize getSize() = 0; //< Get the size of the item (in pixels)
+  virtual bool isIndexedByFrame() const = 0;
+  virtual indexRange getFrameIndexRange() const { return indexRange(-1,-1); }   // range -1,-1 is returend if the item cannot be drawn
+  virtual QSize getSize() const = 0; //< Get the size of the item (in pixels)
 
   // Is this a containter item (can it have children)? If yes this function will be called when the number of children changes.
   virtual void updateChildItems() {};
@@ -86,27 +86,27 @@ public:
 
   // Return the info title and info list to be shown in the fileInfo groupBox.
   // The default implementations will return empty strings/list.
-  virtual QString getInfoTitle() { return QString(); }
-  virtual QList<infoItem> getInfoList() { return QList<infoItem>(); }
+  virtual QString getInfoTitle() const { return QString(); }
+  virtual QList<infoItem> getInfoList() const { return QList<infoItem>(); }
 
   /* Get the title of the properties panel. The child class has to overload this.
    * This can be different depending on the type of playlistItem.
    * For example a playlistItemYUVFile will return "YUV File properties".
   */
-  virtual QString getPropertiesTitle() = 0;
+  virtual QString getPropertiesTitle() const = 0;
   QWidget *getPropertiesWidget() { if (!propertiesWidget) createPropertiesWidget(); return propertiesWidget.data(); }
   bool propertiesWidgetCreated() const { return propertiesWidget; }
 
   // Does the playlist item currently accept drops of the given item?
-  virtual bool acceptDrops(playlistItem *draggingItem) { Q_UNUSED(draggingItem); return false; }
+  virtual bool acceptDrops(playlistItem *draggingItem) const { Q_UNUSED(draggingItem); return false; }
 
   // ----- is indexed by frame ----
   // if the item is indexed by frame (isIndexedByFrame() returns true) the following functions have to be reimplemented by the item
-  virtual double getFrameRate()    { return 0; }
-  virtual int    getSampling()     { return 1; }
+  virtual double getFrameRate()    const { return 0; }
+  virtual int    getSampling()     const { return 1; }
 
   // If isIndexedByFrame() return false, the item is shown for a certain period of time (duration).
-  virtual double getDuration()  { return -1; }
+  virtual double getDuration()  const { return -1; }
 
   // Draw the item using the given painter and zoom factor. If the item is indexed by frame, the given frame index will be drawn. If the
   // item is not indexed by frame, the parameter frameIdx is ignored. If playback is set, the item might change it's drawing behavior. For
@@ -120,11 +120,11 @@ public:
   virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) { Q_UNUSED(pixelPos); Q_UNUSED(frameIdx); return ValuePairListSets(); }
 
   // If you want your item to be droppable onto a difference object, return true here and return a valid video handler.
-  virtual bool canBeUsedInDifference() { return false; }
+  virtual bool canBeUsedInDifference() const { return false; }
   virtual frameHandler *getFrameHandler() { return NULL; }
 
   // If this item provides statistics, return them here so that they can be used correctly in an overlay
-  virtual bool              providesStatistics()   { return false; }
+  virtual bool              providesStatistics()   const { return false; }
   virtual statisticHandler *getStatisticsHandler() { return NULL; }
 
   // ----- Caching -----
@@ -132,13 +132,13 @@ public:
   // Can this item be cached? The default is no. Set cachingEnabled in your subclass to true
   // if caching is enabled. Before every caching operation is started, this is checked. So caching
   // can also be temporarily disabled.
-  bool isCachable() { return cachingEnabled; }
+  bool isCachable() const { return cachingEnabled; }
   // Cache the given frame
   virtual void cacheFrame(int idx) { Q_UNUSED(idx); }
   // Get a list of all cached frames (just the frame indices)
-  virtual QList<int> getCachedFrames() { return QList<int>(); }
+  virtual QList<int> getCachedFrames() const { return QList<int>(); }
   // How many bytes will caching one frame use (in bytes)?
-  virtual unsigned int getCachingFrameSize() { return 0; }
+  virtual unsigned int getCachingFrameSize() const { return 0; }
 
   // ----- Detection of source/file change events -----
 
@@ -154,7 +154,7 @@ public:
   virtual void updateFileWatchSetting() {};
 
   // Return a list containing this item and all child items (if any).
-  QList<playlistItem*> getItemAndAllChildren();
+  QList<playlistItem*> getItemAndAllChildren() const;
   
 signals:
   // Something in the item changed. If redraw is set, a redraw of the item is necessary.
@@ -186,7 +186,7 @@ protected:
   bool   cachingEnabled;
 
   // When saving the playlist, append the properties of the playlist item (the id)
-  void appendPropertiesToPlaylist(QDomElementYUView &d);
+  void appendPropertiesToPlaylist(QDomElementYUView &d) const;
   // Load the properties (the playlist ID)
   static void loadPropertiesFromPlaylist(const QDomElementYUView &root, playlistItem *newItem);
 

--- a/source/playlistItemDifference.cpp
+++ b/source/playlistItemDifference.cpp
@@ -144,7 +144,7 @@ void playlistItemDifference::updateChildItems()
   difference.setInputVideos(childVideo0, childVideo1);
 
   // Update the frame range
-  startEndFrame = getstartEndFrameLimits();
+  startEndFrame = getStartEndFrameLimits();
 }
 
 void playlistItemDifference::savePlaylist(QDomElement &root, const QDir &playlistDir)
@@ -179,7 +179,7 @@ playlistItemDifference *playlistItemDifference::newPlaylistItemDifference(const 
   return newDiff;
 }
 
-indexRange playlistItemDifference::getstartEndFrameLimits()
+indexRange playlistItemDifference::getStartEndFrameLimits()
 {
   playlistItemStatic *childStatic0 = (childCount() > 0) ? dynamic_cast<playlistItemStatic*>(child(0)) : NULL;
   playlistItemStatic *childStatic1 = (childCount() > 1) ? dynamic_cast<playlistItemStatic*>(child(1)) : NULL;
@@ -191,7 +191,7 @@ indexRange playlistItemDifference::getstartEndFrameLimits()
   {
     if (childVideo0)
       // Just one item. Return it's limits
-      return childVideo0->getstartEndFrameLimits();
+      return childVideo0->getStartEndFrameLimits();
     else if (childStatic0)
       // Just one item and it is static
       return indexRange(0,1);
@@ -201,8 +201,8 @@ indexRange playlistItemDifference::getstartEndFrameLimits()
     if (childVideo0 && childVideo1)
     {
       // Two items. Return the overlapping region.
-      indexRange limit0 = childVideo0->getstartEndFrameLimits();
-      indexRange limit1 = childVideo1->getstartEndFrameLimits();
+      indexRange limit0 = childVideo0->getStartEndFrameLimits();
+      indexRange limit1 = childVideo1->getStartEndFrameLimits();
 
       int start = std::max(limit0.first, limit1.first);
       int end   = std::min(limit0.second, limit1.second);

--- a/source/playlistItemDifference.cpp
+++ b/source/playlistItemDifference.cpp
@@ -147,7 +147,7 @@ void playlistItemDifference::updateChildItems()
   startEndFrame = getstartEndFrameLimits();
 }
 
-void playlistItemDifference::savePlaylist(QDomElement &root, QDir playlistDir)
+void playlistItemDifference::savePlaylist(QDomElement &root, const QDir &playlistDir)
 {
   QDomElementYUView d = root.ownerDocument().createElement("playlistItemDifference");
 
@@ -166,7 +166,7 @@ void playlistItemDifference::savePlaylist(QDomElement &root, QDir playlistDir)
   root.appendChild(d);
 }
 
-playlistItemDifference *playlistItemDifference::newPlaylistItemDifference(QDomElementYUView root)
+playlistItemDifference *playlistItemDifference::newPlaylistItemDifference(const QDomElementYUView &root)
 {
   playlistItemDifference *newDiff = new playlistItemDifference();
 
@@ -220,7 +220,7 @@ indexRange playlistItemDifference::getstartEndFrameLimits()
   return indexRange(-1,-1);
 }
 
-ValuePairListSets playlistItemDifference::getPixelValues(QPoint pixelPos, int frameIdx)
+ValuePairListSets playlistItemDifference::getPixelValues(const QPoint &pixelPos, int frameIdx)
 {
   ValuePairListSets newSet;
 

--- a/source/playlistItemDifference.cpp
+++ b/source/playlistItemDifference.cpp
@@ -35,7 +35,7 @@ playlistItemDifference::playlistItemDifference()
 }
 
 // This item accepts dropping of two items that provide video
-bool playlistItemDifference::acceptDrops(playlistItem *draggingItem)
+bool playlistItemDifference::acceptDrops(playlistItem *draggingItem) const
 {
   return (childCount() < 2 && draggingItem->canBeUsedInDifference());
 }
@@ -43,7 +43,7 @@ bool playlistItemDifference::acceptDrops(playlistItem *draggingItem)
 /* For a difference item, the info list is just a list of the names of the
  * child elemnts.
  */
-QList<infoItem> playlistItemDifference::getInfoList()
+QList<infoItem> playlistItemDifference::getInfoList() const
 {
   QList<infoItem> infoList;
 
@@ -93,7 +93,7 @@ void playlistItemDifference::drawItem(QPainter *painter, int frameIdx, double zo
   difference.drawFrame(painter, frameIdx, zoomFactor);
 }
 
-QSize playlistItemDifference::getSize() 
+QSize playlistItemDifference::getSize() const
 { 
   if (!difference.inputsValid())
   {
@@ -147,7 +147,7 @@ void playlistItemDifference::updateChildItems()
   startEndFrame = getStartEndFrameLimits();
 }
 
-void playlistItemDifference::savePlaylist(QDomElement &root, const QDir &playlistDir)
+void playlistItemDifference::savePlaylist(QDomElement &root, const QDir &playlistDir) const
 {
   QDomElementYUView d = root.ownerDocument().createElement("playlistItemDifference");
 
@@ -179,7 +179,7 @@ playlistItemDifference *playlistItemDifference::newPlaylistItemDifference(const 
   return newDiff;
 }
 
-indexRange playlistItemDifference::getStartEndFrameLimits()
+indexRange playlistItemDifference::getStartEndFrameLimits() const
 {
   playlistItemStatic *childStatic0 = (childCount() > 0) ? dynamic_cast<playlistItemStatic*>(child(0)) : NULL;
   playlistItemStatic *childStatic1 = (childCount() > 1) ? dynamic_cast<playlistItemStatic*>(child(1)) : NULL;

--- a/source/playlistItemDifference.h
+++ b/source/playlistItemDifference.h
@@ -29,18 +29,18 @@ public:
   playlistItemDifference();
 
   // The difference item accepts drops of items that provide video
-  virtual bool acceptDrops(playlistItem *draggingItem) Q_DECL_OVERRIDE;
+  virtual bool acceptDrops(playlistItem *draggingItem) const Q_DECL_OVERRIDE;
   
-  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "Difference Info"; };
-  virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
+  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "Difference Info"; }
+  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
 
-  virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "Difference Properties"; }
+  virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "Difference Properties"; }
 
   // Overload from playlistItemIndexed
-  virtual indexRange getStartEndFrameLimits() Q_DECL_OVERRIDE;
+  virtual indexRange getStartEndFrameLimits() const Q_DECL_OVERRIDE;
 
   // Overload from playlistItemVideo. 
-  virtual QSize getSize() Q_DECL_OVERRIDE;
+  virtual QSize getSize() const Q_DECL_OVERRIDE;
   
   // Overload from playlistItemVideo. We add some specific drawing functionality if the two
   // children are not comparable.
@@ -51,7 +51,7 @@ public:
   void updateChildItems() Q_DECL_OVERRIDE;
   
   // Overload from playlistItem. Save the playlist item to playlist.
-  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) const Q_DECL_OVERRIDE;
   // Create a new playlistItemDifference from the playlist file entry. Return NULL if parsing failed.
   static playlistItemDifference *newPlaylistItemDifference(const QDomElementYUView &stringElement);
 

--- a/source/playlistItemDifference.h
+++ b/source/playlistItemDifference.h
@@ -31,13 +31,13 @@ public:
   // The difference item accepts drops of items that provide video
   virtual bool acceptDrops(playlistItem *draggingItem) Q_DECL_OVERRIDE;
   
-  virtual QString getInfoTitel() Q_DECL_OVERRIDE { return "Difference Info"; };
+  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "Difference Info"; };
   virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
 
   virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "Difference Properties"; }
 
   // Overload from playlistItemIndexed
-  virtual indexRange getstartEndFrameLimits() Q_DECL_OVERRIDE;
+  virtual indexRange getStartEndFrameLimits() Q_DECL_OVERRIDE;
 
   // Overload from playlistItemVideo. 
   virtual QSize getSize() Q_DECL_OVERRIDE;

--- a/source/playlistItemDifference.h
+++ b/source/playlistItemDifference.h
@@ -51,12 +51,12 @@ public:
   void updateChildItems() Q_DECL_OVERRIDE;
   
   // Overload from playlistItem. Save the playlist item to playlist.
-  virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
   // Create a new playlistItemDifference from the playlist file entry. Return NULL if parsing failed.
-  static playlistItemDifference *newPlaylistItemDifference(QDomElementYUView stringElement);
+  static playlistItemDifference *newPlaylistItemDifference(const QDomElementYUView &stringElement);
 
   // Get the pixel values from A, B and the difference.
-  virtual ValuePairListSets getPixelValues(QPoint pixelPos, int frameIdx) Q_DECL_OVERRIDE;
+  virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) Q_DECL_OVERRIDE;
 
   // Return the frame handler pointer that draws the difference
   virtual frameHandler *getFrameHandler() Q_DECL_OVERRIDE { return &difference; }

--- a/source/playlistItemHEVCFile.cpp
+++ b/source/playlistItemHEVCFile.cpp
@@ -92,7 +92,7 @@ playlistItemHEVCFile::playlistItemHEVCFile(const QString &hevcFilePath)
   fillStatisticList();
 
   // Set the frame number limits
-  startEndFrame = getstartEndFrameLimits();
+  startEndFrame = getStartEndFrameLimits();
 
   if (startEndFrame.second == -1)
     // No frames to decode
@@ -1172,7 +1172,7 @@ void playlistItemHEVCFile::reloadItemSource()
     return;
 
   // Set the frame number limits
-  startEndFrame = getstartEndFrameLimits();
+  startEndFrame = getStartEndFrameLimits();
 
   // Reset the videoHandlerYUV source. With the next draw event, the videoHandlerYUV will request to decode the frame again.
   yuvVideo.invalidateAllBuffers();

--- a/source/playlistItemHEVCFile.cpp
+++ b/source/playlistItemHEVCFile.cpp
@@ -52,7 +52,7 @@ const int playlistItemHEVCFile::vectorTable[35][2] = {
   {-32, 32} };
 
 
-playlistItemHEVCFile::playlistItemHEVCFile(QString hevcFilePath)
+playlistItemHEVCFile::playlistItemHEVCFile(const QString &hevcFilePath)
   : playlistItemIndexed(hevcFilePath)
 {
   // Set the properties of the playlistItem
@@ -119,7 +119,7 @@ playlistItemHEVCFile::playlistItemHEVCFile(QString hevcFilePath)
   cachingEnabled = false;
 }
 
-void playlistItemHEVCFile::savePlaylist(QDomElement &root, QDir playlistDir)
+void playlistItemHEVCFile::savePlaylist(QDomElement &root, const QDir &playlistDir)
 {
   // Determine the relative path to the hevc file. We save both in the playlist.
   QUrl fileURL( annexBFile.getAbsoluteFilePath() );
@@ -138,7 +138,7 @@ void playlistItemHEVCFile::savePlaylist(QDomElement &root, QDir playlistDir)
   root.appendChild(d);
 }
 
-playlistItemHEVCFile *playlistItemHEVCFile::newplaylistItemHEVCFile(QDomElementYUView root, QString playlistFilePath)
+playlistItemHEVCFile *playlistItemHEVCFile::newplaylistItemHEVCFile(const QDomElementYUView &root, const QString &playlistFilePath)
 {
   // Parse the dom element. It should have all values of a playlistItemHEVCFile
   QString absolutePath = root.findChildValue("absolutePath");
@@ -795,7 +795,7 @@ void playlistItemHEVCFile::cacheStatistics(const de265_image *img, int iPOC)
   int ctb_size = 1 << log2CTBSize;	// width and height of each ctb
 
   // Save Slice index
-  StatisticsType *statsTypeSliceIdx = statSource.getStatisticsType(0);
+  const StatisticsType *statsTypeSliceIdx = statSource.getStatisticsType(0);
   anItem.type = blockType;
   uint16_t *tmpArr = new uint16_t[ widthInCTB * heightInCTB ];
   de265_internals_get_CTB_sliceIdx(img, tmpArr);
@@ -1317,7 +1317,7 @@ void playlistItemHEVCFile::loadStatisticToCache(int frameIdx, int typeIdx)
   }
 }
 
-ValuePairListSets playlistItemHEVCFile::getPixelValues(QPoint pixelPos, int frameIdx) 
+ValuePairListSets playlistItemHEVCFile::getPixelValues(const QPoint &pixelPos, int frameIdx)
 { 
   ValuePairListSets newSet;
   

--- a/source/playlistItemHEVCFile.cpp
+++ b/source/playlistItemHEVCFile.cpp
@@ -114,7 +114,7 @@ playlistItemHEVCFile::playlistItemHEVCFile(const QString &hevcFilePath)
   cachingEnabled = false;
 }
 
-void playlistItemHEVCFile::savePlaylist(QDomElement &root, const QDir &playlistDir)
+void playlistItemHEVCFile::savePlaylist(QDomElement &root, const QDir &playlistDir) const
 {
   // Determine the relative path to the hevc file. We save both in the playlist.
   QUrl fileURL( annexBFile.getAbsoluteFilePath() );
@@ -153,7 +153,7 @@ playlistItemHEVCFile *playlistItemHEVCFile::newplaylistItemHEVCFile(const QDomEl
   return newFile;
 }
 
-QList<infoItem> playlistItemHEVCFile::getInfoList()
+QList<infoItem> playlistItemHEVCFile::getInfoList() const
 {
   QList<infoItem> infoList;
 
@@ -836,7 +836,7 @@ void playlistItemHEVCFile::cacheStatistics(const de265_image *img, int iPOC)
   statsCacheCurPOC = iPOC;
 }
 
-void playlistItemHEVCFile::getPBSubPosition(int partMode, int cbSizePix, int pbIdx, int *pbX, int *pbY, int *pbW, int *pbH)
+void playlistItemHEVCFile::getPBSubPosition(int partMode, int cbSizePix, int pbIdx, int *pbX, int *pbY, int *pbW, int *pbH) const
 {
   // Get the position/width/height of the PB
   if (partMode == 0) // PART_2Nx2N

--- a/source/playlistItemHEVCFile.h
+++ b/source/playlistItemHEVCFile.h
@@ -22,16 +22,15 @@
 #include "playlistitemIndexed.h"
 #include "videoHandlerYUV.h"
 #include "fileSourceHEVCAnnexBFile.h"
-#include "de265.h"
+#include "de265wrapper.h"
 #include "statisticHandler.h"
 
-#include <QLibrary>
 #include <QFuture>
 
 class videoHandler;
 
 class playlistItemHEVCFile :
-  public playlistItemIndexed
+  public playlistItemIndexed, private de265Wrapper
 {
   Q_OBJECT
 
@@ -102,81 +101,10 @@ private:
 
   de265_decoder_context* decoder;
 
-  // typedefs for libde265 decoder library function pointers
-  typedef de265_decoder_context *(*f_de265_new_decoder)          ();
-  typedef void                   (*f_de265_set_parameter_bool)   (de265_decoder_context*, de265_param, int);
-  typedef void                   (*f_de265_set_parameter_int)    (de265_decoder_context*, de265_param, int);
-  typedef void                   (*f_de265_disable_logging)      ();
-  typedef void                   (*f_de265_set_verbosity)        (int);
-  typedef de265_error            (*f_de265_start_worker_threads) (de265_decoder_context*, int);
-  typedef void                   (*f_de265_set_limit_TID)        (de265_decoder_context*, int);
-  typedef const char*            (*f_de265_get_error_text)       (de265_error);
-  typedef de265_chroma           (*f_de265_get_chroma_format)    (const de265_image*);
-  typedef int                    (*f_de265_get_image_width)      (const de265_image*, int);
-  typedef int                    (*f_de265_get_image_height)     (const de265_image*, int);
-  typedef const uint8_t*         (*f_de265_get_image_plane)      (const de265_image*, int, int*);
-  typedef int                    (*f_de265_get_bits_per_pixel)   (const de265_image*, int);
-  typedef de265_error            (*f_de265_decode)               (de265_decoder_context*, int*);
-  typedef de265_error            (*f_de265_push_data)            (de265_decoder_context*, const void*, int, de265_PTS, void*);
-  typedef de265_error            (*f_de265_flush_data)           (de265_decoder_context*);
-  typedef const de265_image*     (*f_de265_get_next_picture)     (de265_decoder_context*);
-  typedef de265_error            (*f_de265_free_decoder)         (de265_decoder_context*);
-
-  // libde265 decoder library function pointers for internals
-  typedef void (*f_de265_internals_get_CTB_Info_Layout)		   (const de265_image*, int*, int*, int*);
-  typedef void (*f_de265_internals_get_CTB_sliceIdx)			   (const de265_image*, uint16_t*);
-  typedef void (*f_de265_internals_get_CB_Info_Layout)		   (const de265_image*, int*, int*, int*);
-  typedef void (*f_de265_internals_get_CB_info)				       (const de265_image*, uint16_t*);
-  typedef void (*f_de265_internals_get_PB_Info_layout)		   (const de265_image*, int*, int*, int*);
-  typedef void (*f_de265_internals_get_PB_info)				       (const de265_image*, int16_t*, int16_t*, int16_t*, int16_t*, int16_t*, int16_t*);
-  typedef void (*f_de265_internals_get_IntraDir_Info_layout) (const de265_image*, int*, int*, int*);
-  typedef void (*f_de265_internals_get_intraDir_info)			   (const de265_image*, uint8_t*, uint8_t*);
-  typedef void (*f_de265_internals_get_TUInfo_Info_layout)	 (const de265_image*, int*, int*, int*);
-  typedef void (*f_de265_internals_get_TUInfo_info)			     (const de265_image*, uint8_t*);
-
-  // Decoder library function pointers
-  f_de265_new_decoder			     de265_new_decoder;
-  f_de265_set_parameter_bool   de265_set_parameter_bool;
-  f_de265_set_parameter_int	   de265_set_parameter_int;
-  f_de265_disable_logging		   de265_disable_logging;
-  f_de265_set_verbosity		     de265_set_verbosity;
-  f_de265_start_worker_threads de265_start_worker_threads;
-  f_de265_set_limit_TID		     de265_set_limit_TID;
-  f_de265_get_error_text		   de265_get_error_text;
-  f_de265_get_chroma_format    de265_get_chroma_format;
-  f_de265_get_image_width      de265_get_image_width;
-  f_de265_get_image_height	   de265_get_image_height;
-  f_de265_get_image_plane   	 de265_get_image_plane;
-  f_de265_get_bits_per_pixel	 de265_get_bits_per_pixel;
-  f_de265_decode 				       de265_decode;
-  f_de265_push_data			       de265_push_data;
-  f_de265_flush_data			     de265_flush_data;
-  f_de265_get_next_picture	   de265_get_next_picture;
-  f_de265_free_decoder    	   de265_free_decoder;
-
-  // Decoder library function pointers for internals
-  f_de265_internals_get_CTB_Info_Layout		    de265_internals_get_CTB_Info_Layout;
-  f_de265_internals_get_CTB_sliceIdx			    de265_internals_get_CTB_sliceIdx;
-  f_de265_internals_get_CB_Info_Layout		    de265_internals_get_CB_Info_Layout;
-  f_de265_internals_get_CB_info				        de265_internals_get_CB_info;
-  f_de265_internals_get_PB_Info_layout		    de265_internals_get_PB_Info_layout;
-  f_de265_internals_get_PB_info				        de265_internals_get_PB_info;
-  f_de265_internals_get_IntraDir_Info_layout  de265_internals_get_IntraDir_Info_layout;
-  f_de265_internals_get_intraDir_info         de265_internals_get_intraDir_info;
-  f_de265_internals_get_TUInfo_Info_layout	  de265_internals_get_TUInfo_Info_layout;
-  f_de265_internals_get_TUInfo_info           de265_internals_get_TUInfo_info;
-
-    // Was there an error? If everything is allright it will be DE265_OK.
+  // Was there an error? If everything is allright it will be DE265_OK.
   de265_error decError;
 
-  // Decoder library
-  void loadDecoderLibrary();
   void allocateNewDecoder();
-  QLibrary decLib;
-
-  // Status reporting
-  QString StatusText;
-  bool internalError;		///< There was an internal error and the decoder can not be used.
 
   /// ===== Buffering
 #if SSE_CONVERSION
@@ -219,7 +147,6 @@ private:
   void cacheStatistics_TUTree_recursive(uint8_t *tuInfo, int tuInfoWidth, int tuUnitSizePix, int iPOC, int tuIdx, int log2TUSize, int trDepth);
 
   bool retrieveStatistics;    ///< if set to true the decoder will also get statistics from each decoded frame and put them into the local cache
-  bool internalsSupported;		///< does the loaded library support the extraction of internals/statistics?
 
   // Convert intra direction mode into vector
   static const int vectorTable[35][2];

--- a/source/playlistItemHEVCFile.h
+++ b/source/playlistItemHEVCFile.h
@@ -41,12 +41,12 @@ public:
    * provide a pointer to the widget stack for the properties panels. The constructor will then call
    * addPropertiesWidget to add the custom properties panel.
   */
-  playlistItemHEVCFile(QString fileName);
+  playlistItemHEVCFile(const QString &fileName);
 
   // Save the HEVC file element to the given xml structure.
-  virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
   // Create a new playlistItemHEVCFile from the playlist file entry. Return NULL if parsing failed.
-  static playlistItemHEVCFile *newplaylistItemHEVCFile(QDomElementYUView root, QString playlistFilePath);
+  static playlistItemHEVCFile *newplaylistItemHEVCFile(const QDomElementYUView &root, const QString &playlistFilePath);
 
   // Return the info title and info list to be shown in the fileInfo groupBox.
   // The default implementations will return empty strings/list.
@@ -61,7 +61,7 @@ public:
   virtual void drawItem(QPainter *painter, int frameIdx, double zoomFactor, bool playback) Q_DECL_OVERRIDE;
 
   // Return the source (YUV and statistics) values under the given pixel position.
-  virtual ValuePairListSets getPixelValues(QPoint pixelPos, int frameIdx) Q_DECL_OVERRIDE;
+  virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) Q_DECL_OVERRIDE;
 
   // If you want your item to be droppable onto a difference object, return true here and return a valid video handler.
   virtual bool canBeUsedInDifference() Q_DECL_OVERRIDE { return true; }

--- a/source/playlistItemHEVCFile.h
+++ b/source/playlistItemHEVCFile.h
@@ -43,17 +43,17 @@ public:
   playlistItemHEVCFile(const QString &fileName);
 
   // Save the HEVC file element to the given xml structure.
-  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) const Q_DECL_OVERRIDE;
   // Create a new playlistItemHEVCFile from the playlist file entry. Return NULL if parsing failed.
   static playlistItemHEVCFile *newplaylistItemHEVCFile(const QDomElementYUView &root, const QString &playlistFilePath);
 
   // Return the info title and info list to be shown in the fileInfo groupBox.
   // The default implementations will return empty strings/list.
-  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "HEVC File Info"; }
-  virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
+  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "HEVC File Info"; }
+  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
 
-  virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "HEVC File Properties"; };
-  virtual QSize getSize() Q_DECL_OVERRIDE { return yuvVideo.getFrameSize(); }
+  virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "HEVC File Properties"; }
+  virtual QSize getSize() const Q_DECL_OVERRIDE { return yuvVideo.getFrameSize(); }
   
   // Draw the item using the given painter and zoom factor. If the item is indexed by frame, the given frame index will be drawn. If the
   // item is not indexed by frame, the parameter frameIdx is ignored.
@@ -63,11 +63,11 @@ public:
   virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) Q_DECL_OVERRIDE;
 
   // If you want your item to be droppable onto a difference object, return true here and return a valid video handler.
-  virtual bool canBeUsedInDifference() Q_DECL_OVERRIDE { return true; }
+  virtual bool canBeUsedInDifference() const Q_DECL_OVERRIDE { return true; }
   virtual frameHandler *getFrameHandler() Q_DECL_OVERRIDE { return &yuvVideo; }
 
   // Override from playlistItemIndexed. The annexBFile handler can tell us how many POSs there are.
-  virtual indexRange getStartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, annexBFile.getNumberPOCs()-1); }
+  virtual indexRange getStartEndFrameLimits() const Q_DECL_OVERRIDE { return indexRange(0, annexBFile.getNumberPOCs()-1); }
 
   // Add the file type filters and the extensions of files that we can load.
   static void getSupportedFileExtensions(QStringList &allExtensions, QStringList &filters);
@@ -142,7 +142,7 @@ private:
 
   // With the given partitioning mode, the size of the CU and the prediction block index, calculate the
   // sub-position and size of the prediction block
-  void getPBSubPosition(int partMode, int CUSizePix, int pbIdx, int *pbX, int *pbY, int *pbW, int *pbH);
+  void getPBSubPosition(int partMode, int CUSizePix, int pbIdx, int *pbX, int *pbY, int *pbW, int *pbH) const;
   //
   void cacheStatistics_TUTree_recursive(uint8_t *tuInfo, int tuInfoWidth, int tuUnitSizePix, int iPOC, int tuIdx, int log2TUSize, int trDepth);
 

--- a/source/playlistItemHEVCFile.h
+++ b/source/playlistItemHEVCFile.h
@@ -49,7 +49,7 @@ public:
 
   // Return the info title and info list to be shown in the fileInfo groupBox.
   // The default implementations will return empty strings/list.
-  virtual QString getInfoTitel() Q_DECL_OVERRIDE { return "HEVC File Info"; }
+  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "HEVC File Info"; }
   virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
 
   virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "HEVC File Properties"; };
@@ -67,7 +67,7 @@ public:
   virtual frameHandler *getFrameHandler() Q_DECL_OVERRIDE { return &yuvVideo; }
 
   // Override from playlistItemIndexed. The annexBFile handler can tell us how many POSs there are.
-  virtual indexRange getstartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, annexBFile.getNumberPOCs()-1); }
+  virtual indexRange getStartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, annexBFile.getNumberPOCs()-1); }
 
   // Add the file type filters and the extensions of files that we can load.
   static void getSupportedFileExtensions(QStringList &allExtensions, QStringList &filters);

--- a/source/playlistItemImageFile.cpp
+++ b/source/playlistItemImageFile.cpp
@@ -26,7 +26,7 @@
 
 #define IMAGEFILE_ERROR_TEXT "The given image file could not be laoaded."
 
-playlistItemImageFile::playlistItemImageFile(QString filePath) : playlistItemStatic(filePath)
+playlistItemImageFile::playlistItemImageFile(const QString &filePath) : playlistItemStatic(filePath)
 {
   // Set the properties of the playlistItem
   setIcon(0, QIcon(":img_television.png"));
@@ -46,7 +46,7 @@ playlistItemImageFile::playlistItemImageFile(QString filePath) : playlistItemSta
   updateFileWatchSetting();
 }
 
-void playlistItemImageFile::savePlaylist(QDomElement &root, QDir playlistDir)
+void playlistItemImageFile::savePlaylist(QDomElement &root, const QDir &playlistDir)
 {
   // Determine the relative path to the raw file. We save both in the playlist.
   QUrl fileURL(plItemNameOrFileName);
@@ -67,7 +67,7 @@ void playlistItemImageFile::savePlaylist(QDomElement &root, QDir playlistDir)
 
 /* Parse the playlist and return a new playlistItemImageFile.
 */
-playlistItemImageFile *playlistItemImageFile::newplaylistItemImageFile(QDomElementYUView root, QString playlistFilePath)
+playlistItemImageFile *playlistItemImageFile::newplaylistItemImageFile(const QDomElementYUView &root, const QString &playlistFilePath)
 {
   // Parse the dom element. It should have all values of a playlistItemImageFile
   QString absolutePath = root.findChildValue("absolutePath");
@@ -135,7 +135,7 @@ void playlistItemImageFile::getSupportedFileExtensions(QStringList &allExtension
   filters.append(filter);
 }
 
-ValuePairListSets playlistItemImageFile::getPixelValues(QPoint pixelPos, int frameIdx)
+ValuePairListSets playlistItemImageFile::getPixelValues(const QPoint &pixelPos, int frameIdx)
 {
   ValuePairListSets newSet;
   newSet.append("RGB", frame.getPixelValues(pixelPos, frameIdx));

--- a/source/playlistItemImageFile.cpp
+++ b/source/playlistItemImageFile.cpp
@@ -46,7 +46,7 @@ playlistItemImageFile::playlistItemImageFile(const QString &filePath) : playlist
   updateFileWatchSetting();
 }
 
-void playlistItemImageFile::savePlaylist(QDomElement &root, const QDir &playlistDir)
+void playlistItemImageFile::savePlaylist(QDomElement &root, const QDir &playlistDir) const
 {
   // Determine the relative path to the raw file. We save both in the playlist.
   QUrl fileURL(plItemNameOrFileName);
@@ -142,7 +142,7 @@ ValuePairListSets playlistItemImageFile::getPixelValues(const QPoint &pixelPos, 
   return newSet;
 }
 
-QList<infoItem> playlistItemImageFile::getInfoList()
+QList<infoItem> playlistItemImageFile::getInfoList() const
 {
   QList<infoItem> infoList;
 

--- a/source/playlistItemImageFile.h
+++ b/source/playlistItemImageFile.h
@@ -31,7 +31,7 @@ class playlistItemImageFile :
   Q_OBJECT
 
 public:
-  playlistItemImageFile(QString imagePath);
+  playlistItemImageFile(const QString &imagePath);
 
   // ------ Overload from playlistItem
 
@@ -44,12 +44,12 @@ public:
   virtual QSize getSize() Q_DECL_OVERRIDE { return frame.getFrameSize(); }
 
   // Overload from playlistItem. Save the text item to playlist.
-  virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
   // Create a new playlistItemText from the playlist file entry. Return NULL if parsing failed.
-  static playlistItemImageFile *newplaylistItemImageFile(QDomElementYUView root, QString playlistFilePath);
+  static playlistItemImageFile *newplaylistItemImageFile(const QDomElementYUView &root, const QString &playlistFilePath);
     
   // Return the RGB values under the given pixel position.
-  virtual ValuePairListSets getPixelValues(QPoint pixelPos, int frameIdx) Q_DECL_OVERRIDE;
+  virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) Q_DECL_OVERRIDE;
 
   // Draw the text item. Since isIndexedByFrame() returned false, this item is not indexed by frames
   // and the given value of frameIdx will be ignored.
@@ -71,7 +71,7 @@ public:
   
 private slots:
   // The image file that we loaded was changed.
-  void fileSystemWatcherFileChanged(const QString path) { Q_UNUSED(path); fileChanged = true; }
+  void fileSystemWatcherFileChanged(const QString &path) { Q_UNUSED(path); fileChanged = true; }
 
 private:
   

--- a/source/playlistItemImageFile.h
+++ b/source/playlistItemImageFile.h
@@ -35,16 +35,16 @@ public:
 
   // ------ Overload from playlistItem
 
-  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "Image Info"; }
-  virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
+  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "Image Info"; }
+  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
 
-  virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "Image Properties"; }
+  virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "Image Properties"; }
 
   // Get the text size (using the current text, font/text size ...)
-  virtual QSize getSize() Q_DECL_OVERRIDE { return frame.getFrameSize(); }
+  virtual QSize getSize() const Q_DECL_OVERRIDE { return frame.getFrameSize(); }
 
   // Overload from playlistItem. Save the text item to playlist.
-  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) const Q_DECL_OVERRIDE;
   // Create a new playlistItemText from the playlist file entry. Return NULL if parsing failed.
   static playlistItemImageFile *newplaylistItemImageFile(const QDomElementYUView &root, const QString &playlistFilePath);
     
@@ -62,7 +62,7 @@ public:
   virtual frameHandler *getFrameHandler() Q_DECL_OVERRIDE { return &frame; }
 
   // An image can be used in a difference.
-  virtual bool canBeUsedInDifference() Q_DECL_OVERRIDE { return true; }
+  virtual bool canBeUsedInDifference() const Q_DECL_OVERRIDE { return true; }
 
   // ----- Detection of source/file change events -----
   virtual bool isSourceChanged()        Q_DECL_OVERRIDE { bool b = fileChanged; fileChanged = false; return b; }

--- a/source/playlistItemImageFile.h
+++ b/source/playlistItemImageFile.h
@@ -35,7 +35,7 @@ public:
 
   // ------ Overload from playlistItem
 
-  virtual QString getInfoTitel() Q_DECL_OVERRIDE { return "Image Info"; }
+  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "Image Info"; }
   virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
 
   virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "Image Properties"; }

--- a/source/playlistItemImageFileSequence.cpp
+++ b/source/playlistItemImageFileSequence.cpp
@@ -22,7 +22,7 @@
 #include <QDebug>
 #include <QSettings>
 
-playlistItemImageFileSequence::playlistItemImageFileSequence(QString rawFilePath)
+playlistItemImageFileSequence::playlistItemImageFileSequence(const QString &rawFilePath)
   : playlistItemIndexed(rawFilePath)
 {
   // Set the properties of the playlistItem
@@ -52,14 +52,14 @@ playlistItemImageFileSequence::playlistItemImageFileSequence(QString rawFilePath
   updateFileWatchSetting();
 }
 
-bool playlistItemImageFileSequence::isImageSequence(QString filePath)
+bool playlistItemImageFileSequence::isImageSequence(const QString &filePath)
 {
   QStringList files;
   fillImageFileList(files, filePath);
   return files.count() > 1;
 }
 
-void playlistItemImageFileSequence::fillImageFileList(QStringList &imageFiles, QString filePath)
+void playlistItemImageFileSequence::fillImageFileList(QStringList &imageFiles, const QString &filePath)
 {
   // See if the filename ends with a number
   QFileInfo fi(filePath);
@@ -149,7 +149,7 @@ QList<infoItem> playlistItemImageFileSequence::getInfoList()
   return infoList;
 }
 
-void playlistItemImageFileSequence::savePlaylist(QDomElement &root, QDir playlistDir)
+void playlistItemImageFileSequence::savePlaylist(QDomElement &root, const QDir &playlistDir)
 {
   QDomElementYUView d = root.ownerDocument().createElement("playlistItemImageFileSequence");
 
@@ -174,7 +174,7 @@ void playlistItemImageFileSequence::savePlaylist(QDomElement &root, QDir playlis
 
 /* Parse the playlist and return a new playlistItemRawFile.
 */
-playlistItemImageFileSequence *playlistItemImageFileSequence::newplaylistItemImageFileSequence(QDomElementYUView root, QString playlistFilePath)
+playlistItemImageFileSequence *playlistItemImageFileSequence::newplaylistItemImageFileSequence(const QDomElementYUView &root, const QString &playlistFilePath)
 {
   playlistItemImageFileSequence *newSequence = new playlistItemImageFileSequence();
 
@@ -251,7 +251,7 @@ void playlistItemImageFileSequence::loadFrame(int frameIdx)
   }
 }
 
-void playlistItemImageFileSequence::setInternals(QString filePath)
+void playlistItemImageFileSequence::setInternals(const QString &filePath)
 {
   // Set start end frame and frame size if it has not been set yet.
   if (startEndFrame == indexRange(-1,-1))

--- a/source/playlistItemImageFileSequence.cpp
+++ b/source/playlistItemImageFileSequence.cpp
@@ -255,7 +255,7 @@ void playlistItemImageFileSequence::setInternals(const QString &filePath)
 {
   // Set start end frame and frame size if it has not been set yet.
   if (startEndFrame == indexRange(-1,-1))
-    startEndFrame = getstartEndFrameLimits();
+    startEndFrame = getStartEndFrameLimits();
 
   // Open frame 0 and set the size of it
   QPixmap frame0 = QPixmap(imageFiles[0]);

--- a/source/playlistItemImageFileSequence.cpp
+++ b/source/playlistItemImageFileSequence.cpp
@@ -134,7 +134,7 @@ void playlistItemImageFileSequence::createPropertiesWidget()
   vAllLaout->insertStretch(2, 1);
 }
 
-QList<infoItem> playlistItemImageFileSequence::getInfoList()
+QList<infoItem> playlistItemImageFileSequence::getInfoList() const
 {
   QList<infoItem> infoList;
 
@@ -149,7 +149,7 @@ QList<infoItem> playlistItemImageFileSequence::getInfoList()
   return infoList;
 }
 
-void playlistItemImageFileSequence::savePlaylist(QDomElement &root, const QDir &playlistDir)
+void playlistItemImageFileSequence::savePlaylist(QDomElement &root, const QDir &playlistDir) const
 {
   QDomElementYUView d = root.ownerDocument().createElement("playlistItemImageFileSequence");
 

--- a/source/playlistItemImageFileSequence.h
+++ b/source/playlistItemImageFileSequence.h
@@ -41,22 +41,22 @@ public:
   playlistItemImageFileSequence(const QString &rawFilePath = QString());
 
   // Overload from playlistItem. Save the raw file item to playlist.
-  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) const Q_DECL_OVERRIDE;
 
   // Override from playlistItem. Return the info title and info list to be shown in the fileInfo groupBox.
-  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "Image Sequence Info"; }
-  virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
+  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "Image Sequence Info"; }
+  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
 
-  virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "Image Sequence Properties"; }
+  virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "Image Sequence Properties"; }
 
   // Create a new playlistItemImageFileSequence from the playlist file entry. Return NULL if parsing failed.
   static playlistItemImageFileSequence *newplaylistItemImageFileSequence(const QDomElementYUView &root, const QString &playlistFilePath);
 
   // All the functions that we have to overload if we are indexed by frame
-  virtual QSize getSize() Q_DECL_OVERRIDE { return video.getFrameSize(); }
+  virtual QSize getSize() const Q_DECL_OVERRIDE { return video.getFrameSize(); }
   
   // A raw file can be used in a difference
-  virtual bool canBeUsedInDifference() Q_DECL_OVERRIDE { return true; }
+  virtual bool canBeUsedInDifference() const Q_DECL_OVERRIDE { return true; }
   virtual frameHandler *getFrameHandler() Q_DECL_OVERRIDE { return &video; }
 
   virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) Q_DECL_OVERRIDE { return ValuePairListSets("RGB", video.getPixelValues(pixelPos, frameIdx)); }
@@ -68,10 +68,10 @@ public:
   // Cache the given frame
   virtual void cacheFrame(int idx) Q_DECL_OVERRIDE { if (!cachingEnabled) return; cachingMutex.lock(); video.cacheFrame(idx); cachingMutex.unlock(); }
   // Get a list of all cached frames (just the frame indices)
-  virtual QList<int> getCachedFrames() Q_DECL_OVERRIDE { return video.getCachedFrames(); }
+  virtual QList<int> getCachedFrames() const Q_DECL_OVERRIDE { return video.getCachedFrames(); }
   // How many bytes will caching one frame use (in bytes)?
   // For a raw file we only cache the output pixmap so it is w*h*PIXMAP_BYTESPERPIXEL bytes. 
-  virtual unsigned int getCachingFrameSize() Q_DECL_OVERRIDE { return getSize().width() * getSize().height() * PIXMAP_BYTESPERPIXEL; }
+  virtual unsigned int getCachingFrameSize() const Q_DECL_OVERRIDE { return getSize().width() * getSize().height() * PIXMAP_BYTESPERPIXEL; }
 
   // Add the file type filters and the extensions of files that we can load.
   static void getSupportedFileExtensions(QStringList &allExtensions, QStringList &filters);
@@ -95,8 +95,8 @@ private slots:
 
 protected:
 
-  // Override from playlistItemIndexed. For a raw raw file the index range is 0...numFrames-1. 
-  virtual indexRange getStartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, getNumberFrames()-1); }
+  // Override from playlistItemIndexed. For a raw raw file the index range is 0...numFrames-1.
+  virtual indexRange getStartEndFrameLimits() const Q_DECL_OVERRIDE { return indexRange(0, getNumberFrames()-1); }
 
 private:
 
@@ -104,7 +104,7 @@ private:
   // and set propertiesWidget to point to it.
   virtual void createPropertiesWidget() Q_DECL_OVERRIDE;
 
-  virtual qint64 getNumberFrames() { return imageFiles.length(); }
+  virtual qint64 getNumberFrames() const { return imageFiles.length(); }
 
   // Set internal values (frame Size, caching, ...). Call this after the imageFiles list has been filled.
   // Get the internal name and set it as text of the playlistItem. 

--- a/source/playlistItemImageFileSequence.h
+++ b/source/playlistItemImageFileSequence.h
@@ -38,10 +38,10 @@ class playlistItemImageFileSequence :
   Q_OBJECT
 
 public:
-  playlistItemImageFileSequence(QString rawFilePath = QString());
+  playlistItemImageFileSequence(const QString &rawFilePath = QString());
 
   // Overload from playlistItem. Save the raw file item to playlist.
-  virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
 
   // Override from playlistItem. Return the info title and info list to be shown in the fileInfo groupBox.
   virtual QString getInfoTitel() Q_DECL_OVERRIDE { return "Image Sequence Info"; }
@@ -50,7 +50,7 @@ public:
   virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "Image Sequence Properties"; }
 
   // Create a new playlistItemImageFileSequence from the playlist file entry. Return NULL if parsing failed.
-  static playlistItemImageFileSequence *newplaylistItemImageFileSequence(QDomElementYUView root, QString playlistFilePath);
+  static playlistItemImageFileSequence *newplaylistItemImageFileSequence(const QDomElementYUView &root, const QString &playlistFilePath);
 
   // All the functions that we have to overload if we are indexed by frame
   virtual QSize getSize() Q_DECL_OVERRIDE { return video.getFrameSize(); }
@@ -59,7 +59,7 @@ public:
   virtual bool canBeUsedInDifference() Q_DECL_OVERRIDE { return true; }
   virtual frameHandler *getFrameHandler() Q_DECL_OVERRIDE { return &video; }
 
-  virtual ValuePairListSets getPixelValues(QPoint pixelPos, int frameIdx) Q_DECL_OVERRIDE { return ValuePairListSets("RGB", video.getPixelValues(pixelPos, frameIdx)); }
+  virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) Q_DECL_OVERRIDE { return ValuePairListSets("RGB", video.getPixelValues(pixelPos, frameIdx)); }
 
   // Draw the item
   virtual void drawItem(QPainter *painter, int frameIdx, double zoomFactor, bool playback) Q_DECL_OVERRIDE;
@@ -78,7 +78,7 @@ public:
 
   // Check if this is just one image, or if there is a pattern in the file name. E.g: 
   // image000.png, image001.png ...
-  static bool isImageSequence(QString filePath);
+  static bool isImageSequence(const QString &filePath);
 
   // ----- Detection of source/file change events -----
   virtual bool isSourceChanged()        Q_DECL_OVERRIDE { bool b = fileChanged; fileChanged = false; return b; }
@@ -91,7 +91,7 @@ private slots:
   virtual void loadFrame(int frameIdx);
 
   // The image file that we loaded was changed.
-  void fileSystemWatcherFileChanged(const QString path) { Q_UNUSED(path); fileChanged = true; }
+  void fileSystemWatcherFileChanged(const QString &path) { Q_UNUSED(path); fileChanged = true; }
 
 protected:
 
@@ -109,12 +109,12 @@ private:
   // Set internal values (frame Size, caching, ...). Call this after the imageFiles list has been filled.
   // Get the internal name and set it as text of the playlistItem. 
   // E.g. for "somehting_0001.png" this will set the name "something_xxxx.png"
-  void setInternals(QString filePath);
+  void setInternals(const QString &filePath);
 
   QString internalName;
 
   // Fill the given imageFiles list with all the files that can be found for the given file.
-  static void fillImageFileList(QStringList &imageFiles, QString filePath);
+  static void fillImageFileList(QStringList &imageFiles, const QString &filePath);
   QStringList imageFiles;
   
   videoHandler video;

--- a/source/playlistItemImageFileSequence.h
+++ b/source/playlistItemImageFileSequence.h
@@ -44,7 +44,7 @@ public:
   virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
 
   // Override from playlistItem. Return the info title and info list to be shown in the fileInfo groupBox.
-  virtual QString getInfoTitel() Q_DECL_OVERRIDE { return "Image Sequence Info"; }
+  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "Image Sequence Info"; }
   virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
 
   virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "Image Sequence Properties"; }
@@ -96,7 +96,7 @@ private slots:
 protected:
 
   // Override from playlistItemIndexed. For a raw raw file the index range is 0...numFrames-1. 
-  virtual indexRange getstartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, getNumberFrames()-1); }
+  virtual indexRange getStartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, getNumberFrames()-1); }
 
 private:
 

--- a/source/playlistItemOverlay.cpp
+++ b/source/playlistItemOverlay.cpp
@@ -42,7 +42,7 @@ playlistItemOverlay::playlistItemOverlay() :
 /* For an overlay item, the info list is just a list of the names of the
  * child elemnts.
  */
-QList<infoItem> playlistItemOverlay::getInfoList()
+QList<infoItem> playlistItemOverlay::getInfoList() const
 {
   QList<infoItem> infoList;
 
@@ -143,7 +143,7 @@ void playlistItemOverlay::drawItem(QPainter *painter, int frameIdx, double zoomF
   painter->translate( centerRoundTL(boundingRect) * zoomFactor );
 }
 
-QSize playlistItemOverlay::getSize()
+QSize playlistItemOverlay::getSize() const
 { 
   if (childCount() == 0)
   {
@@ -323,7 +323,7 @@ void playlistItemOverlay::createPropertiesWidget( )
   connect(ui.alignmentVertical, SIGNAL(valueChanged(int)), this, SLOT(controlChanged(int)));
 }
 
-void playlistItemOverlay::savePlaylist(QDomElement &root, const QDir &playlistDir)
+void playlistItemOverlay::savePlaylist(QDomElement &root, const QDir &playlistDir) const
 {
   QDomElementYUView d = root.ownerDocument().createElement("playlistItemOverlay");
 
@@ -364,7 +364,7 @@ playlistItemOverlay *playlistItemOverlay::newPlaylistItemOverlay(const QDomEleme
   return newOverlay;
 }
 
-playlistItem *playlistItemOverlay::getFirstChildPlaylistItem()
+playlistItem *playlistItemOverlay::getFirstChildPlaylistItem() const
 {
   if (childCount() == 0)
     return NULL;

--- a/source/playlistItemOverlay.cpp
+++ b/source/playlistItemOverlay.cpp
@@ -62,7 +62,7 @@ QList<infoItem> playlistItemOverlay::getInfoList()
   return infoList;
 }
 
-ValuePairListSets playlistItemOverlay::getPixelValues(QPoint pixelPos, int frameIdx)
+ValuePairListSets playlistItemOverlay::getPixelValues(const QPoint &pixelPos, int frameIdx)
 {
   ValuePairListSets newSet;
 
@@ -323,7 +323,7 @@ void playlistItemOverlay::createPropertiesWidget( )
   connect(ui.alignmentVertical, SIGNAL(valueChanged(int)), this, SLOT(controlChanged(int)));
 }
 
-void playlistItemOverlay::savePlaylist(QDomElement &root, QDir playlistDir)
+void playlistItemOverlay::savePlaylist(QDomElement &root, const QDir &playlistDir)
 {
   QDomElementYUView d = root.ownerDocument().createElement("playlistItemOverlay");
 
@@ -346,7 +346,7 @@ void playlistItemOverlay::savePlaylist(QDomElement &root, QDir playlistDir)
   root.appendChild(d);
 }
 
-playlistItemOverlay *playlistItemOverlay::newPlaylistItemOverlay(QDomElementYUView root, QString filePath)
+playlistItemOverlay *playlistItemOverlay::newPlaylistItemOverlay(const QDomElementYUView &root, const QString &filePath)
 {
   Q_UNUSED(filePath);
 

--- a/source/playlistItemOverlay.cpp
+++ b/source/playlistItemOverlay.cpp
@@ -281,7 +281,7 @@ void playlistItemOverlay::updateChildList()
   childLlistUpdateRequired = false;
 }
 
-void playlistItemOverlay::itemAboutToBeDeleter(playlistItem *item)
+void playlistItemOverlay::itemAboutToBeDeleted(playlistItem *item)
 {
   // Remove the item from childList and disconnect signlas/slots
   for (int i = 0; i < childList.count(); i++)

--- a/source/playlistItemOverlay.h
+++ b/source/playlistItemOverlay.h
@@ -31,21 +31,21 @@ public:
   playlistItemOverlay();
 
   // The overlay item accepts drops of items that provide video
-  virtual bool acceptDrops(playlistItem *draggingItem) Q_DECL_OVERRIDE { Q_UNUSED(draggingItem); return true; }
+  virtual bool acceptDrops(playlistItem *draggingItem) const Q_DECL_OVERRIDE { Q_UNUSED(draggingItem); return true; }
 
   // The overlay item is indexed by frame
-  virtual bool isIndexedByFrame() Q_DECL_OVERRIDE { return true; }
-  virtual indexRange getFrameIndexRange() { return (getFirstChildPlaylistItem() == NULL) ? indexRange(-1,-1) : getFirstChildPlaylistItem()->getFrameIndexRange(); }
+  virtual bool isIndexedByFrame() const Q_DECL_OVERRIDE { return true; }
+  virtual indexRange getFrameIndexRange() const { return (getFirstChildPlaylistItem() == NULL) ? indexRange(-1,-1) : getFirstChildPlaylistItem()->getFrameIndexRange(); }
 
-  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "Overlay Info"; };
-  virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
+  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "Overlay Info"; }
+  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
 
-  virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "Overlay Properties"; }
+  virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "Overlay Properties"; }
 
   // Overload from playlistItemVideo. 
-  virtual double getFrameRate() Q_DECL_OVERRIDE { return (getFirstChildPlaylistItem() == NULL) ? 0 : getFirstChildPlaylistItem()->getFrameRate(); }
-  virtual QSize  getSize()      Q_DECL_OVERRIDE;
-  virtual int    getSampling()  Q_DECL_OVERRIDE { return (getFirstChildPlaylistItem() == NULL) ? 1 : getFirstChildPlaylistItem()->getSampling(); }
+  virtual double getFrameRate() const Q_DECL_OVERRIDE { return (getFirstChildPlaylistItem() == NULL) ? 0 : getFirstChildPlaylistItem()->getFrameRate(); }
+  virtual QSize  getSize()      const Q_DECL_OVERRIDE;
+  virtual int    getSampling()  const Q_DECL_OVERRIDE { return (getFirstChildPlaylistItem() == NULL) ? 1 : getFirstChildPlaylistItem()->getSampling(); }
 
   // Overload from playlistItemVideo. We add some specific drawing functionality if the two
   // children are not comparable.
@@ -58,7 +58,7 @@ public:
   virtual void itemAboutToBeDeleted(playlistItem *item) Q_DECL_OVERRIDE;
   
   // Overload from playlistItem. Save the playlist item to playlist.
-  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) const Q_DECL_OVERRIDE;
   // Create a new playlistItemOverlay from the playlist file entry. Return NULL if parsing failed.
   static playlistItemOverlay *newPlaylistItemOverlay(const QDomElementYUView &stringElement, const QString &filePath);
 
@@ -82,7 +82,7 @@ private:
   virtual void createPropertiesWidget() Q_DECL_OVERRIDE;
 
   // Return the first child item (as playlistItem) or NULL if there is no child.
-  playlistItem *getFirstChildPlaylistItem();
+  playlistItem *getFirstChildPlaylistItem() const;
 
   SafeUi<Ui::playlistItemOverlay_Widget> ui;
 

--- a/source/playlistItemOverlay.h
+++ b/source/playlistItemOverlay.h
@@ -37,7 +37,7 @@ public:
   virtual bool isIndexedByFrame() Q_DECL_OVERRIDE { return true; }
   virtual indexRange getFrameIndexRange() { return (getFirstChildPlaylistItem() == NULL) ? indexRange(-1,-1) : getFirstChildPlaylistItem()->getFrameIndexRange(); }
 
-  virtual QString getInfoTitel() Q_DECL_OVERRIDE { return "Overlay Info"; };
+  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "Overlay Info"; };
   virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
 
   virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "Overlay Properties"; }
@@ -55,7 +55,7 @@ public:
   // and emit the signalItemChanged(true).
   void updateChildItems() Q_DECL_OVERRIDE { childLlistUpdateRequired = true; emit signalItemChanged(true, false); }
   // An item will be deleted. Disconnect the signals/slots of this item
-  virtual void itemAboutToBeDeleter(playlistItem *item) Q_DECL_OVERRIDE;
+  virtual void itemAboutToBeDeleted(playlistItem *item) Q_DECL_OVERRIDE;
   
   // Overload from playlistItem. Save the playlist item to playlist.
   virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;

--- a/source/playlistItemOverlay.h
+++ b/source/playlistItemOverlay.h
@@ -58,16 +58,16 @@ public:
   virtual void itemAboutToBeDeleter(playlistItem *item) Q_DECL_OVERRIDE;
   
   // Overload from playlistItem. Save the playlist item to playlist.
-  virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
   // Create a new playlistItemOverlay from the playlist file entry. Return NULL if parsing failed.
-  static playlistItemOverlay *newPlaylistItemOverlay(QDomElementYUView stringElement, QString filePath);
+  static playlistItemOverlay *newPlaylistItemOverlay(const QDomElementYUView &stringElement, const QString &filePath);
 
   // ----- Detection of source/file change events -----
   virtual bool isSourceChanged()        Q_DECL_OVERRIDE;  // Return if one of the child item's source changed.
   virtual void reloadItemSource()       Q_DECL_OVERRIDE;  // Reload all child items
   virtual void updateFileWatchSetting() Q_DECL_OVERRIDE;  // Install/remove the file watchers.
   
-  virtual ValuePairListSets getPixelValues(QPoint pixelPos, int frameIdx) Q_DECL_OVERRIDE;
+  virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) Q_DECL_OVERRIDE;
   
 protected:
 

--- a/source/playlistItemRawFile.cpp
+++ b/source/playlistItemRawFile.cpp
@@ -27,7 +27,7 @@
 #include <QDebug>
 #include <QPainter>
 
-playlistItemRawFile::playlistItemRawFile(QString rawFilePath, QSize frameSize, QString sourcePixelFormat )
+playlistItemRawFile::playlistItemRawFile(const QString &rawFilePath, const QSize &frameSize, const QString &sourcePixelFormat )
   : playlistItemIndexed(rawFilePath), video(NULL)
 {
   // Set the properties of the playlistItem
@@ -178,7 +178,7 @@ void playlistItemRawFile::createPropertiesWidget( )
   vAllLaout->insertStretch(3, 1);
 }
 
-void playlistItemRawFile::savePlaylist(QDomElement &root, QDir playlistDir)
+void playlistItemRawFile::savePlaylist(QDomElement &root, const QDir &playlistDir)
 {
   // Determine the relative path to the raw file. We save both in the playlist.
   QUrl fileURL( dataSource.getAbsoluteFilePath() );
@@ -209,7 +209,7 @@ void playlistItemRawFile::savePlaylist(QDomElement &root, QDir playlistDir)
 
 /* Parse the playlist and return a new playlistItemRawFile.
 */
-playlistItemRawFile *playlistItemRawFile::newplaylistItemRawFile(QDomElementYUView root, QString playlistFilePath)
+playlistItemRawFile *playlistItemRawFile::newplaylistItemRawFile(const QDomElementYUView &root, const QString &playlistFilePath)
 {
   // Parse the dom element. It should have all values of a playlistItemRawFile
   QString absolutePath = root.findChildValue("absolutePath");
@@ -264,7 +264,7 @@ void playlistItemRawFile::loadRawData(int frameIdx)
   }
 }
 
-ValuePairListSets playlistItemRawFile::getPixelValues(QPoint pixelPos, int frameIdx) 
+ValuePairListSets playlistItemRawFile::getPixelValues(const QPoint &pixelPos, int frameIdx)
 { 
   return ValuePairListSets((rawFormat == YUV) ? "YUV" : "RGB", video->getPixelValues(pixelPos, frameIdx)); 
 }

--- a/source/playlistItemRawFile.cpp
+++ b/source/playlistItemRawFile.cpp
@@ -71,7 +71,7 @@ playlistItemRawFile::playlistItemRawFile(const QString &rawFilePath, const QSize
     }
 
     if (video->isFormatValid())
-      startEndFrame = getstartEndFrameLimits();
+      startEndFrame = getStartEndFrameLimits();
   }
   else
   {

--- a/source/playlistItemRawFile.cpp
+++ b/source/playlistItemRawFile.cpp
@@ -92,7 +92,7 @@ playlistItemRawFile::playlistItemRawFile(const QString &rawFilePath, const QSize
   cachingEnabled = true;
 }
 
-qint64 playlistItemRawFile::getNumberFrames()
+qint64 playlistItemRawFile::getNumberFrames() const
 {
   if (!dataSource.isOk() || !video->isFormatValid())
   {
@@ -107,7 +107,7 @@ qint64 playlistItemRawFile::getNumberFrames()
   return (bpf == 0) ? -1 : dataSource.getFileSize() / bpf;
 }
 
-QList<infoItem> playlistItemRawFile::getInfoList()
+QList<infoItem> playlistItemRawFile::getInfoList() const
 {
   QList<infoItem> infoList;
 
@@ -178,7 +178,7 @@ void playlistItemRawFile::createPropertiesWidget( )
   vAllLaout->insertStretch(3, 1);
 }
 
-void playlistItemRawFile::savePlaylist(QDomElement &root, const QDir &playlistDir)
+void playlistItemRawFile::savePlaylist(QDomElement &root, const QDir &playlistDir) const
 {
   // Determine the relative path to the raw file. We save both in the playlist.
   QUrl fileURL( dataSource.getAbsoluteFilePath() );
@@ -283,7 +283,7 @@ void playlistItemRawFile::getSupportedFileExtensions(QStringList &allExtensions,
   filters.append("Raw RGB File (*.rgb *.rbg *.grb *.gbr *.brg *.bgr)");
 }
 
-qint64 playlistItemRawFile::getBytesPerFrame()
+qint64 playlistItemRawFile::getBytesPerFrame() const
 {
   if (rawFormat == YUV)
       return getYUVVideo()->getBytesPerFrame();

--- a/source/playlistItemRawFile.h
+++ b/source/playlistItemRawFile.h
@@ -41,10 +41,10 @@ class playlistItemRawFile :
   Q_OBJECT
 
 public:
-  playlistItemRawFile(QString rawFilePath, QSize frameSize=QSize(-1,-1), QString sourcePixelFormat=QString());
+  playlistItemRawFile(const QString &rawFilePath, const QSize &frameSize=QSize(-1,-1), const QString &sourcePixelFormat=QString());
 
   // Overload from playlistItem. Save the raw file item to playlist.
-  virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
 
   // Override from playlistItem. Return the info title and info list to be shown in the fileInfo groupBox.
   virtual QString getInfoTitel() Q_DECL_OVERRIDE { return (rawFormat == YUV) ? "YUV File Info" : "RGB File Info"; }
@@ -53,7 +53,7 @@ public:
   virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return (rawFormat == YUV) ? "YUV File Properties" : "RGB File Properties"; }
 
   // Create a new playlistItemRawFile from the playlist file entry. Return NULL if parsing failed.
-  static playlistItemRawFile *newplaylistItemRawFile(QDomElementYUView root, QString playlistFilePath);
+  static playlistItemRawFile *newplaylistItemRawFile(const QDomElementYUView &root, const QString &playlistFilePath);
 
   // All the functions that we have to overload if we are indexed by frame
   virtual QSize getSize() Q_DECL_OVERRIDE { return (video) ? video->getFrameSize() : QSize(); }
@@ -62,7 +62,7 @@ public:
   virtual bool canBeUsedInDifference() Q_DECL_OVERRIDE { return true; }
   virtual frameHandler *getFrameHandler() Q_DECL_OVERRIDE { return video.data(); }
 
-  virtual ValuePairListSets getPixelValues(QPoint pixelPos, int frameIdx) Q_DECL_OVERRIDE;
+  virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) Q_DECL_OVERRIDE;
 
   // Draw the item
   virtual void drawItem(QPainter *painter, int frameIdx, double zoomFactor, bool playback) Q_DECL_OVERRIDE;

--- a/source/playlistItemRawFile.h
+++ b/source/playlistItemRawFile.h
@@ -44,22 +44,22 @@ public:
   playlistItemRawFile(const QString &rawFilePath, const QSize &frameSize=QSize(-1,-1), const QString &sourcePixelFormat=QString());
 
   // Overload from playlistItem. Save the raw file item to playlist.
-  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) const Q_DECL_OVERRIDE;
 
   // Override from playlistItem. Return the info title and info list to be shown in the fileInfo groupBox.
-  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return (rawFormat == YUV) ? "YUV File Info" : "RGB File Info"; }
-  virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
+  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return (rawFormat == YUV) ? "YUV File Info" : "RGB File Info"; }
+  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
 
-  virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return (rawFormat == YUV) ? "YUV File Properties" : "RGB File Properties"; }
+  virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return (rawFormat == YUV) ? "YUV File Properties" : "RGB File Properties"; }
 
   // Create a new playlistItemRawFile from the playlist file entry. Return NULL if parsing failed.
   static playlistItemRawFile *newplaylistItemRawFile(const QDomElementYUView &root, const QString &playlistFilePath);
 
   // All the functions that we have to overload if we are indexed by frame
-  virtual QSize getSize() Q_DECL_OVERRIDE { return (video) ? video->getFrameSize() : QSize(); }
+  virtual QSize getSize() const Q_DECL_OVERRIDE { return (video) ? video->getFrameSize() : QSize(); }
   
   // A raw file can be used in a difference
-  virtual bool canBeUsedInDifference() Q_DECL_OVERRIDE { return true; }
+  virtual bool canBeUsedInDifference() const Q_DECL_OVERRIDE { return true; }
   virtual frameHandler *getFrameHandler() Q_DECL_OVERRIDE { return video.data(); }
 
   virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) Q_DECL_OVERRIDE;
@@ -71,10 +71,10 @@ public:
   // Cache the given frame
   virtual void cacheFrame(int idx) Q_DECL_OVERRIDE { if (!cachingEnabled) return; cachingMutex.lock(); video->cacheFrame(idx); cachingMutex.unlock(); }
   // Get a list of all cached frames (just the frame indices)
-  virtual QList<int> getCachedFrames() Q_DECL_OVERRIDE { return video->getCachedFrames(); }
+  virtual QList<int> getCachedFrames() const Q_DECL_OVERRIDE { return video->getCachedFrames(); }
   // How many bytes will caching one frame use (in bytes)?
   // For a raw file we only cache the output pixmap so it is w*h*PIXMAP_BYTESPERPIXEL bytes. 
-  virtual unsigned int getCachingFrameSize() Q_DECL_OVERRIDE { return getSize().width() * getSize().height() * PIXMAP_BYTESPERPIXEL; }
+  virtual unsigned int getCachingFrameSize() const Q_DECL_OVERRIDE { return getSize().width() * getSize().height() * PIXMAP_BYTESPERPIXEL; }
 
   // Add the file type filters and the extensions of files that we can load.
   static void getSupportedFileExtensions(QStringList &allExtensions, QStringList &filters);
@@ -98,7 +98,7 @@ protected:
   void setFormatFromFileName();
 
   // Override from playlistItemIndexed. For a raw raw file the index range is 0...numFrames-1. 
-  virtual indexRange getStartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, getNumberFrames()-1); }
+  virtual indexRange getStartEndFrameLimits() const Q_DECL_OVERRIDE { return indexRange(0, getNumberFrames()-1); }
 
 private:
 
@@ -113,7 +113,7 @@ private:
   // and set propertiesWidget to point to it.
   virtual void createPropertiesWidget() Q_DECL_OVERRIDE;
 
-  virtual qint64 getNumberFrames();
+  virtual qint64 getNumberFrames() const;
   
   fileSource dataSource;
 
@@ -121,8 +121,10 @@ private:
 
   videoHandlerYUV *getYUVVideo() { return dynamic_cast<videoHandlerYUV*>(video.data()); }
   videoHandlerRGB *getRGBVideo() { return dynamic_cast<videoHandlerRGB*>(video.data()); }
+  const videoHandlerYUV *getYUVVideo() const { return dynamic_cast<const videoHandlerYUV*>(video.data()); }
+  const videoHandlerRGB *getRGBVideo() const { return dynamic_cast<const videoHandlerRGB*>(video.data()); }
 
-  qint64 getBytesPerFrame();
+  qint64 getBytesPerFrame() const;
 
 };
 

--- a/source/playlistItemRawFile.h
+++ b/source/playlistItemRawFile.h
@@ -47,7 +47,7 @@ public:
   virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
 
   // Override from playlistItem. Return the info title and info list to be shown in the fileInfo groupBox.
-  virtual QString getInfoTitel() Q_DECL_OVERRIDE { return (rawFormat == YUV) ? "YUV File Info" : "RGB File Info"; }
+  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return (rawFormat == YUV) ? "YUV File Info" : "RGB File Info"; }
   virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
 
   virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return (rawFormat == YUV) ? "YUV File Properties" : "RGB File Properties"; }
@@ -98,7 +98,7 @@ protected:
   void setFormatFromFileName();
 
   // Override from playlistItemIndexed. For a raw raw file the index range is 0...numFrames-1. 
-  virtual indexRange getstartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, getNumberFrames()-1); }
+  virtual indexRange getStartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, getNumberFrames()-1); }
 
 private:
 

--- a/source/playlistItemStatisticsFile.cpp
+++ b/source/playlistItemStatisticsFile.cpp
@@ -30,7 +30,7 @@
 // idea anyways)
 #define STAT_PARSING_BUFFER_SIZE 1048576
 
-playlistItemStatisticsFile::playlistItemStatisticsFile(QString itemNameOrFileName) 
+playlistItemStatisticsFile::playlistItemStatisticsFile(const QString &itemNameOrFileName)
   : playlistItemIndexed(itemNameOrFileName)
 {
   // Set default variables
@@ -452,7 +452,7 @@ void playlistItemStatisticsFile::loadStatisticToCache(int frameIdx, int typeID)
         // Block not in image. Warn about this.
         blockOutsideOfFrame_idx = frameIdx;
 
-      StatisticsType *statsType = statSource.getStatisticsType(type);
+      const StatisticsType *statsType = statSource.getStatisticsType(type);
       Q_ASSERT_X(statsType != NULL, "StatisticsObject::readStatisticsFromFile", "Stat type not found.");
       anItem.type = ((statsType->visualizationType == colorMapType) || (statsType->visualizationType == colorRangeType)) ? blockType : arrowType;
 
@@ -515,10 +515,10 @@ void playlistItemStatisticsFile::loadStatisticToCache(int frameIdx, int typeID)
   return;
 }
 
-QStringList playlistItemStatisticsFile::parseCSVLine(QString line, char delimiter)
+QStringList playlistItemStatisticsFile::parseCSVLine(const QString &srcLine, char delimiter)
 {
-  // first, trim newline and whitespaces from both ends of line
-  line = line.trimmed().remove(" ");
+  // Trim newline and whitespaces from both ends of line
+  QString line = srcLine.trimmed().remove(" ");
 
   // now split string with delimiter
   return line.split(delimiter);
@@ -565,7 +565,7 @@ void playlistItemStatisticsFile::createPropertiesWidget()
   // expand to take up as much space as there is available  
 }
 
-void playlistItemStatisticsFile::savePlaylist(QDomElement &root, QDir playlistDir)
+void playlistItemStatisticsFile::savePlaylist(QDomElement &root, const QDir &playlistDir)
 {
   // Determine the relative path to the yuv file-> We save both in the playlist.
   QUrl fileURL( file.getAbsoluteFilePath() );
@@ -587,7 +587,7 @@ void playlistItemStatisticsFile::savePlaylist(QDomElement &root, QDir playlistDi
   root.appendChild(d);
 }
 
-playlistItemStatisticsFile *playlistItemStatisticsFile::newplaylistItemStatisticsFile(QDomElementYUView root, QString playlistFilePath)
+playlistItemStatisticsFile *playlistItemStatisticsFile::newplaylistItemStatisticsFile(const QDomElementYUView &root, const QString &playlistFilePath)
 {
   // Parse the dom element. It should have all values of a playlistItemStatisticsFile
   QString absolutePath = root.findChildValue("absolutePath");

--- a/source/playlistItemStatisticsFile.cpp
+++ b/source/playlistItemStatisticsFile.cpp
@@ -71,7 +71,7 @@ playlistItemStatisticsFile::~playlistItemStatisticsFile()
   }
 }
 
-QList<infoItem> playlistItemStatisticsFile::getInfoList()
+QList<infoItem> playlistItemStatisticsFile::getInfoList() const
 {
   QList<infoItem> infoList;
 
@@ -515,7 +515,7 @@ void playlistItemStatisticsFile::loadStatisticToCache(int frameIdx, int typeID)
   return;
 }
 
-QStringList playlistItemStatisticsFile::parseCSVLine(const QString &srcLine, char delimiter)
+QStringList playlistItemStatisticsFile::parseCSVLine(const QString &srcLine, char delimiter) const
 {
   // Trim newline and whitespaces from both ends of line
   QString line = srcLine.trimmed().remove(" ");
@@ -565,7 +565,7 @@ void playlistItemStatisticsFile::createPropertiesWidget()
   // expand to take up as much space as there is available  
 }
 
-void playlistItemStatisticsFile::savePlaylist(QDomElement &root, const QDir &playlistDir)
+void playlistItemStatisticsFile::savePlaylist(QDomElement &root, const QDir &playlistDir) const
 {
   // Determine the relative path to the yuv file-> We save both in the playlist.
   QUrl fileURL( file.getAbsoluteFilePath() );

--- a/source/playlistItemStatisticsFile.h
+++ b/source/playlistItemStatisticsFile.h
@@ -47,7 +47,7 @@ public:
   virtual QSize getSize() Q_DECL_OVERRIDE { return statSource.statFrameSize; }
   
   // Return the info title and info list to be shown in the fileInfo groupBox.
-  virtual QString getInfoTitel() Q_DECL_OVERRIDE { return "Statistics File info"; }
+  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "Statistics File info"; }
   virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
 
   /* Get the title of the properties panel. The child class has to overload this.
@@ -63,7 +63,7 @@ public:
 
   virtual void drawItem(QPainter *painter, int frameIdx, double zoomFactor, bool playback) Q_DECL_OVERRIDE;
 
-  virtual indexRange getstartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, maxPOC); }
+  virtual indexRange getStartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, maxPOC); }
 
   // Create a new playlistItemStatisticsFile from the playlist file entry. Return NULL if parsing failed.
   static playlistItemStatisticsFile *newplaylistItemStatisticsFile(const QDomElementYUView &root, const QString &playlistFilePath);

--- a/source/playlistItemStatisticsFile.h
+++ b/source/playlistItemStatisticsFile.h
@@ -42,19 +42,19 @@ public:
   playlistItemStatisticsFile(const QString &itemNameOrFileName);
   virtual ~playlistItemStatisticsFile();
 
-  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) const Q_DECL_OVERRIDE;
 
-  virtual QSize getSize() Q_DECL_OVERRIDE { return statSource.statFrameSize; }
+  virtual QSize getSize() const Q_DECL_OVERRIDE { return statSource.statFrameSize; }
   
   // Return the info title and info list to be shown in the fileInfo groupBox.
-  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "Statistics File info"; }
-  virtual QList<infoItem> getInfoList() Q_DECL_OVERRIDE;
+  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "Statistics File info"; }
+  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
 
   /* Get the title of the properties panel. The child class has to overload this.
    * This can be different depending on the type of playlistItem.
    * For example a playlistItemYUVFile will return "YUV File properties".
   */
-  virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "Statistics File Properties"; }
+  virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "Statistics File Properties"; }
 
   // ------ Statistics ----
 
@@ -63,7 +63,7 @@ public:
 
   virtual void drawItem(QPainter *painter, int frameIdx, double zoomFactor, bool playback) Q_DECL_OVERRIDE;
 
-  virtual indexRange getStartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, maxPOC); }
+  virtual indexRange getStartEndFrameLimits() const Q_DECL_OVERRIDE { return indexRange(0, maxPOC); }
 
   // Create a new playlistItemStatisticsFile from the playlist file entry. Return NULL if parsing failed.
   static playlistItemStatisticsFile *newplaylistItemStatisticsFile(const QDomElementYUView &root, const QString &playlistFilePath);
@@ -72,7 +72,7 @@ public:
   virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) Q_DECL_OVERRIDE { Q_UNUSED(frameIdx); return ValuePairListSets("Stats",statSource.getValuesAt(pixelPos)); }
 
   // A statistics file source of course provides statistics
-  virtual bool              providesStatistics()   { return true; }
+  virtual bool              providesStatistics() const Q_DECL_OVERRIDE { return true; }
   virtual statisticHandler *getStatisticsHandler() { return &statSource; }
 
   // Add the file type filters and the extensions of files that we can load.
@@ -102,7 +102,7 @@ private:
   //! Scan the header: What types are saved in this file?
   void readHeaderFromFile();
   
-  QStringList parseCSVLine(const QString &line, char delimiter);
+  QStringList parseCSVLine(const QString &line, char delimiter) const;
 
   // A list of file positions where each POC/type starts
   QMap<int, QMap<int, qint64> > pocTypeStartList;

--- a/source/playlistItemStatisticsFile.h
+++ b/source/playlistItemStatisticsFile.h
@@ -39,10 +39,10 @@ public:
 
   /*
   */
-  playlistItemStatisticsFile(QString itemNameOrFileName);
+  playlistItemStatisticsFile(const QString &itemNameOrFileName);
   virtual ~playlistItemStatisticsFile();
 
-  virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
 
   virtual QSize getSize() Q_DECL_OVERRIDE { return statSource.statFrameSize; }
   
@@ -66,10 +66,10 @@ public:
   virtual indexRange getstartEndFrameLimits() Q_DECL_OVERRIDE { return indexRange(0, maxPOC); }
 
   // Create a new playlistItemStatisticsFile from the playlist file entry. Return NULL if parsing failed.
-  static playlistItemStatisticsFile *newplaylistItemStatisticsFile(QDomElementYUView root, QString playlistFilePath);
+  static playlistItemStatisticsFile *newplaylistItemStatisticsFile(const QDomElementYUView &root, const QString &playlistFilePath);
 
   // Override from playlistItem. Return the statistics values under the given pixel position.
-  virtual ValuePairListSets getPixelValues(QPoint pixelPos, int frameIdx) Q_DECL_OVERRIDE { Q_UNUSED(frameIdx); return ValuePairListSets("Stats",statSource.getValuesAt(pixelPos)); }
+  virtual ValuePairListSets getPixelValues(const QPoint &pixelPos, int frameIdx) Q_DECL_OVERRIDE { Q_UNUSED(frameIdx); return ValuePairListSets("Stats",statSource.getValuesAt(pixelPos)); }
 
   // A statistics file source of course provides statistics
   virtual bool              providesStatistics()   { return true; }
@@ -102,7 +102,7 @@ private:
   //! Scan the header: What types are saved in this file?
   void readHeaderFromFile();
   
-  QStringList parseCSVLine(QString line, char delimiter);
+  QStringList parseCSVLine(const QString &line, char delimiter);
 
   // A list of file positions where each POC/type starts
   QMap<int, QMap<int, qint64> > pocTypeStartList;

--- a/source/playlistItemText.cpp
+++ b/source/playlistItemText.cpp
@@ -31,7 +31,7 @@
 
 #include <QDebug>
 
-playlistItemText::playlistItemText(QString initialText)
+playlistItemText::playlistItemText(const QString &initialText)
   : playlistItemStatic( QString("Text: \"%1\"").arg(initialText) )
 {
   // Set the properties of the playlistItem
@@ -149,7 +149,7 @@ void playlistItemText::on_textEdit_textChanged()
   emit signalItemChanged(true, false);
 }
 
-void playlistItemText::savePlaylist(QDomElement &root, QDir playlistDir)
+void playlistItemText::savePlaylist(QDomElement &root, const QDir &playlistDir)
 {
   Q_UNUSED(playlistDir);
 
@@ -167,7 +167,7 @@ void playlistItemText::savePlaylist(QDomElement &root, QDir playlistDir)
   root.appendChild(d);
 }
 
-playlistItemText *playlistItemText::newplaylistItemText(QDomElementYUView root)
+playlistItemText *playlistItemText::newplaylistItemText(const QDomElementYUView &root)
 {
   // Get the text and create a new playlistItemText
   QString text = root.findChildValue("text");

--- a/source/playlistItemText.cpp
+++ b/source/playlistItemText.cpp
@@ -149,7 +149,7 @@ void playlistItemText::on_textEdit_textChanged()
   emit signalItemChanged(true, false);
 }
 
-void playlistItemText::savePlaylist(QDomElement &root, const QDir &playlistDir)
+void playlistItemText::savePlaylist(QDomElement &root, const QDir &playlistDir) const
 {
   Q_UNUSED(playlistDir);
 
@@ -207,7 +207,7 @@ void playlistItemText::drawItem(QPainter *painter, int frameIdx, double zoomFact
   painter->drawText( textRect, text );
 }
 
-QSize playlistItemText::getSize()
+QSize playlistItemText::getSize() const
 {
   QFontMetrics metrics(font);
   return metrics.size(0, text);

--- a/source/playlistItemText.h
+++ b/source/playlistItemText.h
@@ -39,7 +39,7 @@ public:
 
   // ------ Overload from playlistItem
 
-  virtual QString getInfoTitel() Q_DECL_OVERRIDE { return "Text Info"; }
+  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "Text Info"; }
 
   virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "Text Properties"; }
 

--- a/source/playlistItemText.h
+++ b/source/playlistItemText.h
@@ -34,7 +34,7 @@ class playlistItemText :
   Q_OBJECT
 
 public:
-  playlistItemText(QString initialText = PLAYLISTITEMTEXT_DEFAULT_TEXT);
+  playlistItemText(const QString &initialText = PLAYLISTITEMTEXT_DEFAULT_TEXT);
   playlistItemText(playlistItemText *cloneFromTxt);
 
   // ------ Overload from playlistItem
@@ -47,9 +47,9 @@ public:
   virtual QSize getSize() Q_DECL_OVERRIDE;
 
   // Overload from playlistItem. Save the text item to playlist.
-  virtual void savePlaylist(QDomElement &root, QDir playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
   // Create a new playlistItemText from the playlist file entry. Return NULL if parsing failed.
-  static playlistItemText *newplaylistItemText(QDomElementYUView stringElement);
+  static playlistItemText *newplaylistItemText(const QDomElementYUView &stringElement);
 
   // Draw the text item. Since isIndexedByFrame() returned false, this item is not indexed by frames
   // and the given value of frameIdx will be ignored.

--- a/source/playlistItemText.h
+++ b/source/playlistItemText.h
@@ -39,15 +39,15 @@ public:
 
   // ------ Overload from playlistItem
 
-  virtual QString getInfoTitle() Q_DECL_OVERRIDE { return "Text Info"; }
+  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "Text Info"; }
 
-  virtual QString getPropertiesTitle() Q_DECL_OVERRIDE { return "Text Properties"; }
+  virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "Text Properties"; }
 
   // Get the text size (using the current text, font/text size ...)
-  virtual QSize getSize() Q_DECL_OVERRIDE;
+  virtual QSize getSize() const Q_DECL_OVERRIDE;
 
   // Overload from playlistItem. Save the text item to playlist.
-  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) Q_DECL_OVERRIDE;
+  virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) const Q_DECL_OVERRIDE;
   // Create a new playlistItemText from the playlist file entry. Return NULL if parsing failed.
   static playlistItemText *newplaylistItemText(const QDomElementYUView &stringElement);
 

--- a/source/playlistItems.cpp
+++ b/source/playlistItems.cpp
@@ -48,7 +48,7 @@ namespace playlistItems
     filters.append(filtersList);
   }
 
-  playlistItem *createPlaylistItemFromFile(QString fileName)
+  playlistItem *createPlaylistItemFromFile(const QString &fileName)
   {
     QFileInfo fi(fileName);
     QString ext = fi.suffix().toLower();
@@ -117,7 +117,7 @@ namespace playlistItems
 
   // Load one playlist item. Load it and return it. This function is seperate so it can be called
   // recursively if an item has children.
-  playlistItem *loadPlaylistItem(QDomElement elem, QString filePath)
+  playlistItem *loadPlaylistItem(const QDomElement &elem, const QString &filePath)
   {
     playlistItem *newItem = NULL;
     bool parseChildren = false;

--- a/source/playlistItems.h
+++ b/source/playlistItems.h
@@ -38,11 +38,11 @@ namespace playlistItems
   void getSupportedFormatsFilters(QStringList &filters);
 
   // When given a file, this function will create the correct playlist item (depending on the file extension)
-  playlistItem *createPlaylistItemFromFile(QString fileName);
+  playlistItem *createPlaylistItemFromFile(const QString &fileName);
 
   // Load a playlist item (and all of it's children) from the playlist
   // Append all loaded playlist items to the list plItemAndIDList (alongside the IDs that were saved in the playlist file)
-  playlistItem *loadPlaylistItem(QDomElement elem, QString filePath);
+  playlistItem *loadPlaylistItem(const QDomElement &elem, const QString &filePath);
 }
 
 #endif // PLAYLISTITEMHANDLER_H

--- a/source/playlistTreeWidget.cpp
+++ b/source/playlistTreeWidget.cpp
@@ -47,7 +47,7 @@ PlaylistTreeWidget::PlaylistTreeWidget(QWidget *parent) : QTreeWidget(parent)
   connect(this, SIGNAL(itemSelectionChanged()), this, SLOT(slotSelectionChanged()));
 }
 
-playlistItem* PlaylistTreeWidget::getDropTarget(const QPoint &pos)
+playlistItem* PlaylistTreeWidget::getDropTarget(const QPoint &pos) const
 {
   playlistItem *pItem = dynamic_cast<playlistItem*>(this->itemAt(pos));
   if (pItem != NULL)
@@ -291,7 +291,7 @@ void PlaylistTreeWidget::contextMenuEvent(QContextMenuEvent * event)
     cloneSelectedItem();
 }
 
-void PlaylistTreeWidget::getSelectedItems( playlistItem *&item1, playlistItem *&item2 )
+void PlaylistTreeWidget::getSelectedItems( playlistItem *&item1, playlistItem *&item2 ) const
 {
   QList<QTreeWidgetItem*> items = selectedItems();
   item1 = NULL;
@@ -857,7 +857,7 @@ void PlaylistTreeWidget::setSelectedItems(playlistItem *item1, playlistItem *ite
   }
 }
 
-QList<playlistItem*> PlaylistTreeWidget::getAllPlaylistItems()
+QList<playlistItem*> PlaylistTreeWidget::getAllPlaylistItems() const
 {
   QList<playlistItem*> returnList;
   for (int i = 0; i < topLevelItemCount(); i++)

--- a/source/playlistTreeWidget.cpp
+++ b/source/playlistTreeWidget.cpp
@@ -47,7 +47,7 @@ PlaylistTreeWidget::PlaylistTreeWidget(QWidget *parent) : QTreeWidget(parent)
   connect(this, SIGNAL(itemSelectionChanged()), this, SLOT(slotSelectionChanged()));
 }
 
-playlistItem* PlaylistTreeWidget::getDropTarget(QPoint pos)
+playlistItem* PlaylistTreeWidget::getDropTarget(const QPoint &pos)
 {
   playlistItem *pItem = dynamic_cast<playlistItem*>(this->itemAt(pos));
   if (pItem != NULL)
@@ -588,7 +588,7 @@ void PlaylistTreeWidget::loadFiles(QStringList files)
   }
 }
 
-void PlaylistTreeWidget::addFileToRecentFileSetting(QString fileName)
+void PlaylistTreeWidget::addFileToRecentFileSetting(const QString &fileName)
 {
   QSettings settings;
   QStringList files = settings.value("recentFileList").toStringList();
@@ -647,7 +647,7 @@ void PlaylistTreeWidget::savePlaylistToFile()
   p_isSaved = true;
 }
 
-void PlaylistTreeWidget::loadPlaylistFile(QString filePath)
+void PlaylistTreeWidget::loadPlaylistFile(const QString &filePath)
 {
   if (topLevelItemCount() != 0)
   {

--- a/source/playlistTreeWidget.cpp
+++ b/source/playlistTreeWidget.cpp
@@ -138,7 +138,7 @@ void PlaylistTreeWidget::dropEvent(QDropEvent *event)
   //playlistItem *pItem = dynamic_cast<playlistItem*>( item );
   //pItem->showPropertiesWidget();
   //propertiesDockWidget->setWindowTitle( pItem->getPropertiesTitle() );
-  //fileInfoGroupBox->setFileInfo( pItem->getInfoTitel(), pItem->getInfoList() );
+  //fileInfoGroupBox->setFileInfo( pItem->getInfoTitle(), pItem->getInfoList() );
 }
 
 void PlaylistTreeWidget::updateAllContainterItems()
@@ -467,7 +467,7 @@ void PlaylistTreeWidget::deleteSelectedPlaylistItems()
     // If the item is in a container item we have to inform the container that the item will be deleted.
     playlistItem *parentItem = plItem->parentPlaylistItem();
     if (parentItem)
-      parentItem->itemAboutToBeDeleter( plItem );
+      parentItem->itemAboutToBeDeleted( plItem );
 
     // If the item is 
     
@@ -508,7 +508,7 @@ void PlaylistTreeWidget::deleteAllPlaylistItems()
     plItem->deleteLater();
   }
 
-  // Something was deleter. The playlist changed.
+  // Something was deleted. The playlist changed.
   emit playlistChanged();
 }
 

--- a/source/playlistTreeWidget.h
+++ b/source/playlistTreeWidget.h
@@ -138,10 +138,10 @@ protected slots:
 private:
 
   //
-  playlistItem* getDropTarget(QPoint pos);
+  playlistItem* getDropTarget(const QPoint &pos);
 
   // Load the given playlist file
-  void loadPlaylistFile(QString filePath);
+  void loadPlaylistFile(const QString &filePath);
 
   // If the playlist is changed and the changes have not been saved yet, this will be true.
   bool p_isSaved;
@@ -151,7 +151,7 @@ private:
   void updateAllContainterItems();
 
   // In the QSettings we keep a list of recent files. Add the given file.
-  void addFileToRecentFileSetting(QString file);
+  void addFileToRecentFileSetting(const QString &file);
 
   // Append the new item at the end of the playlist and connect signals/slots
   void appendNewItem(playlistItem *item, bool emitplaylistChanged = true);

--- a/source/playlistTreeWidget.h
+++ b/source/playlistTreeWidget.h
@@ -53,7 +53,7 @@ public:
   QModelIndex indexForItem(playlistItem * item) { return indexFromItem((QTreeWidgetItem*)item); }
 
   // Get the first two selected items
-  void getSelectedItems(playlistItem *&first, playlistItem *&second);
+  void getSelectedItems(playlistItem *&first, playlistItem *&second) const;
   // Set (up to two) selected items
   void setSelectedItems(playlistItem *item1, playlistItem *item2);
 
@@ -66,7 +66,7 @@ public:
   void setViewStateHandler(viewStateHandler *handler) { stateHandler = handler; }
 
   // Return a list with all playlist items (also all child items)
-  QList<playlistItem*> getAllPlaylistItems();
+  QList<playlistItem*> getAllPlaylistItems() const;
   
 public slots:
   void savePlaylistToFile();
@@ -138,7 +138,7 @@ protected slots:
 private:
 
   //
-  playlistItem* getDropTarget(const QPoint &pos);
+  playlistItem* getDropTarget(const QPoint &pos) const;
 
   // Load the given playlist file
   void loadPlaylistFile(const QString &filePath);

--- a/source/playlistitemIndexed.cpp
+++ b/source/playlistitemIndexed.cpp
@@ -18,7 +18,7 @@
 
 #include "playlistitemIndexed.h"
 
-playlistItemIndexed::playlistItemIndexed(QString itemNameOrFileName) :
+playlistItemIndexed::playlistItemIndexed(const QString &itemNameOrFileName) :
   playlistItem(itemNameOrFileName)
 {
   frameRate = DEFAULT_FRAMERATE;
@@ -124,7 +124,7 @@ void playlistItemIndexed::appendPropertiesToPlaylist(QDomElementYUView &d)
 }
 
 // Load the start/end frame, sampling and frame rate from playlist
-void playlistItemIndexed::loadPropertiesFromPlaylist(QDomElementYUView root, playlistItemIndexed *newItem)
+void playlistItemIndexed::loadPropertiesFromPlaylist(const QDomElementYUView &root, playlistItemIndexed *newItem)
 {
   int startFrame = root.findChildValue("startFrame").toInt();
   int endFrame = root.findChildValue("endFrame").toInt();

--- a/source/playlistitemIndexed.cpp
+++ b/source/playlistitemIndexed.cpp
@@ -34,7 +34,7 @@ QLayout *playlistItemIndexed::createIndexControllers()
     
   ui.setupUi();
     
-  indexRange startEndFrameLimit = getstartEndFrameLimits();
+  indexRange startEndFrameLimit = getStartEndFrameLimits();
   if (startEndFrame == indexRange(-1,-1))
   {
     startEndFrame = startEndFrameLimit;
@@ -83,7 +83,7 @@ void playlistItemIndexed::slotVideoControlChanged()
 void playlistItemIndexed::setStartEndFrame(indexRange range, bool emitSignal)
 {
   // Set the new start/end frame (clip it first)
-  indexRange startEndFrameLimit = getstartEndFrameLimits();
+  indexRange startEndFrameLimit = getStartEndFrameLimits();
   startEndFrame.first = std::max(startEndFrameLimit.first, range.first);
   startEndFrame.second = std::min(startEndFrameLimit.second, range.second);
 
@@ -141,7 +141,7 @@ void playlistItemIndexed::slotUpdateFrameLimits()
   if (!startEndFrameChanged)
   {
     // The user did not change the start/end frame yet. If the new limits increase, we also move the startEndFrame range
-    indexRange startEndFrameLimit = getstartEndFrameLimits();
+    indexRange startEndFrameLimit = getStartEndFrameLimits();
     setStartEndFrame(startEndFrameLimit, false);
   }
   else

--- a/source/playlistitemIndexed.cpp
+++ b/source/playlistitemIndexed.cpp
@@ -112,7 +112,7 @@ void playlistItemIndexed::setStartEndFrame(indexRange range, bool emitSignal)
 }
 
 // For an indexed item we save the start/end, sampling and frame rate to the playlist
-void playlistItemIndexed::appendPropertiesToPlaylist(QDomElementYUView &d)
+void playlistItemIndexed::appendPropertiesToPlaylist(QDomElementYUView &d) const
 {
   // Append the playlist item properties
   playlistItem::appendPropertiesToPlaylist(d);

--- a/source/playlistitemIndexed.h
+++ b/source/playlistitemIndexed.h
@@ -46,7 +46,7 @@ public:
     Normally this is: (0, numFrames-1). This value can change. Just emit a
     signalItemChanged to update the limits.
   */
-  virtual indexRange getstartEndFrameLimits() = 0;
+  virtual indexRange getStartEndFrameLimits() = 0;
 
 protected slots:
   // A control of the indexed item (start/end/frameRate/sampling) changed

--- a/source/playlistitemIndexed.h
+++ b/source/playlistitemIndexed.h
@@ -36,17 +36,17 @@ public:
   playlistItemIndexed(const QString &itemNameOrFileName);
 
   // An indexed playlist item is indexed by frame (duh)
-  virtual bool       isIndexedByFrame()   Q_DECL_OVERRIDE Q_DECL_FINAL { return true;          }
-  virtual indexRange getFrameIndexRange() Q_DECL_OVERRIDE Q_DECL_FINAL { return startEndFrame; }
-  virtual double     getFrameRate()       Q_DECL_OVERRIDE Q_DECL_FINAL { return frameRate;     }
-  virtual int        getSampling()        Q_DECL_OVERRIDE Q_DECL_FINAL { return sampling;      }
+  virtual bool       isIndexedByFrame()   const Q_DECL_OVERRIDE Q_DECL_FINAL { return true;          }
+  virtual indexRange getFrameIndexRange() const Q_DECL_OVERRIDE Q_DECL_FINAL { return startEndFrame; }
+  virtual double     getFrameRate()       const Q_DECL_OVERRIDE Q_DECL_FINAL { return frameRate;     }
+  virtual int        getSampling()        const Q_DECL_OVERRIDE Q_DECL_FINAL { return sampling;      }
 
   /* If you inherit from this class (your playlist item is indexed by frame), you must
     provide the absolute minimum and maximum frame indices that the user can set.
     Normally this is: (0, numFrames-1). This value can change. Just emit a
     signalItemChanged to update the limits.
   */
-  virtual indexRange getStartEndFrameLimits() = 0;
+  virtual indexRange getStartEndFrameLimits() const = 0;
 
 protected slots:
   // A control of the indexed item (start/end/frameRate/sampling) changed
@@ -63,7 +63,7 @@ protected:
   void setStartEndFrame(indexRange range, bool emitSignal);
 
   // For an indexed item we save the start/end, sampling and frame rate to the playlist
-  void appendPropertiesToPlaylist(QDomElementYUView &d);
+  void appendPropertiesToPlaylist(QDomElementYUView &d) const;
 
   // Load the start/end frame, sampling and frame rate from playlist
   static void loadPropertiesFromPlaylist(const QDomElementYUView &root, playlistItemIndexed *newItem);

--- a/source/playlistitemIndexed.h
+++ b/source/playlistitemIndexed.h
@@ -33,7 +33,7 @@ class playlistItemIndexed :
 
 public:
 
-  playlistItemIndexed(QString itemNameOrFileName);
+  playlistItemIndexed(const QString &itemNameOrFileName);
 
   // An indexed playlist item is indexed by frame (duh)
   virtual bool       isIndexedByFrame()   Q_DECL_OVERRIDE Q_DECL_FINAL { return true;          }
@@ -66,7 +66,7 @@ protected:
   void appendPropertiesToPlaylist(QDomElementYUView &d);
 
   // Load the start/end frame, sampling and frame rate from playlist
-  static void loadPropertiesFromPlaylist(QDomElementYUView root, playlistItemIndexed *newItem);
+  static void loadPropertiesFromPlaylist(const QDomElementYUView &root, playlistItemIndexed *newItem);
 
   double     frameRate;
   int        sampling;

--- a/source/playlistitemStatic.cpp
+++ b/source/playlistitemStatic.cpp
@@ -40,7 +40,7 @@ QLayout *playlistItemStatic::createStaticTimeController()
 }
 
 // For a static item we save the duration to playlist
-void playlistItemStatic::appendPropertiesToPlaylist(QDomElementYUView &d)
+void playlistItemStatic::appendPropertiesToPlaylist(QDomElementYUView &d) const
 {
   // Append the playlist item properties
   playlistItem::appendPropertiesToPlaylist(d);

--- a/source/playlistitemStatic.cpp
+++ b/source/playlistitemStatic.cpp
@@ -18,7 +18,7 @@
 
 #include "playlistitemStatic.h"
 
-playlistItemStatic::playlistItemStatic(QString itemNameOrFileName) :
+playlistItemStatic::playlistItemStatic(const QString &itemNameOrFileName) :
     playlistItem(itemNameOrFileName)
 {
   duration = PLAYLISTITEMTEXT_DEFAULT_DURATION;
@@ -49,7 +49,7 @@ void playlistItemStatic::appendPropertiesToPlaylist(QDomElementYUView &d)
 }
 
 // Load the duration from playlist
-void playlistItemStatic::loadPropertiesFromPlaylist(QDomElementYUView root, playlistItemStatic *newItem)
+void playlistItemStatic::loadPropertiesFromPlaylist(const QDomElementYUView &root, playlistItemStatic *newItem)
 {
   newItem->duration = root.findChildValue("duration").toDouble();
   playlistItem::loadPropertiesFromPlaylist(root, newItem);

--- a/source/playlistitemStatic.h
+++ b/source/playlistitemStatic.h
@@ -35,7 +35,7 @@ class playlistItemStatic :
 
 public:
 
-  playlistItemStatic(QString itemNameOrFileName);
+  playlistItemStatic(const QString &itemNameOrFileName);
 
   // This is a static item and it is not indexed by frame.
   virtual bool isIndexedByFrame() Q_DECL_OVERRIDE Q_DECL_FINAL { return false; }
@@ -57,7 +57,7 @@ protected:
 
   // Load/Save from/to playlist
   void appendPropertiesToPlaylist(QDomElementYUView &d);
-  static void loadPropertiesFromPlaylist(QDomElementYUView root, playlistItemStatic *newItem);
+  static void loadPropertiesFromPlaylist(const QDomElementYUView &root, playlistItemStatic *newItem);
 
   // The duration that this item is shown for
   double duration;

--- a/source/playlistitemStatic.h
+++ b/source/playlistitemStatic.h
@@ -38,10 +38,10 @@ public:
   playlistItemStatic(const QString &itemNameOrFileName);
 
   // This is a static item and it is not indexed by frame.
-  virtual bool isIndexedByFrame() Q_DECL_OVERRIDE Q_DECL_FINAL { return false; }
+  virtual bool isIndexedByFrame() const Q_DECL_OVERRIDE Q_DECL_FINAL { return false; }
 
   // A static item is shown for a certain duration
-  virtual double getDuration() Q_DECL_OVERRIDE Q_DECL_FINAL { return duration; }
+  virtual double getDuration() const Q_DECL_OVERRIDE Q_DECL_FINAL { return duration; }
 
 public slots:
   void on_durationSpinBox_valueChanged(double val) { duration = val; }
@@ -56,7 +56,7 @@ protected:
   QLayout *createStaticTimeController();
 
   // Load/Save from/to playlist
-  void appendPropertiesToPlaylist(QDomElementYUView &d);
+  void appendPropertiesToPlaylist(QDomElementYUView &d) const;
   static void loadPropertiesFromPlaylist(const QDomElementYUView &root, playlistItemStatic *newItem);
 
   // The duration that this item is shown for

--- a/source/propertiesWidget.cpp
+++ b/source/propertiesWidget.cpp
@@ -46,7 +46,7 @@ void PropertiesWidget::currentSelectedItemsChanged(playlistItem *item1, playlist
     if (item1)
       parentWidget()->setWindowTitle( item1->getPropertiesTitle() );
     else
-      parentWidget()->setWindowTitle( PROPERTIESWIDGET_DEFAULT_WINDOW_TITEL );
+      parentWidget()->setWindowTitle( PROPERTIESWIDGET_DEFAULT_WINDOW_TITLE );
   }
 
   if (item1)

--- a/source/propertiesWidget.h
+++ b/source/propertiesWidget.h
@@ -25,7 +25,7 @@
 #include <QVBoxLayout>
 
 // This is the text that will be shown in the dockWidgets title if no playlistitem is selected
-#define PROPERTIESWIDGET_DEFAULT_WINDOW_TITEL "Properties"
+#define PROPERTIESWIDGET_DEFAULT_WINDOW_TITLE "Properties"
 
 class PropertiesWidget : public QWidget
 {

--- a/source/settingswindow.cpp
+++ b/source/settingswindow.cpp
@@ -75,7 +75,7 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
   loadSettings();
 }
 
-unsigned int SettingsWindow::getCacheSizeInMB()
+unsigned int SettingsWindow::getCacheSizeInMB() const
 {
   unsigned int useMem = 0;
   // update video cache

--- a/source/settingswindow.h
+++ b/source/settingswindow.h
@@ -31,7 +31,7 @@ public:
   explicit SettingsWindow(QWidget *parent = 0);
 
   // Get settings
-  unsigned int getCacheSizeInMB();
+  unsigned int getCacheSizeInMB() const;
 
 public slots:
   void show() { loadSettings(); QWidget::show(); }

--- a/source/splitViewWidget.cpp
+++ b/source/splitViewWidget.cpp
@@ -434,7 +434,7 @@ void splitViewWidget::updatePixelPositions()
   }
 }
 
-void splitViewWidget::paintZoomBox(int view, QPainter *painter, int xSplit, QPoint drawArea_botR, playlistItem *item, int frame, QPoint pixelPos, bool pixelPosInItem, double zoomFactor)
+void splitViewWidget::paintZoomBox(int view, QPainter *painter, int xSplit, const QPoint &drawArea_botR, playlistItem *item, int frame, const QPoint &pixelPos, bool pixelPosInItem, double zoomFactor)
 {
   if (!drawZoomBox)
     return;
@@ -870,7 +870,7 @@ void splitViewWidget::wheelEvent (QWheelEvent *e)
   }
 }
 
-void splitViewWidget::zoomIn(QPoint zoomPoint)
+void splitViewWidget::zoomIn(const QPoint &zoomPoint)
 {
   // The zoom point works like this: After the zoom operation the pixel at zoomPoint shall
   // still be at the same position (zoomPoint)
@@ -927,7 +927,7 @@ void splitViewWidget::zoomIn(QPoint zoomPoint)
   }
 }
 
-void splitViewWidget::zoomOut(QPoint zoomPoint)
+void splitViewWidget::zoomOut(const QPoint &zoomPoint)
 {
   if (!zoomPoint.isNull() && SPLITVIEWWIDGET_ZOOM_OUT_MOUSE == 1)
   {
@@ -1304,7 +1304,7 @@ void splitViewWidget::getViewState(QPoint &offset, double &zoom, bool &split, do
     mode = 1;
 }
 
-void splitViewWidget::setViewState(QPoint offset, double zoom, bool split, double splitPoint, int mode)
+void splitViewWidget::setViewState(const QPoint &offset, double zoom, bool split, double splitPoint, int mode)
 {
   // Set all the values
   if (isSeparateWidget)

--- a/source/splitViewWidget.cpp
+++ b/source/splitViewWidget.cpp
@@ -1292,7 +1292,7 @@ void splitViewWidget::on_separateViewGroupBox_toggled(bool state)
   emit signalShowSeparateWindow(state);
 }
 
-void splitViewWidget::getViewState(QPoint &offset, double &zoom, bool &split, double &splitPoint, int &mode) 
+void splitViewWidget::getViewState(QPoint &offset, double &zoom, bool &split, double &splitPoint, int &mode) const
 { 
   offset = centerOffset; 
   zoom = zoomFactor; 

--- a/source/splitViewWidget.h
+++ b/source/splitViewWidget.h
@@ -87,7 +87,7 @@ public:
   bool handleKeyPress(QKeyEvent *event);
 
   // Get and set the current state (center point and zoom, is splitting active? if yes the split line position)
-  void getViewState(QPoint &offset, double &zoom, bool &split, double &splitPoint, int &mode);
+  void getViewState(QPoint &offset, double &zoom, bool &split, double &splitPoint, int &mode) const;
   void setViewState(const QPoint &offset,  double zoom,  bool split,  double splitPoint,  int mode);
 
   // Are the views linked? Only the primary view will return the correct value.

--- a/source/splitViewWidget.h
+++ b/source/splitViewWidget.h
@@ -70,7 +70,7 @@ public:
   // Set the minimum size hint. This will only be valid until the next showEvent. This is used when adding the widget
   // as a new central widget. Then this size guarantees that the splitVie will have a certain size.
   // Call before adding the widget using setCenterWidget().
-  void setMinimumSizeHint(QSize size) { minSizeHint = size; }
+  void setMinimumSizeHint(const QSize &size) { minSizeHint = size; }
 
   // Update the splitView. If playback is running, call the second funtion so that the control can update conditionally.
   void update() { QWidget::update(); }
@@ -88,7 +88,7 @@ public:
 
   // Get and set the current state (center point and zoom, is splitting active? if yes the split line position)
   void getViewState(QPoint &offset, double &zoom, bool &split, double &splitPoint, int &mode);
-  void setViewState(QPoint offset,  double zoom,  bool split,  double splitPoint,  int mode);
+  void setViewState(const QPoint &offset,  double zoom,  bool split,  double splitPoint,  int mode);
 
   // Are the views linked? Only the primary view will return the correct value.
   bool viewsLinked() { return linkViews; }
@@ -113,8 +113,8 @@ public slots:
 
   /// Zoom in/out to the given point. If no point is given, the center of the view will be
   /// used for the zoom operation.
-  void zoomIn(QPoint zoomPoint = QPoint());
-  void zoomOut(QPoint zoomPoint = QPoint());
+  void zoomIn(const QPoint &zoomPoint = QPoint());
+  void zoomOut(const QPoint &zoomPoint = QPoint());
 
   // Update the control and emit signalShowSeparateWindow(bool).
   // This can be connected from the main window to allow keyboard shortcuts.
@@ -192,7 +192,7 @@ protected:
   bool   drawZoomBox;            //!< If set to true, the paint event will draw the zoom box(es)
   QPoint zoomBoxMousePosition;   //!< If we are drawing the zoom box(es) we have to know where the mouse currently is.
   QColor zoomBoxBackgroundColor; //!< The color of the zoom box background (read from settings)
-  void   paintZoomBox(int view, QPainter *painter, int xSplit, QPoint drawArea_botR, playlistItem *item, int frame, QPoint pixelPos, bool pixelPosInItem, double zoomFactor);
+  void   paintZoomBox(int view, QPainter *painter, int xSplit, const QPoint &drawArea_botR, playlistItem *item, int frame, const QPoint &pixelPos, bool pixelPosInItem, double zoomFactor);
 
   //!< Using the current mouse position, calculate the position in the items under the mouse (per view)
   void   updatePixelPositions();

--- a/source/statisticHandler.cpp
+++ b/source/statisticHandler.cpp
@@ -237,7 +237,7 @@ ValuePairList statisticHandler::getValuesAt(const QPoint &pos)
       if (statsList.size() == 0 && typeID == INT_INVALID) // no active statistics
         continue;
 
-      StatisticsType* aType = getStatisticsType(typeID);
+      const StatisticsType* aType = getStatisticsType(typeID);
       Q_ASSERT(aType->typeID != INT_INVALID && aType->typeID == typeID);
 
       // find item of this type at requested position
@@ -310,7 +310,7 @@ bool statisticHandler::setStatisticsTypeList(const StatisticsTypeList &typeList)
 
 /* Check if at least one of the statistics is actually displayed.
 */
-bool statisticHandler::anyStatisticsRendered()
+bool statisticHandler::anyStatisticsRendered() const
 {
   for (int i = 0; i<statsTypeList.count(); i++)
   {
@@ -572,7 +572,7 @@ void statisticHandler::deleteSecondaryStatisticsHandlerControls()
   itemArrowCheckboxes[1].clear();
 }
 
-void statisticHandler::savePlaylist(QDomElementYUView &root)
+void statisticHandler::savePlaylist(QDomElementYUView &root) const
 {
   for (int row = 0; row < statsTypeList.length(); ++row)
   {

--- a/source/statisticHandler.cpp
+++ b/source/statisticHandler.cpp
@@ -223,7 +223,7 @@ StatisticsType* statisticHandler::getStatisticsType(int typeID)
 
 // return raw(!) value of frontmost, active statistic item at given position
 // Info is always read from the current buffer. So these values are only valid if a draw event occured first.
-ValuePairList statisticHandler::getValuesAt(QPoint pos)
+ValuePairList statisticHandler::getValuesAt(const QPoint &pos)
 {
   ValuePairList valueList;
 
@@ -280,10 +280,10 @@ ValuePairList statisticHandler::getValuesAt(QPoint pos)
  * we do not overwrite our statistics type, we just change their parameters
  * return if something has changed where a redraw would be necessary
 */
-bool statisticHandler::setStatisticsTypeList(const StatisticsTypeList & typeList)
+bool statisticHandler::setStatisticsTypeList(const StatisticsTypeList &typeList)
 {
   bool bChanged = false;
-  foreach(const StatisticsType & aType, typeList)
+  foreach(const StatisticsType &aType, typeList)
   {
     StatisticsType* internalType = getStatisticsType(aType.typeID);
 
@@ -588,7 +588,7 @@ void statisticHandler::savePlaylist(QDomElementYUView &root)
   }
 }
 
-void statisticHandler::loadPlaylist(QDomElementYUView &root)
+void statisticHandler::loadPlaylist(const QDomElementYUView &root)
 {
   QString statItemName;
   int i = 0;

--- a/source/statisticHandler.h
+++ b/source/statisticHandler.h
@@ -47,11 +47,11 @@ public:
   ValuePairList getValuesAt(const QPoint &pos);
 
   // Get the list of all statistics that this source can provide
-  StatisticsTypeList getStatisticsTypeList() { return statsTypeList; }
+  StatisticsTypeList getStatisticsTypeList() const { return statsTypeList; }
   // Set the attributes of the statistics that this source can provide (rendered, drawGrid...)
   bool setStatisticsTypeList(const StatisticsTypeList &typeList);
   // Return true if any of the statistics are actually rendered
-  bool anyStatisticsRendered();
+  bool anyStatisticsRendered() const;
 
   // Create all the checkboxes/spliders and so on. If recreateControlsOnly is set, the ui is assumed to be already
   // initialized. Only all the controls are created.
@@ -82,7 +82,7 @@ public:
   void clearStatTypes();
 
   // Load/Save status of statistics from playlist file
-  void savePlaylist(QDomElementYUView &root);
+  void savePlaylist(QDomElementYUView &root) const;
   void loadPlaylist(const QDomElementYUView &root);
 
   QHash<int, StatisticsItemList> statsCache; // cache of the statistics for the current POC [statsTypeID]

--- a/source/statisticHandler.h
+++ b/source/statisticHandler.h
@@ -44,7 +44,7 @@ public:
   statisticHandler();
 
   // Get the statistics values under the curso pos (if they are visible)
-  ValuePairList getValuesAt(QPoint pos);
+  ValuePairList getValuesAt(const QPoint &pos);
 
   // Get the list of all statistics that this source can provide
   StatisticsTypeList getStatisticsTypeList() { return statsTypeList; }
@@ -71,7 +71,7 @@ public:
   void paintStatistics(QPainter *painter, int frameIdx, double zoomFactor);
 
   // Get the statisticsType with the given typeID from p_statsTypeList
-  StatisticsType* getStatisticsType(int typeID);
+  StatisticsType *getStatisticsType(int typeID);
 
   int lastFrameIdx;
   QSize statFrameSize;
@@ -83,7 +83,7 @@ public:
 
   // Load/Save status of statistics from playlist file
   void savePlaylist(QDomElementYUView &root);
-  void loadPlaylist(QDomElementYUView &root);
+  void loadPlaylist(const QDomElementYUView &root);
 
   QHash<int, StatisticsItemList> statsCache; // cache of the statistics for the current POC [statsTypeID]
   int statsCacheFrameIdx;

--- a/source/statisticsExtensions.h
+++ b/source/statisticsExtensions.h
@@ -59,7 +59,7 @@ public:
   }
   virtual ~ColorRange() {} // This class is meant to be derived from.
 
-  virtual QColor getColor(float value)
+  virtual QColor getColor(float value) const
   {
     // clamp the value to [min max]
     if (value > rangeMax) value = (float)rangeMax;
@@ -122,7 +122,7 @@ public:
     setTypeFromName(rangeName);
   }
 
-  virtual QColor getColor(float value)
+  virtual QColor getColor(float value) const
   {
     // clamp the value to [min max]
     if (value > rangeMax)
@@ -446,7 +446,7 @@ public:
 
   // If the internal valueMap can map the value to text, text and value will be returned.
   // Otherwise just the value as QString will be returned.
-  QString getValueTxt(int val)
+  QString getValueTxt(int val) const
   {
     if (valMap.contains(val))
     {

--- a/source/statisticsExtensions.h
+++ b/source/statisticsExtensions.h
@@ -34,14 +34,14 @@ typedef QMap<int,QColor> ColorMap;
 class ColorRange {
 public:
   ColorRange() {}
-  ColorRange(int min, QColor colMin, int max, QColor colMax)
+  ColorRange(int min, const QColor &colMin, int max, const QColor &colMax)
   {
     rangeMin = min;
     rangeMax = max;
     minColor = colMin;
     maxColor = colMax;
   }
-  ColorRange(QStringList row)
+  ColorRange(const QStringList &row)
   {
     rangeMin = row[2].toInt();
     unsigned char minColorR = row[4].toInt();
@@ -107,14 +107,14 @@ enum defaultColormaps_t {
 class DefaultColorRange : public ColorRange
 {
 public:
-  DefaultColorRange(QString rangeName, int min, int max)
+  DefaultColorRange(const QString &rangeName, int min, int max)
   {
     rangeMin = min;
     rangeMax = max;
     setTypeFromName(rangeName);
   }
 
-  DefaultColorRange(QStringList &row)
+  DefaultColorRange(const QStringList &row)
   {
     rangeMin = row[2].toInt();
     rangeMax = row[3].toInt();
@@ -329,7 +329,7 @@ public:
   }
 
 private:
-  void setTypeFromName(QString rangeName)
+  void setTypeFromName(const QString &rangeName)
   {
     if (rangeName == "jet")
       type = jetColormap;
@@ -393,7 +393,7 @@ public:
     scaleToBlockSize = false;
     visualizationType = colorRangeType;
   }
-  StatisticsType(int tID, QString sName, visualizationType_t visType)
+  StatisticsType(int tID, const QString &sName, visualizationType_t visType)
   {
     typeID = tID;
     typeName = sName;
@@ -405,7 +405,7 @@ public:
     scaleToBlockSize = false;
     visualizationType = visType;
   }
-  StatisticsType(int tID, QString sName, QString defaultColorRangeName, int rangeMin, int rangeMax) :
+  StatisticsType(int tID, const QString &sName, const QString &defaultColorRangeName, int rangeMin, int rangeMax) :
     colorRange(new DefaultColorRange(defaultColorRangeName, rangeMin, rangeMax))
   {
     typeID = tID;
@@ -418,7 +418,7 @@ public:
     scaleToBlockSize = false;
     visualizationType = colorMapType;
   }
-  StatisticsType(int tID, QString sName, visualizationType_t visType, int cRangeMin, QColor cRangeMinColor, int cRangeMax, QColor cRangeMaxColor ) :
+  StatisticsType(int tID, const QString &sName, visualizationType_t visType, int cRangeMin, const QColor &cRangeMinColor, int cRangeMax, const QColor &cRangeMaxColor ) :
     colorRange(new ColorRange(cRangeMin, cRangeMinColor, cRangeMax, cRangeMaxColor))
   {
     typeID = tID;
@@ -432,7 +432,7 @@ public:
     visualizationType = visType;
   }
 
-  void readFromRow(QStringList row)
+  void readFromRow(const QStringList &row)
   {
     if( row.count() >= 5 )
     {

--- a/source/typedef.h
+++ b/source/typedef.h
@@ -140,7 +140,7 @@ private:
 #define MAX_SCALE_FACTOR 5
 #define MAX_RECENT_FILES 5
 
-template <typename T> inline T clip(const T& n, const T& lower, const T& upper) { return std::max(lower, std::min(n, upper)); }
+template <typename T> inline T clip(const T &n, const T &lower, const T &upper) { return std::max(lower, std::min(n, upper)); }
 
 // A pair of two strings
 typedef QPair<QString, QString> ValuePair;
@@ -153,23 +153,23 @@ public:
   // Create an empty list
   ValuePairListSets() {}
   // Create a ValuePairListSets from one list of values with a title.
-  ValuePairListSets(QString title, ValuePairList valueList)
+  ValuePairListSets(const QString &title, const ValuePairList &valueList)
   {
     append(title, valueList);
   }
   // Append a pair of QString and ValuePairList
-  void append(QString title, ValuePairList valueList)
+  void append(const QString &title, const ValuePairList &valueList)
   {
     QList::append( QPair<QString, ValuePairList>(title, valueList) );
   }
   // Append a list to this list
-  void append(ValuePairListSets list)
+  void append(const ValuePairListSets &list)
   {
     QList::append(list);
   }
 };
 
-Q_DECL_CONSTEXPR inline QPoint centerRoundTL(const QRect & r) Q_DECL_NOTHROW
+Q_DECL_CONSTEXPR inline QPoint centerRoundTL(const QRect &r) Q_DECL_NOTHROW
 {
   // cast avoids overflow on addition
   return QPoint(int((qint64(r.left())+r.right()-1)/2), int((qint64(r.top())+r.bottom()-1)/2));
@@ -184,8 +184,8 @@ public:
   QDomElementYUView(const QDomElement &a) : QDomElement(a) {};
   // Look through all the child items. If one child element exists with the given tagName, return it's text node.
   // All attributes of the child (if found) are appended to attributes.
-  QString findChildValue(QString tagName) { ValuePairList b; return findChildValue(tagName, b); }
-  QString findChildValue(QString tagName, ValuePairList &attributeList)
+  QString findChildValue(const QString &tagName) const { ValuePairList b; return findChildValue(tagName, b); }
+  QString findChildValue(const QString &tagName, ValuePairList &attributeList) const
   {
     for (QDomNode n = firstChild(); !n.isNull(); n = n.nextSibling())
       if (n.isElement() && n.toElement().tagName() == tagName)
@@ -203,7 +203,7 @@ public:
   }
   // Append a new child to this element with the given type, and name (as text node).
   // All QString pairs in ValuePairList are appended as attributes.
-  void appendProperiteChild(QString type, QString name, ValuePairList attributes=ValuePairList())
+  void appendProperiteChild(const QString &type, const QString &name, const ValuePairList &attributes=ValuePairList())
   {
     QDomElement newChild = ownerDocument().createElement(type);
     newChild.appendChild( ownerDocument().createTextNode(name) );

--- a/source/videoHandler.cpp
+++ b/source/videoHandler.cpp
@@ -123,17 +123,6 @@ QPixmap videoHandler::calculateDifference(frameHandler *item2, int frame, QList<
   return frameHandler::calculateDifference(item2, frame, differenceInfoList, amplificationFactor, markDifference);
 }
 
-QRgb videoHandler::getPixelVal(QPoint pixelPos)
-{
-  if (currentImage_frameIndex != currentFrameIdx)
-  {
-    currentImage = currentFrame.toImage();
-    currentImage_frameIndex = currentFrameIdx;
-  }
-
-  return currentImage.pixel( pixelPos );
-}
-
 QRgb videoHandler::getPixelVal(int x, int y)
 {
   if (currentImage_frameIndex != currentFrameIdx)
@@ -186,7 +175,7 @@ void videoHandler::cachingTimerEvent()
 }
 
 // Compute the MSE between the given char sources for numPixels bytes
-float videoHandler::computeMSE( unsigned char *ptr, unsigned char *ptr2, int numPixels ) const
+float videoHandler::computeMSE( unsigned char *ptr, unsigned char *ptr2, int numPixels )
 {
   float mse=0.0;
 

--- a/source/videoHandler.h
+++ b/source/videoHandler.h
@@ -61,11 +61,11 @@ public:
   // Try to guess and set the format (frameSize/srcPixelFormat) from the raw data in the right raw format.
   // If a file size is given, it is tested if the guessed format and the file size match. You can overload this
   // for any specific raw format. The default implementation does nothing.
-  virtual void setFormatFromCorrelation(QByteArray rawData, qint64 fileSize=-1) { Q_UNUSED(rawData); Q_UNUSED(fileSize); }
+  virtual void setFormatFromCorrelation(const QByteArray &rawData, qint64 fileSize=-1) { Q_UNUSED(rawData); Q_UNUSED(fileSize); }
 
   // If you know the frame size and the bit depth and the file size (and maybe a subFormat) then we can try to guess
   // the format from that. You can override this for a specific raw format. The default implementation does nothing.
-  virtual void setFormatFromSize(QSize size, int bitDepth, qint64 fileSize, QString subFormat) { Q_UNUSED(size); Q_UNUSED(bitDepth); Q_UNUSED(fileSize); Q_UNUSED(subFormat); }
+  virtual void setFormatFromSize(const QSize &size, int bitDepth, qint64 fileSize, const QString &subFormat) { Q_UNUSED(size); Q_UNUSED(bitDepth); Q_UNUSED(fileSize); Q_UNUSED(subFormat); }
 
   // The input frame buffer. After the signal signalRequestFrame(int) is emitted, the corresponding frame should be in here and
   // requestedFrame_idx should be set.
@@ -99,11 +99,10 @@ protected:
 
   // As the frameHandler implementations, we get the pixel values from currentImage. For a video, however, we
   // have to first check if currentImage contains the correct frame.
-  virtual QRgb getPixelVal(QPoint pixelPos) Q_DECL_OVERRIDE;
   virtual QRgb getPixelVal(int x, int y) Q_DECL_OVERRIDE;
 
   // Compute the MSE between the given char sources for numPixels bytes
-  float computeMSE( unsigned char *ptr, unsigned char *ptr2, int numPixels ) const;
+  static float computeMSE( unsigned char *ptr, unsigned char *ptr2, int numPixels );
 
   // The video handler want's to draw a frame but it's not cached yet and has to be loaded.
   // A sub class can change this implementation to request raw data of a certain format instead of an image.

--- a/source/videoHandler.h
+++ b/source/videoHandler.h
@@ -48,10 +48,10 @@ public:
     
   virtual void drawFrame(QPainter *painter, int frameIdx, double zoomFactor) Q_DECL_OVERRIDE;
 
-  virtual int getNrFramesCached() { return pixmapCache.size(); }
+  virtual int getNrFramesCached() const { return pixmapCache.size(); }
   // Caching: Load the frame with the given index into the cache
   virtual void cacheFrame(int frameIdx);
-  virtual QList<int> getCachedFrames() { return pixmapCache.keys(); }
+  virtual QList<int> getCachedFrames() const { return pixmapCache.keys(); }
 
   QImage getCurrentFrameAsImage() { return currentFrame.toImage(); }
     

--- a/source/videoHandlerDifference.cpp
+++ b/source/videoHandlerDifference.cpp
@@ -76,7 +76,7 @@ void videoHandlerDifference::setInputVideos(frameHandler *childVideo0, frameHand
   }
 }
 
-ValuePairList videoHandlerDifference::getPixelValues(QPoint pixelPos, int frameIdx, frameHandler *item2)
+ValuePairList videoHandlerDifference::getPixelValues(const QPoint &pixelPos, int frameIdx, frameHandler *item2)
 {
   Q_UNUSED(item2);
 
@@ -86,7 +86,7 @@ ValuePairList videoHandlerDifference::getPixelValues(QPoint pixelPos, int frameI
   return inputVideo[0]->getPixelValues(pixelPos, frameIdx, inputVideo[1]);
 }
 
-void videoHandlerDifference::drawPixelValues(QPainter *painter, int frameIdx, QRect videoRect, double zoomFactor, frameHandler *item2)
+void videoHandlerDifference::drawPixelValues(QPainter *painter, int frameIdx, const QRect &videoRect, double zoomFactor, frameHandler *item2)
 {
   Q_UNUSED(item2);
 

--- a/source/videoHandlerDifference.cpp
+++ b/source/videoHandlerDifference.cpp
@@ -41,7 +41,7 @@ void videoHandlerDifference::loadFrame(int frameIndex)
   emit signalHandlerChanged(false, false);
 }
 
-bool videoHandlerDifference::inputsValid()
+bool videoHandlerDifference::inputsValid() const
 {
   if (inputVideo[0] == NULL || inputVideo[1] == NULL)
     return false;
@@ -148,7 +148,7 @@ void videoHandlerDifference::slotDifferenceControlChanged()
   }
 }
 
-void videoHandlerDifference::reportFirstDifferencePosition(QList<infoItem> &infoList)
+void videoHandlerDifference::reportFirstDifferencePosition(QList<infoItem> &infoList) const
 {
   if (!inputsValid())
     return;
@@ -190,7 +190,7 @@ void videoHandlerDifference::reportFirstDifferencePosition(QList<infoItem> &info
   infoList.append( infoItem("Difference", "Frames are identical") );
 }
 
-bool videoHandlerDifference::hierarchicalPosition( int x, int y, int blockSize, int &firstX, int &firstY, int &partIndex, const QImage diffImg )
+bool videoHandlerDifference::hierarchicalPosition( int x, int y, int blockSize, int &firstX, int &firstY, int &partIndex, const QImage &diffImg ) const
 {
   if (x >= frameSize.width() || y >= frameSize.height())
     // This block is entirely outside of the picture

--- a/source/videoHandlerDifference.h
+++ b/source/videoHandlerDifference.h
@@ -46,10 +46,10 @@ public:
   QList<infoItem> differenceInfoList;
 
   // Draw the pixel values depending on the children type. E.g. if both children are YUV handlers, draw the YUV differences.
-  virtual void drawPixelValues(QPainter *painter, int frameIdx, QRect videoRect, double zoomFactor, frameHandler *item2=NULL) Q_DECL_OVERRIDE;
+  virtual void drawPixelValues(QPainter *painter, int frameIdx, const QRect &videoRect, double zoomFactor, frameHandler *item2=NULL) Q_DECL_OVERRIDE;
 
   // The difference overloads this and returns the difference values (A-B)
-  virtual ValuePairList getPixelValues(QPoint pixelPos, int frameIdx, frameHandler *item2=NULL) Q_DECL_OVERRIDE;
+  virtual ValuePairList getPixelValues(const QPoint &pixelPos, int frameIdx, frameHandler *item2=NULL) Q_DECL_OVERRIDE;
 
   // Calculate the position of the first difference and add the info to the list
   void reportFirstDifferencePosition(QList<infoItem> &infoList);

--- a/source/videoHandlerDifference.h
+++ b/source/videoHandlerDifference.h
@@ -34,7 +34,7 @@ public:
   virtual void loadFrameForCaching(int frameIndex, QPixmap &frameToCache) Q_DECL_OVERRIDE { Q_UNUSED(frameIndex); Q_UNUSED(frameToCache); };
   
   // Are both inputs valid and can be used?
-  bool inputsValid();
+  bool inputsValid() const;
 
   // Create the yuv controls and return a pointer to the layout. 
   virtual QLayout *createDifferenceHandlerControls();
@@ -52,7 +52,7 @@ public:
   virtual ValuePairList getPixelValues(const QPoint &pixelPos, int frameIdx, frameHandler *item2=NULL) Q_DECL_OVERRIDE;
 
   // Calculate the position of the first difference and add the info to the list
-  void reportFirstDifferencePosition(QList<infoItem> &infoList);
+  void reportFirstDifferencePosition(QList<infoItem> &infoList) const;
     
 private slots:
   void slotDifferenceControlChanged();
@@ -73,7 +73,7 @@ private:
   QPointer<frameHandler> inputVideo[2];
 
   // Recursively scan the LCU
-  bool hierarchicalPosition( int x, int y, int blockSize, int &firstX, int &firstY, int &partIndex, const QImage diffImg );
+  bool hierarchicalPosition(int x, int y, int blockSize, int &firstX, int &firstY, int &partIndex, const QImage &diffImg ) const;
 
   SafeUi<Ui::videoHandlerDifference> ui;
 

--- a/source/videoHandlerRGB.cpp
+++ b/source/videoHandlerRGB.cpp
@@ -137,7 +137,7 @@ videoHandlerRGB::RGBFormatList::RGBFormatList()
 
 /* Put all the names of the yuvPixelFormats into a list and return it
 */
-QStringList videoHandlerRGB::RGBFormatList::getFormattedNames()
+QStringList videoHandlerRGB::RGBFormatList::getFormattedNames() const
 {
   QStringList l;
   for (int i = 0; i < count(); i++)
@@ -147,7 +147,7 @@ QStringList videoHandlerRGB::RGBFormatList::getFormattedNames()
   return l;
 }
 
-videoHandlerRGB::rgbPixelFormat videoHandlerRGB::RGBFormatList::getFromName(const QString &name)
+videoHandlerRGB::rgbPixelFormat videoHandlerRGB::RGBFormatList::getFromName(const QString &name) const
 {
   for (int i = 0; i < count(); i++)
   {
@@ -163,7 +163,7 @@ videoHandlerRGB::RGBFormatList videoHandlerRGB::rgbPresetList;
 
 /* Get the number of bytes for a frame with this yuvPixelFormat and the given size
 */
-qint64 videoHandlerRGB::rgbPixelFormat::bytesPerFrame(const QSize &frameSize)
+qint64 videoHandlerRGB::rgbPixelFormat::bytesPerFrame(const QSize &frameSize) const
 {
   if (bitsPerValue == 0 || !frameSize.isValid())
     return 0;

--- a/source/videoHandlerRGB.cpp
+++ b/source/videoHandlerRGB.cpp
@@ -137,7 +137,7 @@ videoHandlerRGB::RGBFormatList::RGBFormatList()
 
 /* Put all the names of the yuvPixelFormats into a list and return it
 */
-QStringList videoHandlerRGB::RGBFormatList::getFormatedNames()
+QStringList videoHandlerRGB::RGBFormatList::getFormattedNames()
 {
   QStringList l;
   for (int i = 0; i < count(); i++)
@@ -272,7 +272,7 @@ QLayout *videoHandlerRGB::createRGBVideoHandlerControls(bool isSizeFixed)
   ui.setupUi();
 
   // Set all the values of the properties widget to the values of this class
-  ui.rgbFormatComboBox->addItems( rgbPresetList.getFormatedNames() );
+  ui.rgbFormatComboBox->addItems( rgbPresetList.getFormattedNames() );
   ui.rgbFormatComboBox->addItem( "Custom..." );
   int idx = rgbPresetList.indexOf( srcPixelFormat );
   if (idx == -1)

--- a/source/videoHandlerRGB.cpp
+++ b/source/videoHandlerRGB.cpp
@@ -35,7 +35,7 @@
 #define DEBUG_RGB(fmt,...) ((void)0)
 #endif
 
-videoHandlerRGB_CustomFormatDialog::videoHandlerRGB_CustomFormatDialog(QString rgbFormat, int bitDepth, bool planar, bool alpha)
+videoHandlerRGB_CustomFormatDialog::videoHandlerRGB_CustomFormatDialog(const QString &rgbFormat, int bitDepth, bool planar, bool alpha)
 {
   setupUi(this);
 
@@ -73,7 +73,7 @@ QString videoHandlerRGB::rgbPixelFormat::getName() const
   return name;
 }
 
-void videoHandlerRGB::rgbPixelFormat::setFromName(QString name)
+void videoHandlerRGB::rgbPixelFormat::setFromName(const QString &name)
 {
   if (name == "Unknown Pixel Format")
   {
@@ -109,16 +109,15 @@ QString videoHandlerRGB::rgbPixelFormat::getRGBFormatString() const
   return name;
 }
 
-void videoHandlerRGB::rgbPixelFormat::setRGBFormatFromString(QString format)
+void videoHandlerRGB::rgbPixelFormat::setRGBFormatFromString(const QString &format)
 {
-  format = format.toLower();
   for (int i = 0; i < 3; i++)
   {
-    if (format[i] == 'r')
+    if (format[i].toLower() == 'r')
       posR = i;
-    else if (format[i] == 'g')
+    else if (format[i].toLower() == 'g')
       posG = i;
-    else if (format[i] == 'b')
+    else if (format[i].toLower() == 'b')
       posB = i;
   }
 }
@@ -148,7 +147,7 @@ QStringList videoHandlerRGB::RGBFormatList::getFormatedNames()
   return l;
 }
 
-videoHandlerRGB::rgbPixelFormat videoHandlerRGB::RGBFormatList::getFromName(QString name)
+videoHandlerRGB::rgbPixelFormat videoHandlerRGB::RGBFormatList::getFromName(const QString &name)
 {
   for (int i = 0; i < count(); i++)
   {
@@ -164,7 +163,7 @@ videoHandlerRGB::RGBFormatList videoHandlerRGB::rgbPresetList;
 
 /* Get the number of bytes for a frame with this yuvPixelFormat and the given size
 */
-qint64 videoHandlerRGB::rgbPixelFormat::bytesPerFrame(QSize frameSize)
+qint64 videoHandlerRGB::rgbPixelFormat::bytesPerFrame(const QSize &frameSize)
 {
   if (bitsPerValue == 0 || !frameSize.isValid())
     return 0;
@@ -206,7 +205,7 @@ videoHandlerRGB::~videoHandlerRGB()
   rgbFormatMutex.lock();
 }
 
-ValuePairList videoHandlerRGB::getPixelValues(QPoint pixelPos, int frameIdx, frameHandler *item2)
+ValuePairList videoHandlerRGB::getPixelValues(const QPoint &pixelPos, int frameIdx, frameHandler *item2)
 {
   ValuePairList values;
 
@@ -473,7 +472,7 @@ bool videoHandlerRGB::loadRawRGBData(int frameIndex)
 
 // Convert the given raw YUV data in sourceBuffer (using srcPixelFormat) to pixmap (RGB-888), using the
 // buffer tmpRGBBuffer for intermediate RGB values.
-void videoHandlerRGB::convertRGBToPixmap(QByteArray sourceBuffer, QPixmap &outputPixmap, QByteArray &tmpRGBBuffer)
+void videoHandlerRGB::convertRGBToPixmap(const QByteArray &sourceBuffer, QPixmap &outputPixmap, QByteArray &tmpRGBBuffer)
 {
   DEBUG_RGB( "videoHandlerRGB::convertRGBToPixmap" );
 
@@ -489,7 +488,7 @@ void videoHandlerRGB::convertRGBToPixmap(QByteArray sourceBuffer, QPixmap &outpu
 
 // Convert the data in "sourceBuffer" from the format "srcPixelFormat" to RGB 888. While doing so, apply the 
 // scaling factors, inversions and only convert the selected color components.
-void videoHandlerRGB::convertSourceToRGB888(QByteArray &sourceBuffer, QByteArray &targetBuffer)
+void videoHandlerRGB::convertSourceToRGB888(const QByteArray &sourceBuffer, QByteArray &targetBuffer)
 {
   // Check if the source buffer is of the correct size
   Q_ASSERT_X(sourceBuffer.size() >= getBytesPerFrame(), "videoHandlerRGB::convertSourceToRGB888", "The source buffer does not hold enough data.");
@@ -691,7 +690,7 @@ void videoHandlerRGB::convertSourceToRGB888(QByteArray &sourceBuffer, QByteArray
     Q_ASSERT_X(false, "videoHandlerRGB::convertSourceToRGB888", "Unsupported display mode.");
 }
 
-void videoHandlerRGB::getPixelValue(QPoint pixelPos, int frameIdx, unsigned int &R, unsigned int &G, unsigned int &B)
+void videoHandlerRGB::getPixelValue(const QPoint &pixelPos, int frameIdx, unsigned int &R, unsigned int &G, unsigned int &B)
 {
   // Update the raw RGB data if necessary
   loadRawRGBData(frameIdx);
@@ -750,7 +749,7 @@ void videoHandlerRGB::getPixelValue(QPoint pixelPos, int frameIdx, unsigned int 
     Q_ASSERT_X(false, "videoHandlerRGB::getPixelValue", "No RGB format with less than 8 or more than 16 bits supported yet.");
 }
 
-void videoHandlerRGB::setFrameSize(QSize size, bool emitSignal)
+void videoHandlerRGB::setFrameSize(const QSize &size, bool emitSignal)
 {
   if (size != frameSize)
   {
@@ -761,7 +760,7 @@ void videoHandlerRGB::setFrameSize(QSize size, bool emitSignal)
   videoHandler::setFrameSize(size, emitSignal);
 }
 
-void videoHandlerRGB::setFormatFromSize(QSize size, int bitDepth, qint64 fileSize, QString subFormat)
+void videoHandlerRGB::setFormatFromSize(const QSize &size, int bitDepth, qint64 fileSize, const QString &subFormat)
 {
   // If the bit depth could not be determined, check 8 and 10 bit
   int testBitDepths = (bitDepth > 0) ? 1 : 2;
@@ -812,7 +811,7 @@ void videoHandlerRGB::setFormatFromSize(QSize size, int bitDepth, qint64 fileSiz
   }
 }
 
-void videoHandlerRGB::drawPixelValues(QPainter *painter, int frameIdx, QRect videoRect, double zoomFactor, frameHandler *item2)
+void videoHandlerRGB::drawPixelValues(QPainter *painter, int frameIdx, const QRect &videoRect, double zoomFactor, frameHandler *item2)
 {
   // First determine which pixels from this item are actually visible, because we only have to draw the pixel values
   // of the pixels that are actually visible

--- a/source/videoHandlerRGB.h
+++ b/source/videoHandlerRGB.h
@@ -166,7 +166,7 @@ protected:
     // Default constructor. Fill the list with all the supported YUV formats.
     RGBFormatList();
     // Get all the YUV formats as a formatted list (for the dropdonw control)
-    QStringList getFormatedNames();
+    QStringList getFormattedNames();
     // Get the yuvPixelFormat with the given name
     rgbPixelFormat getFromName(const QString &name);
   };

--- a/source/videoHandlerRGB.h
+++ b/source/videoHandlerRGB.h
@@ -36,7 +36,7 @@ class videoHandlerRGB_CustomFormatDialog : public QDialog, private Ui::CustomRGB
 {
   Q_OBJECT
 public:
-  videoHandlerRGB_CustomFormatDialog(QString rgbFormat, int bitDepth, bool planar, bool alpha);
+  videoHandlerRGB_CustomFormatDialog(const QString &rgbFormat, int bitDepth, bool planar, bool alpha);
   QString getRGBFormat() { return rgbOrderComboBox->currentText(); }
   int getBitDepth() { return bitDepthSpinBox->value(); }
   bool getPlanar() { return planarCheckBox->isChecked(); }
@@ -59,14 +59,14 @@ public:
   virtual bool isFormatValid() Q_DECL_OVERRIDE { return (frameHandler::isFormatValid() && srcPixelFormat != "Unknown Pixel Format"); }
     
   // Return the RGB values for the given pixel
-  virtual ValuePairList getPixelValues(QPoint pixelPos, int frameIdx, frameHandler *item2) Q_DECL_OVERRIDE;
+  virtual ValuePairList getPixelValues(const QPoint &pixelPos, int frameIdx, frameHandler *item2) Q_DECL_OVERRIDE;
 
   // Get the number of bytes for one RGB frame with the current format
   virtual qint64 getBytesPerFrame() { return srcPixelFormat.bytesPerFrame(frameSize); }
 
   // Try to guess and set the format (frameSize/srcPixelFormat) from the raw RGB data.
   // If a file size is given, it is tested if the RGB format and the file size match.
-  virtual void setFormatFromCorrelation(QByteArray rawRGBData, qint64 fileSize=-1) Q_DECL_OVERRIDE { /* TODO */ Q_UNUSED(rawRGBData); Q_UNUSED(fileSize); };
+  virtual void setFormatFromCorrelation(const QByteArray &rawRGBData, qint64 fileSize=-1) Q_DECL_OVERRIDE { /* TODO */ Q_UNUSED(rawRGBData); Q_UNUSED(fileSize); }
 
   // Create the rgb controls and return a pointer to the layout.
   // rgbFormatFixed: For example a RGB file does not have a fixed format (the user can change this),
@@ -77,19 +77,19 @@ public:
   virtual QString getRawRGBPixelFormatName() { return srcPixelFormat.getName(); }
   // Set the current raw format and update the control. Only emit a signalHandlerChanged signal
   // if emitSignal is true.
-  virtual void setRGBPixelFormatByName(QString name, bool emitSignal=false) { srcPixelFormat.setFromName(name); if (emitSignal) emit signalHandlerChanged(true, true); }
+  virtual void setRGBPixelFormatByName(const QString &name, bool emitSignal=false) { srcPixelFormat.setFromName(name); if (emitSignal) emit signalHandlerChanged(true, true); }
   
   // The Frame size is about to change. If this happens, our local buffers all need updating.
-  virtual void setFrameSize(QSize size, bool emitSignal = false) Q_DECL_OVERRIDE ;
+  virtual void setFrameSize(const QSize &size, bool emitSignal = false) Q_DECL_OVERRIDE ;
 
   // If you know the frame size of the video, the file size (and optionally the bit depth) we can guess
   // the remaining values. The rate value is set if a matching format could be found.
   // The sub format can be one of: "RGB", "GBR" or "BGR"
-  virtual void setFormatFromSize(QSize size, int bitDepth, qint64 fileSize, QString subFormat) Q_DECL_OVERRIDE;
+  virtual void setFormatFromSize(const QSize &size, int bitDepth, qint64 fileSize, const QString &subFormat) Q_DECL_OVERRIDE;
 
   // Draw the pixel values of the visible pixels in the center of each pixel. Only draw values for the given range of pixels.
   // Overridden from playlistItemVideo. This is a RGB source, so we can draw the source RGB values from the source data.
-  virtual void drawPixelValues(QPainter *painter, int frameIdx, QRect videoRect, double zoomFactor, frameHandler *item2=NULL) Q_DECL_OVERRIDE;
+  virtual void drawPixelValues(QPainter *painter, int frameIdx, const QRect &videoRect, double zoomFactor, frameHandler *item2=NULL) Q_DECL_OVERRIDE;
 
   // The buffer of the raw RGB data of the current frame (and its frame index)
   // Before using the currentFrameRawRGBData, you have to check if the currentFrameRawRGBData_frameIdx is correct. If not,
@@ -139,19 +139,19 @@ protected:
     rgbPixelFormat(int bitsPerValue, bool planar, bool alphaChannel, int posR=0, int posG=1, int posB=2)
                    : posR(posR), posG(posG), posB(posB), bitsPerValue(bitsPerValue), planar(planar), alphaChannel(alphaChannel) 
     { Q_ASSERT_X(posR != posG && posR != posB && posG != posB, "rgbPixelFormat", "Invalid RGB format set"); }
-    bool operator==(const rgbPixelFormat& a) const { return getName() == a.getName(); } // Comparing names should be enough since you are not supposed to create your own rgbPixelFormat instances anyways.
-    bool operator!=(const rgbPixelFormat& a) const { return getName()!= a.getName(); }
-    bool operator==(const QString& a) const { return getName() == a; }
-    bool operator!=(const QString& a) const { return getName() != a; }
+    bool operator==(const rgbPixelFormat &a) const { return getName() == a.getName(); } // Comparing names should be enough since you are not supposed to create your own rgbPixelFormat instances anyways.
+    bool operator!=(const rgbPixelFormat &a) const { return getName()!= a.getName(); }
+    bool operator==(const QString &a) const { return getName() == a; }
+    bool operator!=(const QString &a) const { return getName() != a; }
     bool isValid() { return bitsPerValue != 0 && posR != posG && posR != posB && posG != posB; }
     // Get a name representation of this item (this will be unique for the set parameters)
     QString getName() const;
-    void setFromName(QString name);
+    void setFromName(const QString &name);
     // Get/Set the RGB format from string (accepted string are: "RGB", "BGR", ...)
     QString getRGBFormatString() const;
-    void setRGBFormatFromString(QString sFormat);
+    void setRGBFormatFromString(const QString &sFormat);
     // Get the number of bytes for a frame with this rgbPixelFormat and the given size
-    qint64 bytesPerFrame( QSize frameSize );
+    qint64 bytesPerFrame(const QSize &frameSize);
     // The order of each component (E.g. for GBR this is posR=2,posG=0,posB=1)
     int posR, posG, posB;
     int bitsPerValue;
@@ -168,7 +168,7 @@ protected:
     // Get all the YUV formats as a formatted list (for the dropdonw control)
     QStringList getFormatedNames();
     // Get the yuvPixelFormat with the given name
-    rgbPixelFormat getFromName(QString name);
+    rgbPixelFormat getFromName(const QString &name);
   };
   static RGBFormatList rgbPresetList;
 
@@ -183,7 +183,7 @@ protected:
   bool componentInvert[3];
   
   // Get the RGB values for the given pixel.
-  virtual void getPixelValue(QPoint pixelPos, int frameIdx, unsigned int &R, unsigned int &G, unsigned int &B);
+  virtual void getPixelValue(const QPoint &pixelPos, int frameIdx, unsigned int &R, unsigned int &G, unsigned int &B);
 
   // Load the given frame and convert it to pixmap. After this, currentFrameRawRGBData and currentFrame will
   // contain the frame with the given frame index.
@@ -200,7 +200,7 @@ private:
   bool loadRawRGBData(int frameIndex);
 
   // Convert from RGB (which ever format is selected) to pixmap (RGB-888)
-  void convertRGBToPixmap(QByteArray sourceBuffer, QPixmap &outputPixmap, QByteArray &tmpRGBBuffer);
+  void convertRGBToPixmap(const QByteArray &sourceBuffer, QPixmap &outputPixmap, QByteArray &tmpRGBBuffer);
 
   // Set the new pixel format thread save (lock the mutex)
   void setSrcPixelFormat( rgbPixelFormat newFormat ) { rgbFormatMutex.lock(); srcPixelFormat = newFormat; rgbFormatMutex.unlock(); }
@@ -212,7 +212,7 @@ private:
   byteArrayAligned tmpBufferRawRGBDataCaching;
 #else
   // Convert one frame from the current pixel format to RGB888
-  void convertSourceToRGB888(QByteArray &sourceBuffer, QByteArray &targetBuffer);
+  void convertSourceToRGB888(const QByteArray &sourceBuffer, QByteArray &targetBuffer);
   QByteArray tmpBufferRGB;
   QByteArray tmpBufferRGBCaching;
   QByteArray tmpBufferRawRGBDataCaching;

--- a/source/videoHandlerRGB.h
+++ b/source/videoHandlerRGB.h
@@ -37,10 +37,10 @@ class videoHandlerRGB_CustomFormatDialog : public QDialog, private Ui::CustomRGB
   Q_OBJECT
 public:
   videoHandlerRGB_CustomFormatDialog(const QString &rgbFormat, int bitDepth, bool planar, bool alpha);
-  QString getRGBFormat() { return rgbOrderComboBox->currentText(); }
-  int getBitDepth() { return bitDepthSpinBox->value(); }
-  bool getPlanar() { return planarCheckBox->isChecked(); }
-  bool getAlphaChannel() { return alphaChannelCheckBox->isChecked(); }
+  QString getRGBFormat() const { return rgbOrderComboBox->currentText(); }
+  int getBitDepth() const { return bitDepthSpinBox->value(); }
+  bool getPlanar() const { return planarCheckBox->isChecked(); }
+  bool getAlphaChannel() const { return alphaChannelCheckBox->isChecked(); }
 };
 
 /** The videoHandlerRGB can be used in any playlistItem to read/display RGB data. A playlistItem could even provide multiple RGB videos.
@@ -56,13 +56,13 @@ public:
   virtual ~videoHandlerRGB();
 
   // The format is valid if the frame width/height/pixel format are set
-  virtual bool isFormatValid() Q_DECL_OVERRIDE { return (frameHandler::isFormatValid() && srcPixelFormat != "Unknown Pixel Format"); }
+  virtual bool isFormatValid() const Q_DECL_OVERRIDE { return (frameHandler::isFormatValid() && srcPixelFormat != "Unknown Pixel Format"); }
     
   // Return the RGB values for the given pixel
   virtual ValuePairList getPixelValues(const QPoint &pixelPos, int frameIdx, frameHandler *item2) Q_DECL_OVERRIDE;
 
   // Get the number of bytes for one RGB frame with the current format
-  virtual qint64 getBytesPerFrame() { return srcPixelFormat.bytesPerFrame(frameSize); }
+  virtual qint64 getBytesPerFrame() const { return srcPixelFormat.bytesPerFrame(frameSize); }
 
   // Try to guess and set the format (frameSize/srcPixelFormat) from the raw RGB data.
   // If a file size is given, it is tested if the RGB format and the file size match.
@@ -74,7 +74,7 @@ public:
   virtual QLayout *createRGBVideoHandlerControls(bool isSizeFixed=false);
 
   // Get the name of the currently selected RGB pixel format
-  virtual QString getRawRGBPixelFormatName() { return srcPixelFormat.getName(); }
+  virtual QString getRawRGBPixelFormatName() const { return srcPixelFormat.getName(); }
   // Set the current raw format and update the control. Only emit a signalHandlerChanged signal
   // if emitSignal is true.
   virtual void setRGBPixelFormatByName(const QString &name, bool emitSignal=false) { srcPixelFormat.setFromName(name); if (emitSignal) emit signalHandlerChanged(true, true); }
@@ -151,7 +151,7 @@ protected:
     QString getRGBFormatString() const;
     void setRGBFormatFromString(const QString &sFormat);
     // Get the number of bytes for a frame with this rgbPixelFormat and the given size
-    qint64 bytesPerFrame(const QSize &frameSize);
+    qint64 bytesPerFrame(const QSize &frameSize) const;
     // The order of each component (E.g. for GBR this is posR=2,posG=0,posB=1)
     int posR, posG, posB;
     int bitsPerValue;
@@ -166,9 +166,9 @@ protected:
     // Default constructor. Fill the list with all the supported YUV formats.
     RGBFormatList();
     // Get all the YUV formats as a formatted list (for the dropdonw control)
-    QStringList getFormattedNames();
+    QStringList getFormattedNames() const;
     // Get the yuvPixelFormat with the given name
-    rgbPixelFormat getFromName(const QString &name);
+    rgbPixelFormat getFromName(const QString &name) const;
   };
   static RGBFormatList rgbPresetList;
 

--- a/source/videoHandlerYUV.cpp
+++ b/source/videoHandlerYUV.cpp
@@ -39,7 +39,7 @@
 
 /* Get the number of bytes for a frame with this yuvPixelFormat and the given size
 */
-qint64 videoHandlerYUV::yuvPixelFormat::bytesPerFrame(const QSize &frameSize)
+qint64 videoHandlerYUV::yuvPixelFormat::bytesPerFrame(const QSize &frameSize) const
 {
   if (name == "Unknown Pixel Format" || !frameSize.isValid())
     return 0;
@@ -89,7 +89,7 @@ videoHandlerYUV::YUVFormatList::YUVFormatList()
 
 /* Put all the names of the yuvPixelFormats into a list and return it
 */
-QStringList videoHandlerYUV::YUVFormatList::getFormattedNames()
+QStringList videoHandlerYUV::YUVFormatList::getFormattedNames() const
 {
   QStringList l;
   for (int i = 0; i < count(); i++)
@@ -99,7 +99,7 @@ QStringList videoHandlerYUV::YUVFormatList::getFormattedNames()
   return l;
 }
 
-videoHandlerYUV::yuvPixelFormat videoHandlerYUV::YUVFormatList::getFromName(const QString &name)
+videoHandlerYUV::yuvPixelFormat videoHandlerYUV::YUVFormatList::getFromName(const QString &name) const
 {
   for (int i = 0; i < count(); i++)
   {

--- a/source/videoHandlerYUV.cpp
+++ b/source/videoHandlerYUV.cpp
@@ -39,7 +39,7 @@
 
 /* Get the number of bytes for a frame with this yuvPixelFormat and the given size
 */
-qint64 videoHandlerYUV::yuvPixelFormat::bytesPerFrame(QSize frameSize)
+qint64 videoHandlerYUV::yuvPixelFormat::bytesPerFrame(const QSize &frameSize)
 {
   if (name == "Unknown Pixel Format" || !frameSize.isValid())
     return 0;
@@ -99,7 +99,7 @@ QStringList videoHandlerYUV::YUVFormatList::getFormatedNames()
   return l;
 }
 
-videoHandlerYUV::yuvPixelFormat videoHandlerYUV::YUVFormatList::getFromName(QString name)
+videoHandlerYUV::yuvPixelFormat videoHandlerYUV::YUVFormatList::getFromName(const QString &name)
 {
   for (int i = 0; i < count(); i++)
   {
@@ -132,7 +132,7 @@ videoHandlerYUV::videoHandlerYUV() : videoHandler()
   rawYUVData_frameIdx = -1;
 }
 
-void videoHandlerYUV::loadValues(QSize newFramesize, QString sourcePixelFormat)
+void videoHandlerYUV::loadValues(const QSize &newFramesize, const QString &sourcePixelFormat)
 {
   setFrameSize(newFramesize);
   setSrcPixelFormat( yuvFormatList.getFromName(sourcePixelFormat) );
@@ -321,7 +321,7 @@ void videoHandlerYUV::yuv420_to_argb8888(quint8 *yp, quint8 *up, quint8 *vp, qui
 #if SSE_CONVERSION
 void videoHandlerYUV::convert2YUV444(byteArrayAligned &sourceBuffer, byteArrayAligned &targetBuffer)
 #else
-void videoHandlerYUV::convert2YUV444(QByteArray &sourceBuffer, QByteArray &targetBuffer)
+void videoHandlerYUV::convert2YUV444(const QByteArray &sourceBuffer, QByteArray &targetBuffer)
 #endif
 {
   if (srcPixelFormat == "Unknown Pixel Format") {
@@ -915,9 +915,9 @@ void videoHandlerYUV::applyYUVTransformation(QByteArray &sourceBuffer)
 #endif
 
 #if SSE_CONVERSION
-void videoHandlerYUV::convertYUV4442RGB(byteArrayAligned &sourceBuffer, byteArrayAligned &targetBuffer)
+void videoHandlerYUV::convertYUV4442RGB(const byteArrayAligned &sourceBuffer, byteArrayAligned &targetBuffer)
 #else
-void videoHandlerYUV::convertYUV4442RGB(QByteArray &sourceBuffer, QByteArray &targetBuffer)
+void videoHandlerYUV::convertYUV4442RGB(const QByteArray &sourceBuffer, QByteArray &targetBuffer)
 #endif
 {
   static unsigned char clp_buf[384+256+384];
@@ -1499,7 +1499,7 @@ QPixmap videoHandlerYUV::calculateDifference(frameHandler *item2, int frame, QLi
   return retPixmap;
 }
 
-ValuePairList videoHandlerYUV::getPixelValues(QPoint pixelPos, int frameIdx, frameHandler *item2)
+ValuePairList videoHandlerYUV::getPixelValues(const QPoint &pixelPos, int frameIdx, frameHandler *item2)
 {
   ValuePairList values;
 
@@ -1549,7 +1549,7 @@ ValuePairList videoHandlerYUV::getPixelValues(QPoint pixelPos, int frameIdx, fra
   return values;
 }
 
-void videoHandlerYUV::drawPixelValues(QPainter *painter, int frameIdx,  QRect videoRect, double zoomFactor, frameHandler *item2)
+void videoHandlerYUV::drawPixelValues(QPainter *painter, int frameIdx, const QRect &videoRect, double zoomFactor, frameHandler *item2)
 {
   // Get the other YUV item (if any)
   videoHandlerYUV *yuvItem2 = NULL;
@@ -1696,7 +1696,7 @@ void videoHandlerYUV::drawPixelValues(QPainter *painter, int frameIdx,  QRect vi
   painter->setPen(backupPen);
 }
 
-void videoHandlerYUV::setFormatFromSize(QSize size, int bitDepth, qint64 fileSize, QString subFormat)
+void videoHandlerYUV::setFormatFromSize(const QSize &size, int bitDepth, qint64 fileSize, const QString &subFormat)
 {
   // If the bit depth could not be determined, check 8 and 10 bit
   int testBitDepths = (bitDepth > 0) ? 1 : 2;
@@ -1757,7 +1757,7 @@ void videoHandlerYUV::setFormatFromSize(QSize size, int bitDepth, qint64 fileSiz
   * If a file size is given, we test if the candidates frame size is a multiple of the fileSize. If fileSize is -1, this test
   * is skipped.
   */
-void videoHandlerYUV::setFormatFromCorrelation(QByteArray rawYUVData, qint64 fileSize)
+void videoHandlerYUV::setFormatFromCorrelation(const QByteArray &rawYUVData, qint64 fileSize)
 {
   unsigned char *ptr;
   float leastMSE, mse;
@@ -1773,7 +1773,7 @@ void videoHandlerYUV::setFormatFromCorrelation(QByteArray rawYUVData, qint64 fil
   // The definition is here to not pollute any other namespace unnecessarily
   class candMode_t {
   public:
-    candMode_t(QSize size, QString formatName) { frameSize = size; pixelFormatName = formatName; interesting = false; mseY = 0.0; }
+    candMode_t(const QSize &size, const QString &formatName) { frameSize = size; pixelFormatName = formatName; interesting = false; mseY = 0.0; }
     QSize   frameSize;
     QString pixelFormatName;
 
@@ -1970,7 +1970,7 @@ bool videoHandlerYUV::loadRawYUVData(int frameIndex)
 
 // Convert the given raw YUV data in sourceBuffer (using srcPixelFormat) to pixmap (RGB-888), using the
 // buffer tmpRGBBuffer for intermediate RGB values.
-void videoHandlerYUV::convertYUVToPixmap(QByteArray sourceBuffer, QPixmap &outputPixmap, QByteArray &tmpRGBBuffer, QByteArray &tmpYUV444Buffer)
+void videoHandlerYUV::convertYUVToPixmap(const QByteArray &sourceBuffer, QPixmap &outputPixmap, QByteArray &tmpRGBBuffer, QByteArray &tmpYUV444Buffer)
 {
   DEBUG_YUV( "videoHandlerYUV::convertYUVToPixmap" );
 
@@ -2008,7 +2008,7 @@ void videoHandlerYUV::convertYUVToPixmap(QByteArray sourceBuffer, QPixmap &outpu
   outputPixmap.convertFromImage(tmpImage);
 }
 
-void videoHandlerYUV::getPixelValue(QPoint pixelPos, int frameIdx, unsigned int &Y, unsigned int &U, unsigned int &V)
+void videoHandlerYUV::getPixelValue(const QPoint &pixelPos, int frameIdx, unsigned int &Y, unsigned int &U, unsigned int &V)
 {
   // Update the raw YUV data if necessary
   loadRawYUVData(frameIdx);
@@ -2046,7 +2046,7 @@ void videoHandlerYUV::getPixelValue(QPoint pixelPos, int frameIdx, unsigned int 
 #if SSE_CONVERSION
 void videoHandlerYUV::convertYUV420ToRGB(byteArrayAligned &sourceBuffer, byteArrayAligned &targetBuffer)
 #else
-void videoHandlerYUV::convertYUV420ToRGB(QByteArray &sourceBuffer, QByteArray &targetBuffer, QSize size)
+void videoHandlerYUV::convertYUV420ToRGB(const QByteArray &sourceBuffer, QByteArray &targetBuffer, const QSize &size)
 #endif
 {
   int frameWidth, frameHeight;
@@ -2304,7 +2304,7 @@ void videoHandlerYUV::convertYUV420ToRGB(QByteArray &sourceBuffer, QByteArray &t
   }
 }
 
-void videoHandlerYUV::setYUVPixelFormatByName(QString name, bool emitSignal)
+void videoHandlerYUV::setYUVPixelFormatByName(const QString &name, bool emitSignal)
 {
   yuvPixelFormat newSrcPixelFormat = yuvFormatList.getFromName(name);
   if (newSrcPixelFormat != srcPixelFormat)
@@ -2330,7 +2330,7 @@ void videoHandlerYUV::setYUVPixelFormatByName(QString name, bool emitSignal)
   }
 }
 
-void videoHandlerYUV::setFrameSize(QSize size, bool emitSignal)
+void videoHandlerYUV::setFrameSize(const QSize &size, bool emitSignal)
 {
   if (size != frameSize)
   {

--- a/source/videoHandlerYUV.cpp
+++ b/source/videoHandlerYUV.cpp
@@ -89,7 +89,7 @@ videoHandlerYUV::YUVFormatList::YUVFormatList()
 
 /* Put all the names of the yuvPixelFormats into a list and return it
 */
-QStringList videoHandlerYUV::YUVFormatList::getFormatedNames()
+QStringList videoHandlerYUV::YUVFormatList::getFormattedNames()
 {
   QStringList l;
   for (int i = 0; i < count(); i++)
@@ -1109,7 +1109,7 @@ QLayout *videoHandlerYUV::createYUVVideoHandlerControls(bool isSizeFixed)
   ui.setupUi();
 
   // Set all the values of the properties widget to the values of this class
-  ui.yuvFileFormatComboBox->addItems( yuvFormatList.getFormatedNames() );
+  ui.yuvFileFormatComboBox->addItems( yuvFormatList.getFormattedNames() );
   int idx = yuvFormatList.indexOf( srcPixelFormat );
   ui.yuvFileFormatComboBox->setCurrentIndex( idx );
   ui.yuvFileFormatComboBox->setEnabled(!isSizeFixed);

--- a/source/videoHandlerYUV.h
+++ b/source/videoHandlerYUV.h
@@ -186,7 +186,7 @@ protected:
     // Default constructor. Fill the list with all the supported YUV formats.
     YUVFormatList();
     // Get all the YUV formats as a formatted list (for the dropdonw control)
-    QStringList getFormatedNames();
+    QStringList getFormattedNames();
     // Get the yuvPixelFormat with the given name
     yuvPixelFormat getFromName(const QString &name);
   };

--- a/source/videoHandlerYUV.h
+++ b/source/videoHandlerYUV.h
@@ -48,7 +48,7 @@ public:
   // Return the YUV values for the given pixel
   // If a second item is provided, return the difference values to that item at the given position. If th second item
   // cannot be cast to a videoHandlerYUV, we call the frameHandler::getPixelValues function.
-  virtual ValuePairList getPixelValues(QPoint pixelPos, int frameIdx, frameHandler *item2=NULL) Q_DECL_OVERRIDE;
+  virtual ValuePairList getPixelValues(const QPoint &pixelPos, int frameIdx, frameHandler *item2=NULL) Q_DECL_OVERRIDE;
   
   // Overload from playlistItemVideo. Calculate the difference of this playlistItemYuvSource
   // to another playlistItemVideo. If item2 cannot be converted to a playlistItemYuvSource,
@@ -62,11 +62,11 @@ public:
   // If you know the frame size of the video, the file size (and optionally the bit depth) we can guess
   // the remaining values. The rate value is set if a matching format could be found.
   // If the sub format is "444" we will assume 4:4:4 input. Otherwise 4:2:0 will be assumed.
-  virtual void setFormatFromSize(QSize size, int bitDepth, qint64 fileSize, QString subFormat) Q_DECL_OVERRIDE;
+  virtual void setFormatFromSize(const QSize &size, int bitDepth, qint64 fileSize, const QString &subFormat) Q_DECL_OVERRIDE;
 
   // Try to guess and set the format (frameSize/srcPixelFormat) from the raw YUV data.
   // If a file size is given, it is tested if the YUV format and the file size match.
-  virtual void setFormatFromCorrelation(QByteArray rawYUVData, qint64 fileSize=-1);
+  virtual void setFormatFromCorrelation(const QByteArray &rawYUVData, qint64 fileSize=-1);
 
   // Create the yuv controls and return a pointer to the layout.
   // yuvFormatFixed: For example a YUV file does not have a fixed format (the user can change this),
@@ -77,17 +77,17 @@ public:
   virtual QString getRawYUVPixelFormatName() { return srcPixelFormat.name; }
   // Set the current yuv format and update the control. Only emit a signalHandlerChanged signal
   // if emitSignal is true.
-  virtual void setYUVPixelFormatByName(QString name, bool emitSignal=false);
+  virtual void setYUVPixelFormatByName(const QString &name, bool emitSignal=false);
 
   // When loading a videoHandlerYUV from playlist file, this can be used to set all the parameters at once
-  void loadValues(QSize frameSize, QString sourcePixelFormat);
+  void loadValues(const QSize &frameSize, const QString &sourcePixelFormat);
 
   // Draw the pixel values of the visible pixels in the center of each pixel. Only draw values for the given range of pixels.
   // Overridden from playlistItemVideo. This is a YUV source, so we can draw the YUV values.
-  virtual void drawPixelValues(QPainter *painter, int frameIdx, QRect videoRect, double zoomFactor, frameHandler *item2=NULL) Q_DECL_OVERRIDE;
+  virtual void drawPixelValues(QPainter *painter, int frameIdx, const QRect &videoRect, double zoomFactor, frameHandler *item2=NULL) Q_DECL_OVERRIDE;
 
   // The Frame size is about to change. If this happens, our local buffers all need updating.
-  virtual void setFrameSize(QSize size, bool emitSignal = false) Q_DECL_OVERRIDE ;
+  virtual void setFrameSize(const QSize &size, bool emitSignal = false) Q_DECL_OVERRIDE ;
 
   // The buffer of the raw YUV data of the current frame (and its frame index)
   // Before using the currentFrameRawYUVData, you have to check if the currentFrameRawYUVData_frameIdx is correct. If not,
@@ -155,17 +155,17 @@ protected:
     yuvPixelFormat() : name("Unknown Pixel Format"), bitsPerSample(0), bitsPerPixelNominator(0), bitsPerPixelDenominator(0),
                        subsamplingHorizontal(0), subsamplingVertical(0), planar(false), bytePerComponentSample(0) {}
     // Convenience constructor that takes all the values.
-    yuvPixelFormat(QString name, int bitsPerSample, int bitsPerPixelNominator, int bitsPerPixelDenominator,
+    yuvPixelFormat(const QString &name, int bitsPerSample, int bitsPerPixelNominator, int bitsPerPixelDenominator,
                    int subsamplingHorizontal, int subsamplingVertical, bool planar, int bytePerComponentSample = 1)
                    : name(name) , bitsPerSample(bitsPerSample), bitsPerPixelNominator(bitsPerPixelNominator)
                    , bitsPerPixelDenominator(bitsPerPixelDenominator), subsamplingHorizontal(subsamplingHorizontal)
                    , subsamplingVertical(subsamplingVertical), planar(planar), bytePerComponentSample(bytePerComponentSample) {}
-    bool operator==(const yuvPixelFormat& a) const { return name == a.name; } // Comparing names should be enough since you are not supposed to create your own yuvPixelFormat instances anyways.
-    bool operator!=(const yuvPixelFormat& a) const { return name != a.name; }
-    bool operator==(const QString& a) const { return name == a; }
-    bool operator!=(const QString& a) const { return name != a; }
+    bool operator==(const yuvPixelFormat &a) const { return name == a.name; } // Comparing names should be enough since you are not supposed to create your own yuvPixelFormat instances anyways.
+    bool operator!=(const yuvPixelFormat &a) const { return name != a.name; }
+    bool operator==(const QString &a) const { return name == a; }
+    bool operator!=(const QString &a) const { return name != a; }
     // Get the number of bytes for a frame with this yuvPixelFormat and the given size
-    qint64 bytesPerFrame( QSize frameSize );
+    qint64 bytesPerFrame(const QSize &frameSize);
     QString name;
     int bitsPerSample;
     int bitsPerPixelNominator;
@@ -188,7 +188,7 @@ protected:
     // Get all the YUV formats as a formatted list (for the dropdonw control)
     QStringList getFormatedNames();
     // Get the yuvPixelFormat with the given name
-    yuvPixelFormat getFromName(QString name);
+    yuvPixelFormat getFromName(const QString &name);
   };
   static YUVFormatList yuvFormatList;
 
@@ -210,7 +210,7 @@ protected:
 #endif
 
   // Get the YUV values for the given pixel.
-  virtual void getPixelValue(QPoint pixelPos, int frameIdx, unsigned int &Y, unsigned int &U, unsigned int &V);
+  virtual void getPixelValue(const QPoint &pixelPos, int frameIdx, unsigned int &Y, unsigned int &U, unsigned int &V);
 
   // Load the given frame and convert it to pixmap. After this, currentFrameRawYUVData and currentFrame will
   // contain the frame with the given frame index.
@@ -230,29 +230,29 @@ private:
   bool loadRawYUVData(int frameIndex);
 
   // Convert from YUV (which ever format is selected) to pixmap (RGB-888)
-  void convertYUVToPixmap(QByteArray sourceBuffer, QPixmap &outputPixmap, QByteArray &tmpRGBBuffer, QByteArray &tmpYUV444Buffer);
+  void convertYUVToPixmap(const QByteArray &sourceBuffer, QPixmap &outputPixmap, QByteArray &tmpRGBBuffer, QByteArray &tmpYUV444Buffer);
 
   // Set the new pixel format thread save (lock the mutex)
   void setSrcPixelFormat( yuvPixelFormat newFormat ) { yuvFormatMutex.lock(); srcPixelFormat = newFormat; yuvFormatMutex.unlock(); }
 
 #if SSE_CONVERSION
   // Convert one frame from the current pixel format to YUV444
-  void convert2YUV444(byteArrayAligned &sourceBuffer, byteArrayAligned &targetBuffer);
+  void convert2YUV444(const byteArrayAligned &sourceBuffer, byteArrayAligned &targetBuffer);
   // Apply transformations to the luma/chroma components
   void applyYUVTransformation(byteArrayAligned &sourceBuffer);
   // Convert one frame from YUV 444 to RGB
-  void convertYUV4442RGB(byteArrayAligned &sourceBuffer, byteArrayAligned &targetBuffer);
+  void convertYUV4442RGB(const byteArrayAligned &sourceBuffer, byteArrayAligned &targetBuffer);
   // Directly convert from YUV 420 to RGB (do not apply YUV math)
-  void convertYUV420ToRGB(byteArrayAligned &sourceBuffer, byteArrayAligned &targetBuffer);
+  void convertYUV420ToRGB(const byteArrayAligned &sourceBuffer, byteArrayAligned &targetBuffer);
 #else
   // Convert one frame from the current pixel format to YUV444
-  void convert2YUV444(QByteArray &sourceBuffer, QByteArray &targetBuffer);
+  void convert2YUV444(const QByteArray &sourceBuffer, QByteArray &targetBuffer);
   // Apply transformations to the luma/chroma components
   void applyYUVTransformation(QByteArray &sourceBuffer);
   // Convert one frame from YUV 444 to RGB
-  void convertYUV4442RGB(QByteArray &sourceBuffer, QByteArray &targetBuffer);
+  void convertYUV4442RGB(const QByteArray &sourceBuffer, QByteArray &targetBuffer);
   // Directly convert from YUV 420 to RGB (do not apply YUV math) (use the given size if valid)
-  void convertYUV420ToRGB(QByteArray &sourceBuffer, QByteArray &targetBuffer, QSize size=QSize());
+  void convertYUV420ToRGB(const QByteArray &sourceBuffer, QByteArray &targetBuffer, const QSize &size=QSize());
 #endif
 
 #if SSE_CONVERSION_420_ALT

--- a/source/videoHandlerYUV.h
+++ b/source/videoHandlerYUV.h
@@ -43,7 +43,7 @@ public:
   videoHandlerYUV();
 
   // The format is valid if the frame width/height/pixel format are set
-  virtual bool isFormatValid() Q_DECL_OVERRIDE { return (frameHandler::isFormatValid() && srcPixelFormat != "Unknown Pixel Format"); }
+  virtual bool isFormatValid() const Q_DECL_OVERRIDE { return (frameHandler::isFormatValid() && srcPixelFormat != "Unknown Pixel Format"); }
 
   // Return the YUV values for the given pixel
   // If a second item is provided, return the difference values to that item at the given position. If th second item
@@ -57,7 +57,7 @@ public:
   virtual QPixmap calculateDifference(frameHandler *item2, int frame, QList<infoItem> &conversionInfoList, int amplificationFactor, bool markDifference) Q_DECL_OVERRIDE;
 
   // Get the number of bytes for one YUV frame with the current format
-  virtual qint64 getBytesPerFrame() { return srcPixelFormat.bytesPerFrame(frameSize); }
+  virtual qint64 getBytesPerFrame() const { return srcPixelFormat.bytesPerFrame(frameSize); }
 
   // If you know the frame size of the video, the file size (and optionally the bit depth) we can guess
   // the remaining values. The rate value is set if a matching format could be found.
@@ -74,7 +74,7 @@ public:
   virtual QLayout *createYUVVideoHandlerControls(bool isSizeFixed=false);
 
   // Get the name of the currently selected YUV pixel format
-  virtual QString getRawYUVPixelFormatName() { return srcPixelFormat.name; }
+  virtual QString getRawYUVPixelFormatName() const { return srcPixelFormat.name; }
   // Set the current yuv format and update the control. Only emit a signalHandlerChanged signal
   // if emitSignal is true.
   virtual void setYUVPixelFormatByName(const QString &name, bool emitSignal=false);
@@ -165,7 +165,7 @@ protected:
     bool operator==(const QString &a) const { return name == a; }
     bool operator!=(const QString &a) const { return name != a; }
     // Get the number of bytes for a frame with this yuvPixelFormat and the given size
-    qint64 bytesPerFrame(const QSize &frameSize);
+    qint64 bytesPerFrame(const QSize &frameSize) const;
     QString name;
     int bitsPerSample;
     int bitsPerPixelNominator;
@@ -186,9 +186,9 @@ protected:
     // Default constructor. Fill the list with all the supported YUV formats.
     YUVFormatList();
     // Get all the YUV formats as a formatted list (for the dropdonw control)
-    QStringList getFormattedNames();
+    QStringList getFormattedNames() const;
     // Get the yuvPixelFormat with the given name
-    yuvPixelFormat getFromName(const QString &name);
+    yuvPixelFormat getFromName(const QString &name) const;
   };
   static YUVFormatList yuvFormatList;
 

--- a/source/viewStateHandler.cpp
+++ b/source/viewStateHandler.cpp
@@ -112,7 +112,7 @@ void viewStateHandler::loadViewState(int slot, bool loadOnSeparateView)
     splitView[0]->setViewState(viewStates[slot].centerOffset, viewStates[slot].zoomFactor, viewStates[slot].splitting, viewStates[slot].splittingPoint, viewStates[slot].viewMode);
 }
 
-void viewStateHandler::savePlaylist(QDomElement root)
+void viewStateHandler::savePlaylist(QDomElement &root)
 {
   for (int i = 0; i < 8; i++)
   {
@@ -172,7 +172,7 @@ void viewStateHandler::savePlaylist(QDomElement root)
 
 }
 
-void viewStateHandler::loadPlaylist(QDomElement viewStateNode)
+void viewStateHandler::loadPlaylist(const QDomElement &viewStateNode)
 {
   // In order to get the pointers to the right playlist items, we need a list of all playlist items
   QList<playlistItem*> allPlaylistItems = playlist->getAllPlaylistItems();

--- a/source/viewStateHandler.h
+++ b/source/viewStateHandler.h
@@ -50,8 +50,8 @@ public:
   bool handleKeyPress(QKeyEvent *event, bool keyFromSeparateView);
 
   // Save the view states to the playlist
-  void savePlaylist(QDomElement plist);
-  void loadPlaylist(QDomElement viewStateNode);
+  void savePlaylist(QDomElement &plist);
+  void loadPlaylist(const QDomElement &viewStateNode);
 
 private:
 


### PR DESCRIPTION
1. Make parameters and methods const-correct.
2. Factor out the de265 library wrapper.
3. Janitorial work.