### PR TITLE
Display infoData for both playlist items, and other fixes/cleanups.

### DIFF
--- a/source/fileInfoWidget.h
+++ b/source/fileInfoWidget.h
@@ -42,6 +42,7 @@ struct infoItem
 struct infoData
 {
   explicit infoData(const QString &title = QString()) : title(title) {}
+  bool isEmpty() const { return title.isEmpty() && items.isEmpty(); }
   QString title;
   QList<infoItem> items;
 };
@@ -59,12 +60,16 @@ public:
   // the QGridLayout infoLayout.
   Q_SLOT void setInfo(const infoData &info1 = infoData(), const infoData &info2 = infoData());
 
-  // One of the buttons in the info panel was clicked.
-  Q_SIGNAL void infoButtonClicked(int row);
+  // One at a given row of a given infoIndex (0 or 1) was clicked.
+  // infoIndex 0 refers to info1 above, infoIndex 1 refers to info2 above
+  Q_SIGNAL void infoButtonClicked(int infoIndex, int row);
 
 private:
   // Clear widgets starting at given row.
   void clear(int startRow);
+
+  // Add information at the given grid row, for a given infoData index (0 or 1).
+  int addInfo(const infoData &data, int row, int infoIndex);
 
   // One of the buttons in the info panel was clicked.
   void infoButtonClickedSlot();

--- a/source/fileInfoWidget.h
+++ b/source/fileInfoWidget.h
@@ -41,6 +41,7 @@ struct infoItem
 
 struct infoData
 {
+  explicit infoData(const QString &title = QString()) : title(title) {}
   QString title;
   QList<infoItem> items;
 };

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -66,14 +66,15 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
   auto const fileInfoAdapter = [this]{
     playlistItem *items[2];
     ui.playlistTreeWidget->getSelectedItems(items[0], items[1]);
-    ui.fileInfoWidget->setInfo(items[0] ? items[0]->getInfo() : infoData());
+    ui.fileInfoWidget->setInfo(items[0] ? items[0]->getInfo() : infoData(),
+                               items[1] ? items[1]->getInfo() : infoData());
   };
   connect(ui.playlistTreeWidget, &PlaylistTreeWidget::selectionRangeChanged, ui.fileInfoWidget, fileInfoAdapter);
   connect(ui.playlistTreeWidget, &PlaylistTreeWidget::selectedItemChanged, ui.fileInfoWidget, fileInfoAdapter);
