### PR TITLE
Factor out platform image format, and related improvements.

### DIFF
--- a/YUView.pro
+++ b/YUView.pro
@@ -115,7 +115,8 @@ INCLUDEPATH += \
 
 OTHER_FILES += \
     HACKING.md \
-    README.md
+    README.md \
+    docs\about.html
 
 target.path = /usr/bin/
 

--- a/docs/about.html
+++ b/docs/about.html
@@ -23,9 +23,9 @@
                     <li><a href="mailto:blaeser@ient.rwth-aachen.de">Max Bl&auml;ser</a></li>
                     <li><a href="mailto:feldmann@ient.rwth-aachen.de">Christian Feldmann</a></li>
                 </ul>
-            <h3>Additional Contributions by</h3>
+            <h3>Contributors</h3>
                 <ul style="list-style-type:square">
-                    <li>Github user KubaO</li>
+                    <li><a href="https://github.com/KubaO/">Kuba Ober</a></li>
                 </ul>
             <h3>Former Developers</h3>
                 <ul style="list-style-type:square">

--- a/source/frameHandler.cpp
+++ b/source/frameHandler.cpp
@@ -18,7 +18,6 @@
 
 #include "frameHandler.h"
 
-#include <QBackingStore>
 #include <QPainter>
 #include "playlistItem.h"
 #include "signalsSlots.h"
@@ -70,33 +69,6 @@ frameHandler::frameSizePresetList frameHandler::presetFrameSizes;
 
 frameHandler::frameHandler()
 {
-  // Get the image format of the paint device. 
-  // TODO Is this correct/a good way of doing this?
-  imageFormat = QImage::Format_Invalid;
-  foreach(QWidget *w, QApplication::topLevelWidgets())
-  {
-    if (!w)
-      continue;
-
-    QBackingStore *bs = w->backingStore();
-    if (!bs)
-      continue;
-
-    QPaintDevice *pd = bs->paintDevice();
-    if (!pd)
-      continue;
-
-    QImage *img = dynamic_cast<QImage*>(pd);
-    if (!img)
-      continue;
-    
-    imageFormat = dynamic_cast<QImage*>(pd)->format();
-    break;
-  }
-
-  if (imageFormat == QImage::Format_Invalid)
-    // Revert to some default value
-    imageFormat = QImage::Format_ARGB32_Premultiplied;
 }
 
 QLayout *frameHandler::createFrameHandlerControls(bool isSizeFixed)
@@ -284,7 +256,7 @@ QImage frameHandler::calculateDifference(frameHandler *item2, const int frame, Q
   int width  = qMin(frameSize.width(), item2->frameSize.width());
   int height = qMin(frameSize.height(), item2->frameSize.height());
 
-  QImage diffImg(width, height, imageFormat);
+  QImage diffImg(width, height, platformImageFormat());
 
   // Also calculate the MSE while we're at it (R,G,B)
   qint64 mseAdd[3] = {0, 0, 0};

--- a/source/frameHandler.h
+++ b/source/frameHandler.h
@@ -93,9 +93,6 @@ protected:
   QRgb getPixelVal(const QPoint &pos)    { return getPixelVal(pos.x(), pos.y()); }
   virtual QRgb getPixelVal(int x, int y) { return currentImage.pixel(x, y);     }
 
-  // The image format that is used internally when handeling QImages
-  QImage::Format imageFormat;
-
 private:
 
   // A list of all frame size presets. Only used privately in this class. Defined in the .cpp file.

--- a/source/settingsDialog.h
+++ b/source/settingsDialog.h
@@ -49,9 +49,6 @@ private slots:
 
 private:
 
-  // The installed memory size. The constructor sets this.
-  unsigned int memSizeInMB;
-
   Ui::SettingsDialog ui;
 };
 

--- a/source/typedef.cpp
+++ b/source/typedef.cpp
@@ -47,3 +47,9 @@ void setupUi(void *ui, void(*setupUi)(void *ui, QWidget *widget))
   unparentWidgets(topLayout);
   Q_ASSERT(widget.findChildren<QObject*>().isEmpty());
 }
+
+QImage::Format pixmapImageFormat()
+{
+  static auto const format = QPixmap(1,1).toImage().format();
+  return (format != QImage::Format_Invalid) ? format : QImage::Format_RGB32;
+}

