### PR TITLE
Protect all access to the pixmap cache and cachingFramesMutices.

### DIFF
--- a/source/videoHandlerRGB.cpp
+++ b/source/videoHandlerRGB.cpp
@@ -329,8 +329,7 @@ void videoHandlerRGB::slotDisplayOptionsChanged()
   // Set the current frame in the buffer to be invalid and clear the cache.
   // Emit that this item needs redraw and the cache needs updating.
   currentFrameIdx = -1;
-  if (pixmapCache.count() > 0)
-    pixmapCache.clear();
+  clearCache();
   emit signalHandlerChanged(true, true);
 }
 
@@ -390,8 +389,7 @@ void videoHandlerRGB::slotRGBFormatControlChanged()
     // The raw rgb data buffer also needs to be reloaded
     currentFrameRawRGBData_frameIdx = -1;
   }
-  if (pixmapCache.count() > 0)
-    pixmapCache.clear();
+  clearCache();
   emit signalHandlerChanged(true, true);
 }
 

--- a/source/videoHandlerYUV.cpp
+++ b/source/videoHandlerYUV.cpp
@@ -841,7 +841,7 @@ void videoHandlerYUV::setSrcPixelFormat(yuvPixelFormat format, bool emitSignal)
     currentImage_frameIndex = -1;
 
     // Clear the cache
-    pixmapCache.clear();
+    clearCache();
 
     if (srcPixelFormat.bytesPerFrame(frameSize) != oldFormatBytesPerFrame)
       // The number of bytes per frame changed. The raw YUV data buffer is also out of date
@@ -883,7 +883,7 @@ void videoHandlerYUV::slotYUVControlChanged()
     // Emit that this item needs redraw and the cache needs updating.
     currentFrameIdx = -1;
     currentImage_frameIndex = -1;
-    pixmapCache.clear();
+    clearCache();
     emit signalHandlerChanged(true, true);
   }
   else if (sender == ui.yuvFormatComboBox)
@@ -903,8 +903,7 @@ void videoHandlerYUV::slotYUVControlChanged()
     if (srcPixelFormat.bytesPerFrame(frameSize) != oldFormatBytesPerFrame)
       // The number of bytes per frame changed. The raw YUV data buffer also has to be updated.
       currentFrameRawYUVData_frameIdx = -1;
-    if (pixmapCache.count() > 0)
-      pixmapCache.clear();
+    clearCache();
     emit signalHandlerChanged(true, true);
   }
 }


### PR DESCRIPTION
Mutex protection is required for both reading and writing from the containers. *No* operation on a Qt container is thread-safe: not even `size()` or other const accessors.