-  connect(ui.fileInfoWidget, &FileInfoWidget::infoButtonClicked, [this](int row){
+  connect(ui.fileInfoWidget, &FileInfoWidget::infoButtonClicked, [this](int infoIndex, int row){
     playlistItem *items[2];
     ui.playlistTreeWidget->getSelectedItems(items[0], items[1]);
-    if (items[0]) items[0]->infoListButtonPressed(row);
+    if (items[infoIndex]) items[infoIndex]->infoListButtonPressed(row);
   });
   connect(ui.playlistTreeWidget, &PlaylistTreeWidget::selectionRangeChanged, ui.playbackController, &PlaybackController::currentSelectedItemsChanged);
   connect(ui.playlistTreeWidget, &PlaylistTreeWidget::selectionRangeChanged, ui.propertiesWidget, &PropertiesWidget::currentSelectedItemsChanged);
@@ -81,7 +82,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
   connect(ui.playlistTreeWidget, &PlaylistTreeWidget::selectedItemChanged, ui.playbackController, &PlaybackController::selectionPropertiesChanged);
   connect(ui.playlistTreeWidget, &PlaylistTreeWidget::itemAboutToBeDeleted, ui.propertiesWidget, &PropertiesWidget::itemAboutToBeDeleted);
   connect(ui.playlistTreeWidget, &PlaylistTreeWidget::openFileDialog, this, &MainWindow::showFileOpenDialog);
-      
+
   ui.displaySplitView->setAttribute(Qt::WA_AcceptTouchEvents);
 
   createMenusAndActions();

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -114,7 +114,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
   ui.playlistTreeWidget->setViewStateHandler(&stateHandler);
 
   // Create the videoCache object
-  cache = new videoCache(ui.playlistTreeWidget, ui.playbackController);
+  cache = new videoCache(ui.playlistTreeWidget, ui.playbackController, this);
   ui.videoCacheStatus->setCache(cache);
 }
 

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -66,7 +66,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
   auto const fileInfoAdapter = [this]{
     playlistItem *items[2];
     ui.playlistTreeWidget->getSelectedItems(items[0], items[1]);
-    ui.fileInfoWidget->setInfo(items[0] ? infoData{items[0]->getInfoTitle(), items[0]->getInfoList()} : infoData());
+    ui.fileInfoWidget->setInfo(items[0] ? items[0]->getInfo() : infoData());
   };
   connect(ui.playlistTreeWidget, &PlaylistTreeWidget::selectionRangeChanged, ui.fileInfoWidget, fileInfoAdapter);
   connect(ui.playlistTreeWidget, &PlaylistTreeWidget::selectedItemChanged, ui.fileInfoWidget, fileInfoAdapter);

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -64,16 +64,14 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
 
   // Connect the playlistWidget signals to some slots
   auto const fileInfoAdapter = [this]{
-    playlistItem *items[2];
-    ui.playlistTreeWidget->getSelectedItems(items[0], items[1]);
+    auto items = ui.playlistTreeWidget->getSelectedItems();
     ui.fileInfoWidget->setInfo(items[0] ? items[0]->getInfo() : infoData(),
                                items[1] ? items[1]->getInfo() : infoData());
   };
   connect(ui.playlistTreeWidget, &PlaylistTreeWidget::selectionRangeChanged, ui.fileInfoWidget, fileInfoAdapter);
   connect(ui.playlistTreeWidget, &PlaylistTreeWidget::selectedItemChanged, ui.fileInfoWidget, fileInfoAdapter);
   connect(ui.fileInfoWidget, &FileInfoWidget::infoButtonClicked, [this](int infoIndex, int row){
-    playlistItem *items[2];
-    ui.playlistTreeWidget->getSelectedItems(items[0], items[1]);
+    auto items = ui.playlistTreeWidget->getSelectedItems();
     if (items[infoIndex]) items[infoIndex]->infoListButtonPressed(row);
   });
   connect(ui.playlistTreeWidget, &PlaylistTreeWidget::selectionRangeChanged, ui.playbackController, &PlaybackController::currentSelectedItemsChanged);

--- a/source/playlistItem.h
+++ b/source/playlistItem.h
@@ -82,8 +82,7 @@ public:
 
   // Return the info title and info list to be shown in the fileInfo groupBox.
   // The default implementations will return empty strings/list.
-  virtual QString getInfoTitle() const { return QString(); }
-  virtual QList<infoItem> getInfoList() const { return QList<infoItem>(); }
+  virtual infoData getInfo() const { return infoData(); }
   // If the playlist item indicates to put a button into the fileInfo, this call back is called if the user presses the button.
   virtual void infoListButtonPressed(int buttonID) { Q_UNUSED(buttonID); }
 

--- a/source/playlistItemDifference.cpp
+++ b/source/playlistItemDifference.cpp
@@ -39,26 +39,26 @@ playlistItemDifference::playlistItemDifference()
 /* For a difference item, the info list is just a list of the names of the
  * child elemnts.
  */
-QList<infoItem> playlistItemDifference::getInfoList() const
+infoData playlistItemDifference::getInfo() const
 {
-  QList<infoItem> infoList;
+  infoData info("Difference Info");
 
   if (childList.count() >= 1)
-    infoList.append(infoItem(QString("File 1"), childList[0]->getName()));
+    info.items.append(infoItem(QString("File 1"), childList[0]->getName()));
   if (childList.count() >= 2)
-    infoList.append(infoItem(QString("File 2"), childList[1]->getName()));
+    info.items.append(infoItem(QString("File 2"), childList[1]->getName()));
 
   // Report the position of the first difference in coding order
-  difference.reportFirstDifferencePosition(infoList);
+  difference.reportFirstDifferencePosition(info.items);
 
   // Report MSE
   for (int i = 0; i < difference.differenceInfoList.length(); i++)
   {
     infoItem p = difference.differenceInfoList[i];
-    infoList.append( p );
+    info.items.append(p);
   }
     
-  return infoList;
+  return info;
 }
 
 void playlistItemDifference::drawItem(QPainter *painter, int frameIdx, double zoomFactor, bool playback)

--- a/source/playlistItemDifference.h
+++ b/source/playlistItemDifference.h
@@ -30,8 +30,7 @@ class playlistItemDifference :
 public:
   playlistItemDifference();
 
-  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "Difference Info"; }
-  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
+  virtual infoData getInfo() const Q_DECL_OVERRIDE;
 
   virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "Difference Properties"; }
 

--- a/source/playlistItemHEVCFile.cpp
+++ b/source/playlistItemHEVCFile.cpp
@@ -151,29 +151,29 @@ playlistItemHEVCFile *playlistItemHEVCFile::newplaylistItemHEVCFile(const QDomEl
   return newFile;
 }
 