--- a/source/typedef.cpp
+++ b/source/typedef.cpp
@@ -51,5 +51,6 @@ void setupUi(void *ui, void(*setupUi)(void *ui, QWidget *widget))
 QImage::Format pixmapImageFormat()
 {
   static auto const format = QPixmap(1,1).toImage().format();
-  return (format != QImage::Format_Invalid) ? format : QImage::Format_RGB32;
+  Q_ASSERT(format != QImage::Format_Invalid);
+  return format;
 }

--- a/source/typedef.h
+++ b/source/typedef.h
@@ -310,4 +310,8 @@ inline int bytesPerPixel(QPixelFormat format)
 
 inline int bytesPerPixel(QImage::Format format) { return bytesPerPixel(QImage::toPixelFormat(format)); }
 
+// Returns the size of system memory in megabytes.
+// This function is thread safe and inexpensive to call.
+unsigned int systemMemorySizeInMB();
+
 #endif // TYPEDEF_H

--- a/source/typedef.h
+++ b/source/typedef.h
@@ -21,7 +21,6 @@
 
 #include <cassert>
 #include <cstring>
-#include <QCache>
 #include <QDomElement>
 #include <QHash>
 #include <QList>
@@ -267,5 +266,7 @@ public:
   }
   bool created() const { return m_created; }
 };
+
+
 
 #endif // TYPEDEF_H

--- a/source/typedef.h
+++ b/source/typedef.h
@@ -43,6 +43,12 @@ enum { is_Q_OS_WIN = 1 };
 enum { is_Q_OS_WIN = 0 };
 #endif
 
+#ifdef Q_OS_LINUX
+enum { is_Q_OS_LINUX = 1 };
+#else
+enum { is_Q_OS_LINUX = 0 };
+#endif
+
 // Activate SSE YUV conversion
 #define SSE_CONVERSION 0
 #if SSE_CONVERSION

--- a/source/typedef.h
+++ b/source/typedef.h
@@ -302,4 +302,12 @@ inline QImage::Format platformImageFormat()
   return pixmapImageFormat();
 }
 
+inline int bytesPerPixel(QPixelFormat format)
+{
+  auto const bits = format.bitsPerPixel();
+  return (bits >= 1) ? ((bits + 7) / 8) : 0;
+}
+
+inline int bytesPerPixel(QImage::Format format) { return bytesPerPixel(QImage::toPixelFormat(format)); }
+
 #endif // TYPEDEF_H

--- a/source/videoHandler.cpp
+++ b/source/videoHandler.cpp
@@ -205,24 +205,8 @@ void videoHandler::cacheFrame(int frameIdx)
 
 unsigned int videoHandler::getCachingFrameSize() const
 {
-  auto imageFormat = platformImageFormat();
-  int nrPixels = frameSize.width() * frameSize.height();
-
-  if (imageFormat == QImage::Format_RGB32 || imageFormat == QImage::Format_ARGB32 || 
-      imageFormat == QImage::Format_ARGB32_Premultiplied || imageFormat == QImage::Format_RGBX8888 || 
-      imageFormat == QImage::Format_RGBA8888 || imageFormat == QImage::Format_RGBA8888_Premultiplied ||
-      imageFormat == QImage::Format_BGR30 || imageFormat == QImage::Format_A2BGR30_Premultiplied || 
-      imageFormat == QImage::Format_RGB30 || imageFormat == QImage::Format_A2RGB30_Premultiplied)
-    return nrPixels * 4;
-  else if (imageFormat == QImage::Format_ARGB8565_Premultiplied || imageFormat == QImage::Format_RGB666 ||
-    imageFormat == QImage::Format_ARGB6666_Premultiplied || imageFormat == QImage::Format_ARGB8555_Premultiplied ||
-    imageFormat == QImage::Format_RGB888)
-    return nrPixels * 3;
-  else if (imageFormat == QImage::Format_RGB16 || imageFormat == QImage::Format_RGB555 ||
-           imageFormat == QImage::Format_RGB444 || imageFormat == QImage::Format_ARGB4444_Premultiplied)
-    return nrPixels * 2;
-
-  return 0;
+  auto bytes = bytesPerPixel(platformImageFormat());
+  return frameSize.width() * frameSize.height() * bytes;
 }
 
 QList<int> videoHandler::getCachedFrames() const

