### PR TITLE
Fix Missing Semicolon won't build

### DIFF
--- a/source/fileInfoWidget.h
+++ b/source/fileInfoWidget.h
@@ -60,7 +60,7 @@ struct infoData
   QString title;
   QList<infoItem> items;
 };
-Q_DECLARE_METATYPE(infoData)
+Q_DECLARE_METATYPE(infoData);
 
 class FileInfoWidget : public QWidget
 {


### PR DESCRIPTION
I tried building source with qt 4.8 mixed with JavaScript environment so I can bring this to a web version. I discovered that the compiler complained about this semicolon at line 63