-QList<infoItem> playlistItemHEVCFile::getInfoList() const
+infoData playlistItemHEVCFile::getInfo() const
 {
-  QList<infoItem> infoList;
+  infoData info("HEVC File Info");
 
   // At first append the file information part (path, date created, file size...)
-  infoList.append(annexBFile.getFileInfoList());
+  info.items.append(annexBFile.getFileInfoList());
 
   if (wrapperError())
   {
-    infoList.append(infoItem("Error", wrapperErrorString()));
+    info.items.append(infoItem("Error", wrapperErrorString()));
   }
   else
   {
     QSize videoSize = yuvVideo.getFrameSize();
-    infoList.append(infoItem("Resolution", QString("%1x%2").arg(videoSize.width()).arg(videoSize.height()), "The video resolution in pixel (width x height)"));
-    infoList.append(infoItem("Num POCs", QString::number(annexBFile.getNumberPOCs()), "The number of pictures in the stream."));
-    infoList.append(infoItem("Frames Cached",QString::number(yuvVideo.getNrFramesCached())));
-    infoList.append(infoItem("Internals", wrapperInternalsSupported() ? "Yes" : "No", "Is the decoder able to provide internals (statistics)?"));
-    infoList.append(infoItem("Stat Parsing", retrieveStatistics ? "Yes" : "No", "Are the statistics of the sequence currently extracted from the stream?"));
-    infoList.append(infoItem("NAL units", "Show NAL units", "Show a detailed list of all NAL units.", true));
+    info.items.append(infoItem("Resolution", QString("%1x%2").arg(videoSize.width()).arg(videoSize.height()), "The video resolution in pixel (width x height)"));
+    info.items.append(infoItem("Num POCs", QString::number(annexBFile.getNumberPOCs()), "The number of pictures in the stream."));
+    info.items.append(infoItem("Frames Cached",QString::number(yuvVideo.getNrFramesCached())));
+    info.items.append(infoItem("Internals", wrapperInternalsSupported() ? "Yes" : "No", "Is the decoder able to provide internals (statistics)?"));
+    info.items.append(infoItem("Stat Parsing", retrieveStatistics ? "Yes" : "No", "Are the statistics of the sequence currently extracted from the stream?"));
+    info.items.append(infoItem("NAL units", "Show NAL units", "Show a detailed list of all NAL units.", true));
   }
 
-  return infoList;
+  return info;
 }
 
 void playlistItemHEVCFile::infoListButtonPressed(int buttonID)

--- a/source/playlistItemHEVCFile.h
+++ b/source/playlistItemHEVCFile.h
@@ -46,9 +46,7 @@ public:
   static playlistItemHEVCFile *newplaylistItemHEVCFile(const QDomElementYUView &root, const QString &playlistFilePath);
 
   // Return the info title and info list to be shown in the fileInfo groupBox.
-  // The default implementations will return empty strings/list.
-  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "HEVC File Info"; }
-  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
+  virtual infoData getInfo() const Q_DECL_OVERRIDE;
   virtual void infoListButtonPressed(int buttonID);
 
   virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "HEVC File Properties"; }

--- a/source/playlistItemImageFile.cpp
+++ b/source/playlistItemImageFile.cpp
@@ -153,24 +153,24 @@ ValuePairListSets playlistItemImageFile::getPixelValues(const QPoint &pixelPos, 
   return newSet;
 }
 
-QList<infoItem> playlistItemImageFile::getInfoList() const
+infoData playlistItemImageFile::getInfo() const
 {
-  QList<infoItem> infoList;
+  infoData info("Image Info");
 
-  infoList.append(infoItem("File", plItemNameOrFileName));
+  info.items.append(infoItem("File", plItemNameOrFileName));
   if (frame.isFormatValid())
   {
     QSize frameSize = frame.getFrameSize();
-    infoList.append(infoItem("Resolution", QString("%1x%2").arg(frameSize.width()).arg(frameSize.height()), "The video resolution in pixel (width x height)"));
+    info.items.append(infoItem("Resolution", QString("%1x%2").arg(frameSize.width()).arg(frameSize.height()), "The video resolution in pixel (width x height)"));
     QImage img = frame.getCurrentFrameAsImage();
-    infoList.append(infoItem("Bit depth", QString::number(img.depth()), "The bit depth of the image."));
+    info.items.append(infoItem("Bit depth", QString::number(img.depth()), "The bit depth of the image."));
   }
   else if (backgroundLoadingFuture.isRunning())
-    infoList.append(infoItem("Status", "Loading...", "The image is being loaded. Please wait."));
+    info.items.append(infoItem("Status", "Loading...", "The image is being loaded. Please wait."));
   else
-    infoList.append(infoItem("Status", "Error", "There was an error loading the image."));
+    info.items.append(infoItem("Status", "Error", "There was an error loading the image."));
 
-  return infoList;
+  return info;
 }
 
 void playlistItemImageFile::reloadItemSource()