--- a/source/videoHandler.cpp
+++ b/source/videoHandler.cpp
@@ -205,6 +205,7 @@ void videoHandler::cacheFrame(int frameIdx)
 
 unsigned int videoHandler::getCachingFrameSize() const
 {
+  auto imageFormat = platformImageFormat();
   int nrPixels = frameSize.width() * frameSize.height();
 
   if (imageFormat == QImage::Format_RGB32 || imageFormat == QImage::Format_ARGB32 || 

--- a/source/videoHandlerRGB.cpp
+++ b/source/videoHandlerRGB.cpp
@@ -490,7 +490,7 @@ void videoHandlerRGB::convertRGBToImage(const QByteArray &sourceBuffer, QImage &
   QImage tmpImage((unsigned char*)tmpRGBBuffer.data(), frameSize.width(), frameSize.height(), QImage::Format_RGB888);
 
   // Set the videoHanlder image and image so the videoHandler can draw the item
-  outputImage = tmpImage.convertToFormat(imageFormat);
+  outputImage = tmpImage.convertToFormat(platformImageFormat());
 }
 
 // Convert the data in "sourceBuffer" from the format "srcPixelFormat" to RGB 888. While doing so, apply the
@@ -1099,7 +1099,7 @@ QImage videoHandlerRGB::calculateDifference(frameHandler *item2, const int frame
   // Convert the image in tmpDiffBufferRGB to a QImage using a QImage intermediate.
   // TODO: Isn't there a faster way to do this? Maybe load a image from "BMP"-like data?
   QImage tmpImage((unsigned char*)tmpDiffBufferRGB.data(), width, height, QImage::Format_RGB888);
-  return tmpImage.convertToFormat(imageFormat);
+  return tmpImage.convertToFormat(platformImageFormat());
 }
 
 void videoHandlerRGB::invalidateAllBuffers()

--- a/source/videoHandlerRGB.cpp
+++ b/source/videoHandlerRGB.cpp
@@ -1098,7 +1098,7 @@ QImage videoHandlerRGB::calculateDifference(frameHandler *item2, const int frame
 
   // Convert the image in tmpDiffBufferRGB to a QImage using a QImage intermediate.
   // TODO: Isn't there a faster way to do this? Maybe load a image from "BMP"-like data?
-  QImage tmpImage((unsigned char*)tmpDiffBufferRGB.data(), width, height, imageFormat);
+  QImage tmpImage((unsigned char*)tmpDiffBufferRGB.data(), width, height, QImage::Format_RGB888);
   return tmpImage.convertToFormat(imageFormat);
 }
 

--- a/source/videoHandlerYUV.cpp
+++ b/source/videoHandlerYUV.cpp
@@ -2782,7 +2782,7 @@ void videoHandlerYUV::convertYUVToImage(const QByteArray &sourceBuffer, QImage &
 #endif
 
     // Set the videoHanlder image and image so the videoHandler can draw the item
-    outputImage = tmpImage.convertToFormat(imageFormat);
+    outputImage = tmpImage.convertToFormat(platformImageFormat());
   }
   else
     outputImage = QImage();
@@ -3375,7 +3375,7 @@ QImage videoHandlerYUV::calculateDifference(frameHandler *item2, const int frame
   // Convert the image in tmpDiffBufferRGB to a QImage using a QImage intermediate.
   // TODO: Isn't there a faster way to do this? Maybe load a image from "BMP"-like data?
   QImage tmpImage((unsigned char*)tmpDiffBufferRGB.data(), w_out, h_out, QImage::Format_RGB888);
-  return tmpImage.convertToFormat(imageFormat);
+  return tmpImage.convertToFormat(platformImageFormat());
 }
 
 void videoHandlerYUV::setYUVPixelFormat(const yuvPixelFormat &newFormat, bool emitSignal)


### PR DESCRIPTION
1. Revert image format conversion bug that sneaked into videoHandlerRGB::calculateDifference.

2. Qt hardcodes the platform image format on Windows and Mac. On X windows, we can get it cheaply from the image embedded in a sample pixmap.

3. Use QPixelFormat to determine the number of bits and thus bytes used per pixel without having to enumerate every image format.

