### PR TITLE
Fix/Improve Linux deployment script

### DIFF
--- a/deployment_linux.sh
+++ b/deployment_linux.sh
@@ -31,7 +31,7 @@ make -w
 # copy files
 cd $SRC_DIR
 mkdir $DIRNAME
-cp $BUILD_DIR/YUView $DIRNAME
+cp $BUILD_DIR/build/release/YUView $DIRNAME
 
 # compress (tar) the directory
 tar czf ../$DIRNAME.tgz $DIRNAME/

--- a/deployment_linux.sh
+++ b/deployment_linux.sh
@@ -26,7 +26,7 @@ $QT_DIR/bin/qmake $PRO_FILE -r -spec linux-g++-64
 
 # run make
 make clean -w
-make -w
+make -j $(nproc) -w
 
 # copy files
 cd $SRC_DIR


### PR DESCRIPTION
`deployment_linux.sh` did not work properly since `qmake` places the final executable in `$BUILD_DIR/build/release` and not `$BUILD_DIR`, so it ended up making a tarball with an empty directory.

I also added a `-j` flag to the make command to speed up the build process. (`nproc` returns the number of logical processors)