--- a/source/playlistItemImageFile.h
+++ b/source/playlistItemImageFile.h
@@ -33,8 +33,7 @@ public:
 
   // ------ Overload from playlistItem
 
-  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "Image Info"; }
-  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
+  virtual infoData getInfo() const Q_DECL_OVERRIDE;
 
   virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "Image Properties"; }
 

--- a/source/playlistItemImageFileSequence.cpp
+++ b/source/playlistItemImageFileSequence.cpp
@@ -151,7 +151,7 @@ QList<infoItem> playlistItemImageFileSequence::getInfoList() const
     infoList.append(infoItem("Status", "Error", "There was an error loading the image."));
   
   if (loadPlaylistFrameMissing)
-    infoList.append(infoItem("Warging","Frames missing", "At least one frame could not be found when loading from playlist."));
+    infoList.append(infoItem("Warning", "Frames missing", "At least one frame could not be found when loading from playlist."));
 
   return infoList;
 }

--- a/source/playlistItemImageFileSequence.cpp
+++ b/source/playlistItemImageFileSequence.cpp
@@ -136,24 +136,24 @@ void playlistItemImageFileSequence::createPropertiesWidget()
   vAllLaout->insertStretch(2, 1);
 }
 
-QList<infoItem> playlistItemImageFileSequence::getInfoList() const
+infoData playlistItemImageFileSequence::getInfo() const
 {
-  QList<infoItem> infoList;
+  infoData info("Image Sequence Info");
 
   if (video.isFormatValid())
   {
     QSize videoSize = video.getFrameSize();
-    infoList.append(infoItem("Num Frames", QString::number(getNumberFrames())));
-    infoList.append(infoItem("Resolution", QString("%1x%2").arg(videoSize.width()).arg(videoSize.height()), "The video resolution in pixel (width x height)"));
-    infoList.append(infoItem("Frames Cached",QString::number(video.getNrFramesCached())));
+    info.items.append(infoItem("Num Frames", QString::number(getNumberFrames())));
+    info.items.append(infoItem("Resolution", QString("%1x%2").arg(videoSize.width()).arg(videoSize.height()), "The video resolution in pixels (width x height)"));
+    info.items.append(infoItem("Frames Cached", QString::number(video.getNrFramesCached())));
   }
   else
-    infoList.append(infoItem("Status", "Error", "There was an error loading the image."));
+    info.items.append(infoItem("Status", "Error", "There was an error loading the image."));
   
   if (loadPlaylistFrameMissing)
-    infoList.append(infoItem("Warning", "Frames missing", "At least one frame could not be found when loading from playlist."));
+    info.items.append(infoItem("Warning", "Frames missing", "At least one frame could not be found when loading from playlist."));
 
-  return infoList;
+  return info;
 }
 
 void playlistItemImageFileSequence::savePlaylist(QDomElement &root, const QDir &playlistDir) const

--- a/source/playlistItemImageFileSequence.h
+++ b/source/playlistItemImageFileSequence.h
@@ -35,8 +35,7 @@ public:
   virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) const Q_DECL_OVERRIDE;
 
   // Override from playlistItem. Return the info title and info list to be shown in the fileInfo groupBox.
-  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "Image Sequence Info"; }
-  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
+  virtual infoData getInfo() const Q_DECL_OVERRIDE;
 
   virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "Image Sequence Properties"; }
 

--- a/source/playlistItemOverlay.cpp
+++ b/source/playlistItemOverlay.cpp
@@ -40,12 +40,12 @@ playlistItemOverlay::playlistItemOverlay() :
 /* For an overlay item, the info list is just a list of the names of the
  * child elemnts.
  */
-QList<infoItem> playlistItemOverlay::getInfoList() const
+infoData playlistItemOverlay::getInfo() const
 {
-  QList<infoItem> infoList;
+  infoData info("Overlay Info");
 
   // Add the size of this playlistItemOverlay
-  infoList.append( infoItem("Overlay Size",QString("(%1,%2)").arg(getSize().width()).arg(getSize().height())) );
+  info.items.append( infoItem("Overlay Size",QString("(%1,%2)").arg(getSize().width()).arg(getSize().height())) );
 
   // Add the sizes of all child items
   for (int i = 0; i < childList.count(); i++)
@@ -54,10 +54,10 @@ QList<infoItem> playlistItemOverlay::getInfoList() const
     if (childItem)
     {
       QSize childSize = childItem->getSize();
-      infoList.append( infoItem(QString("Item %1 size").arg(i),QString("(%1,%2)").arg(childSize.width()).arg(childSize.height())) );
+      info.items.append( infoItem(QString("Item %1 size").arg(i),QString("(%1,%2)").arg(childSize.width()).arg(childSize.height())) );
     }
   }
