### PR TITLE
typedef.h: fix INT_MAX redefinition warning

### DIFF
--- a/source/typedef.h
+++ b/source/typedef.h
@@ -44,7 +44,9 @@
 #include <QString>
 
 // Maximum possible value for int
+#ifndef INT_MAX
 #define INT_MAX 2147483647
+#endif
 #define INT_INVALID -1
 
 // Convenience macro definitions which can be used in if clauses:


### PR DESCRIPTION
gcc pre-defines the INT_MAX macro. Skip redefinition of INT_MAX to avoid build
time warnings.

In file included from source/frameHandler.h:38:0,
                 from source/videoHandler.h:36,
                 from source/videoHandlerYUV.h:36,
                 from source/videoHandlerYUV.cpp:33:
source/typedef.h:47:0: warning: "INT_MAX" redefined