-  return infoList;
+  return info;
 }
 
 ValuePairListSets playlistItemOverlay::getPixelValues(const QPoint &pixelPos, int frameIdx)

--- a/source/playlistItemOverlay.h
+++ b/source/playlistItemOverlay.h
@@ -30,8 +30,7 @@ class playlistItemOverlay : public playlistItemContainer
 public:
   playlistItemOverlay();
 
-  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "Overlay Info"; }
-  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
+  virtual infoData getInfo() const Q_DECL_OVERRIDE;
 
   virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "Overlay Properties"; }
 

--- a/source/playlistItemRawFile.cpp
+++ b/source/playlistItemRawFile.cpp
@@ -116,15 +116,15 @@ qint64 playlistItemRawFile::getNumberFrames() const
   return (bpf == 0) ? -1 : dataSource.getFileSize() / bpf;
 }
 
-QList<infoItem> playlistItemRawFile::getInfoList() const
+infoData playlistItemRawFile::getInfo() const
 {
-  QList<infoItem> infoList;
+  infoData info((rawFormat == YUV) ? "YUV File Info" : "RGB File Info");
 
   // At first append the file information part (path, date created, file size...)
-  infoList.append(dataSource.getFileInfoList());
+  info.items.append(dataSource.getFileInfoList());
 
-  infoList.append(infoItem("Num Frames", QString::number(getNumberFrames())));
-  infoList.append(infoItem("Bytes per Frame", QString("%1").arg(getBytesPerFrame())));
+  info.items.append(infoItem("Num Frames", QString::number(getNumberFrames())));
+  info.items.append(infoItem("Bytes per Frame", QString("%1").arg(getBytesPerFrame())));
 
   if (dataSource.isOk() && video->isFormatValid())
   {
@@ -136,12 +136,12 @@ QList<infoItem> playlistItemRawFile::getInfoList() const
     if ((dataSource.getFileSize() % bpf) != 0)
     {
       // Add a warning
-      infoList.append(infoItem("Warning", "The file size and the given video size and/or raw format do not match."));
+      info.items.append(infoItem("Warning", "The file size and the given video size and/or raw format do not match."));
     }
   }
-  infoList.append(infoItem("Frames Cached", QString::number(video->getNrFramesCached())));
+  info.items.append(infoItem("Frames Cached", QString::number(video->getNrFramesCached())));
 
-  return infoList;
+  return info;
 }
 
 void playlistItemRawFile::setFormatFromFileName()

--- a/source/playlistItemRawFile.h
+++ b/source/playlistItemRawFile.h
@@ -41,8 +41,7 @@ public:
   virtual void savePlaylist(QDomElement &root, const QDir &playlistDir) const Q_DECL_OVERRIDE;
 
   // Override from playlistItem. Return the info title and info list to be shown in the fileInfo groupBox.
-  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return (rawFormat == YUV) ? "YUV File Info" : "RGB File Info"; }
-  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
+  virtual infoData getInfo() const Q_DECL_OVERRIDE;
 
   virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return (rawFormat == YUV) ? "YUV File Properties" : "RGB File Properties"; }
 

--- a/source/playlistItemStatisticsFile.cpp
+++ b/source/playlistItemStatisticsFile.cpp
@@ -71,29 +71,29 @@ playlistItemStatisticsFile::~playlistItemStatisticsFile()
   }
 }
 
-QList<infoItem> playlistItemStatisticsFile::getInfoList() const
+infoData playlistItemStatisticsFile::getInfo() const
 {
-  QList<infoItem> infoList;
+  infoData info("Statistics File info");
 
   // Append the file information (path, date created, file size...)
-  infoList.append( file.getFileInfoList() );
+  info.items.append(file.getFileInfoList());
 
   // Is the file sorted by POC?
-  infoList.append(infoItem("Sorted by POC", fileSortedByPOC ? "Yes" : "No"));
+  info.items.append(infoItem("Sorted by POC", fileSortedByPOC ? "Yes" : "No"));
 
   // Show the progress of the background parsing (if running)
   if (backgroundParserFuture.isRunning())
-    infoList.append(infoItem("Parsing:", QString("%1%...").arg(backgroundParserProgress, 0, 'f', 2) ));
+    info.items.append(infoItem("Parsing:", QString("%1%...").arg(backgroundParserProgress, 0, 'f', 2) ));
 
   // Print a warning if one of the blocks in the statistics file is outside of the defined "frame size"
   if (blockOutsideOfFrame_idx != -1)
-    infoList.append(infoItem("Warning", QString("A block in frame %1 is outside of the given size of the statistics.").arg(blockOutsideOfFrame_idx)));
+    info.items.append(infoItem("Warning", QString("A block in frame %1 is outside of the given size of the statistics.").arg(blockOutsideOfFrame_idx)));
 
   // Show any errors that occured during parsing
   if (!parsingError.isEmpty())
-    infoList.append(infoItem("Parsing Error:", parsingError));
+    info.items.append(infoItem("Parsing Error:", parsingError));
 
-  return infoList;
+  return info;
 }
 
 void playlistItemStatisticsFile::drawItem(QPainter *painter, int frameIdx, double zoomFactor, bool playback)

--- a/source/playlistItemStatisticsFile.h
+++ b/source/playlistItemStatisticsFile.h
@@ -41,8 +41,7 @@ public:
   virtual QSize getSize() const Q_DECL_OVERRIDE { return statSource.statFrameSize; }
   
   // Return the info title and info list to be shown in the fileInfo groupBox.
-  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "Statistics File info"; }
-  virtual QList<infoItem> getInfoList() const Q_DECL_OVERRIDE;
+  virtual infoData getInfo() const Q_DECL_OVERRIDE;
 
   /* Get the title of the properties panel. The child class has to overload this.
    * This can be different depending on the type of playlistItem.

--- a/source/playlistItemText.h
+++ b/source/playlistItemText.h
@@ -35,7 +35,7 @@ public:
   playlistItemText(playlistItemText *cloneFromTxt);
   // ------ Overload from playlistItem
 
-  virtual QString getInfoTitle() const Q_DECL_OVERRIDE { return "Text Info"; }
+  virtual infoData getInfo() const Q_DECL_OVERRIDE { return infoData("Text Info"); }
 
   virtual QString getPropertiesTitle() const Q_DECL_OVERRIDE { return "Text Properties"; }
 

--- a/source/playlistTreeWidget.h
+++ b/source/playlistTreeWidget.h
@@ -19,6 +19,7 @@
 #ifndef PLAYLISTTREEWIDGET_H
 #define PLAYLISTTREEWIDGET_H
 
+#include <array>
 #include <QPointer>
 #include <QTreeWidget>
 #include "typedef.h"
@@ -57,7 +58,7 @@ public:
   QModelIndex indexForItem(playlistItem *item) { return indexFromItem((QTreeWidgetItem*)item); }
 
   // Get the first two selected items
-  void getSelectedItems(playlistItem *&first, playlistItem *&second) const;
+  std::array<playlistItem *, 2> getSelectedItems() const;
   // Set (up to two) selected items
   void setSelectedItems(playlistItem *item1, playlistItem *item2);
 

--- a/source/splitViewWidget.cpp
+++ b/source/splitViewWidget.cpp
@@ -149,8 +149,7 @@ void splitViewWidget::paintEvent(QPaintEvent *paint_event)
   int frame = playback->getCurrentFrame();
 
   // Get the playlist item(s) to draw
-  playlistItem *item[2];
-  playlist->getSelectedItems(item[0], item[1]);
+  auto item = playlist->getSelectedItems();
   bool anyItemsSelected = item[0] != NULL || item[1] != NULL;
 
   // The x position of the split (if splitting)
@@ -387,8 +386,7 @@ void splitViewWidget::paintEvent(QPaintEvent *paint_event)
 void splitViewWidget::updatePixelPositions()
 {
   // Get the selected item(s)
-  playlistItem *item[2];
-  playlist->getSelectedItems(item[0], item[1]);
+  auto item = playlist->getSelectedItems();
   bool anyItemsSelected = item[0] != NULL || item[1] != NULL;
 
   // Get the full size of the area that we can draw on (from the paint device base)
@@ -920,8 +918,7 @@ void splitViewWidget::updateMouseCursor(const QPoint &mousePos)
     // Not dragging or zooming. Show the normal cursor.
 
     // Get the item(s)
-    playlistItem *item[2];
-    playlist->getSelectedItems(item[0], item[1]);
+    auto item = playlist->getSelectedItems();
 
     if (splitting)
     {
@@ -1092,8 +1089,7 @@ void splitViewWidget::zoomToFit()
 
   centerOffset = QPoint(0,0);
 
-  playlistItem *item[2];
-  playlist->getSelectedItems(item[0], item[1]);
+  auto item = playlist->getSelectedItems();
 
   if (item[0] == NULL)
     // We cannot zoom to anything
@@ -1302,8 +1298,7 @@ QPixmap splitViewWidget::getScreenshot(bool fullItem)
   if (fullItem)
   {
     // Get the playlist item to draw
-    playlistItem *item[2];
-    playlist->getSelectedItems(item[0], item[1]);
+    auto item = playlist->getSelectedItems();
     if (item[0] == NULL)
       return QPixmap();
 

--- a/source/videoCache.cpp
+++ b/source/videoCache.cpp
@@ -125,22 +125,13 @@ videoCache::videoCache(PlaylistTreeWidget *playlistTreeWidget, PlaybackControlle
 
   // Create a bunch of new threads that we can use to cache frames in parallel
   for (int i = 0; i < QThread::idealThreadCount(); i++)
-    cachingThreadList.append( new cachingThread(parent) );
+    cachingThreadList.append(new cachingThread(this));
 
   // Connect the signals/slots to communicate with the cacheWorker.
   for (int i = 0; i < cachingThreadList.count(); i++)
     connect(cachingThreadList.at(i), &QThread::finished, this, &videoCache::threadCachingFinished);
 
   workerState = workerIdle;
-}
-
-videoCache::~videoCache()
-{
-  // Delete all caching threads
-  for (int i = 0; i < QThread::idealThreadCount(); i++)
-    delete cachingThreadList[i];
-
-  cachingThreadList.clear();
 }
 
 void videoCache::playlistChanged()

--- a/source/videoCache.cpp
+++ b/source/videoCache.cpp
@@ -226,20 +226,19 @@ void videoCache::updateCacheQueue()
     // 3: The item after 2 is next and so on (wrap around in the playlist) until the previous item is reached.
 
     // Let's start with the currently selected item (if no item is selected, the first item in the playlist is considered as being selected)
-    playlistItem *firstSelection, *secondSelection;
-    playlist->getSelectedItems(firstSelection, secondSelection);
-    if (firstSelection == NULL)
-      firstSelection = allItems[0];
+    auto selection = playlist->getSelectedItems();
+    if (selection[0] == NULL)
+      selection[0] = allItems[0];
 
     // caching was requested for a non-cachable item.
-    if (!firstSelection->isCachable())
+    if (!selection[0]->isCachable())
       return;
 
     // How much space do we need to cache the entire item?
-    indexRange range = firstSelection->getFrameIndexRange(); // These are the frames that we want to cache
-    qint64 cachingFrameSize = firstSelection->getCachingFrameSize();
+    indexRange range = selection[0]->getFrameIndexRange(); // These are the frames that we want to cache
+    qint64 cachingFrameSize = selection[0]->getCachingFrameSize();
     qint64 itemSpaceNeeded = (range.second - range.first + 1) * cachingFrameSize;
-    qint64 alreadyCached = firstSelection->getCachedFrames().count() * cachingFrameSize;
+    qint64 alreadyCached = selection[0]->getCachedFrames().count() * cachingFrameSize;
     itemSpaceNeeded -= alreadyCached;
 
     if (itemSpaceNeeded > cacheLevelMax && itemSpaceNeeded>0)
@@ -249,7 +248,7 @@ void videoCache::updateCacheQueue()
       // Delete all frames from all other items in the playlist from the cache and cache all frames from this item that fit
       for (playlistItem *item : allItems)
       {
-        if (item != firstSelection)
+        if (item != selection[0])
         {
           // Mark all frames of this item as "can be removed if required"
           QList<int> cachedFrames = item->getCachedFrames();
@@ -261,11 +260,11 @@ void videoCache::updateCacheQueue()
       }
 
       // Adjust the range so that only the number of frames are cached that will fit
-      qint64 nrFramesCachable = cacheLevelMax / firstSelection->getCachingFrameSize();
+      qint64 nrFramesCachable = cacheLevelMax / selection[0]->getCachingFrameSize();
       range.second = range.first + nrFramesCachable;
 
       // Enqueue the job. This is the only job.
-      cacheQueue.enqueue( cacheJob(firstSelection, range) );
+      cacheQueue.enqueue( cacheJob(selection[0], range) );
     }
     else if (itemSpaceNeeded > (cacheLevelMax - cacheLevel) && itemSpaceNeeded>0)
     {
@@ -275,12 +274,12 @@ void videoCache::updateCacheQueue()
 
       // We start from the item before the current item and go backwards in the list of all items.
       // The previous item is then last.
-      int itemPos = allItems.indexOf(firstSelection);
+      int itemPos = allItems.indexOf(selection[0]);
       assert(itemPos >= 0); // The current item is not in the list of all items? No possible.
       int i = itemPos - 2;
 
       // Get the cache level without the current item (frames from the current item do not relly occupy space in the cache. We want to cache them anyways)
-      qint64 cacheLevelWithoutCurrent = cacheLevel - firstSelection->getCachedFrames().count() * firstSelection->getCachingFrameSize();
+      qint64 cacheLevelWithoutCurrent = cacheLevel - selection[0]->getCachedFrames().count() * selection[0]->getCachingFrameSize();
       while ((itemSpaceNeeded + cacheLevelWithoutCurrent) > cacheLevelMax)
       {
         if (i < 0)
@@ -334,20 +333,20 @@ void videoCache::updateCacheQueue()
 
       // Enqueue the job. This is the only job.
       // We will not delete any frames from any other items to cache frames from other items.
-      cacheQueue.enqueue( cacheJob(firstSelection, range) );
+      cacheQueue.enqueue( cacheJob(selection[0], range) );
     }
     else
     {
       if (itemSpaceNeeded>0)
       {
-        DEBUG_CACHING("videoCache::All frames of %s fit.", firstSelection->getName().toLatin1().data());
+        DEBUG_CACHING("videoCache::All frames of %s fit.", selection[0]->getName().toLatin1().data());
         // All frames from the current item will fit and there is probably even space for more items.
         // We don't delete any frames from the cache but we will cache as many items as possible.
-        cacheQueue.enqueue( cacheJob(firstSelection, range) );
+        cacheQueue.enqueue( cacheJob(selection[0], range) );
         cacheLevel = cacheLevel + itemSpaceNeeded;
       }
       // Continue caching with the next item
-      int itemPos = allItems.indexOf(firstSelection);
+      int itemPos = allItems.indexOf(selection[0]);
       assert(itemPos >= 0); // The current item is not in the list of all items? No possible.
       int i = itemPos + 1;
 

--- a/source/videoCache.h
+++ b/source/videoCache.h
@@ -51,7 +51,6 @@ public:
   // The video cache interfaces with the playlist to see which items are going to be played next and the
   // playback controller to get the position in the video and the current state (playback/stop).
   videoCache(PlaylistTreeWidget *playlistTreeWidget, PlaybackController *playbackController, QObject *parent = 0);
-  virtual ~videoCache();
   unsigned int cacheRateInBytesPerMs;
 
 private slots:

--- a/source/viewStateHandler.cpp
+++ b/source/viewStateHandler.cpp
@@ -74,10 +74,9 @@ void viewStateHandler::saveViewState(int slot, bool saveOnSeparateView)
     return;
 
   // Get the selected items from the playlist
-  playlistItem *item1, *item2;
-  playlist->getSelectedItems(item1, item2);
-  selectionStates[slot][0] = item1;
-  selectionStates[slot][1] = item2;
+  auto items = playlist->getSelectedItems();
+  selectionStates[slot][0] = items[0];
+  selectionStates[slot][1] = items[1];
 
   // Get the current frame index from the playbackController
   playbackStateFrameIdx(slot) = playback->getCurrentFrame();
@@ -151,12 +150,11 @@ void viewStateHandler::savePlaylist(QDomElement &root)
   state.appendProperiteChild("frameIdx", QString::number(playback->getCurrentFrame()));
   
   // Append the IDs of the selected items
-  playlistItem *item1, *item2;
-  playlist->getSelectedItems(item1, item2);
-  if (item1 != NULL)
-    state.appendProperiteChild("itemID1",  QString::number(item1->getID()));
-  if (item2 != NULL)
-    state.appendProperiteChild("itemID2",  QString::number(item2->getID()));
+  auto items = playlist->getSelectedItems();
+  if (items[0] != NULL)
+    state.appendProperiteChild("itemID1",  QString::number(items[0]->getID()));
+  if (items[1] != NULL)
+    state.appendProperiteChild("itemID2",  QString::number(items[1]->getID()));
   
   // Append the state of the split view
   splitViewWidgetState viewState;

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -248,7 +248,33 @@
    <attribute name="dockWidgetArea">
     <number>2</number>
    </attribute>
-   <widget class="FileInfoWidget" name="fileInfoWidget"/>
+   <widget class="QScrollArea" name="fileInfoScrollArea">
+    <property name="frameShape">
+     <enum>QFrame::NoFrame</enum>
+    </property>
+    <property name="frameShadow">
+     <enum>QFrame::Plain</enum>
+    </property>
+    <property name="horizontalScrollBarPolicy">
+     <enum>Qt::ScrollBarAlwaysOff</enum>
+    </property>
+    <property name="sizeAdjustPolicy">
+     <enum>QAbstractScrollArea::AdjustToContents</enum>
+    </property>
+    <property name="widgetResizable">
+     <bool>true</bool>
+    </property>
+    <widget class="FileInfoWidget" name="fileInfoWidget">
+     <property name="geometry">
+      <rect>
+       <x>0</x>
+       <y>0</y>
+       <width>91</width>
+       <height>624</height>
+      </rect>
+     </property>
+    </widget>
+   </widget>
   </widget>
   <action name="actionOpen">
    <property name="text">


### PR DESCRIPTION
1. File info is shown for one or both selected playlist items.
2. File info is scrollable to keep the main window size from exploding.
3. File info is passed as a unit in `fileInfoData` struct: the title and the items go together.
