### PR TITLE
backport of QOverload marco. for building with qt 5.5

### DIFF
--- a/source/typedef.h
+++ b/source/typedef.h
@@ -414,4 +414,42 @@ QStringList getThemeColors(QString themeName);
 QIcon convertIcon(QString iconPath);
 QPixmap convertPixmap(QString pixmapPath);
 
+#if QT_VERSION <= 0x050700
+// copied from newer version of qglobal.h 
+template <typename... Args>
+struct QNonConstOverload
+{
+    template <typename R, typename T>
+    Q_DECL_CONSTEXPR auto operator()(R (T::*ptr)(Args...)) const Q_DECL_NOTHROW -> decltype(ptr)
+    { return ptr; }
+    template <typename R, typename T>
+    static Q_DECL_CONSTEXPR auto of(R (T::*ptr)(Args...)) Q_DECL_NOTHROW -> decltype(ptr)
+    { return ptr; }
+};
+template <typename... Args>
+struct QConstOverload
+{
+    template <typename R, typename T>
+    Q_DECL_CONSTEXPR auto operator()(R (T::*ptr)(Args...) const) const Q_DECL_NOTHROW -> decltype(ptr)
+    { return ptr; }
+    template <typename R, typename T>
+    static Q_DECL_CONSTEXPR auto of(R (T::*ptr)(Args...) const) Q_DECL_NOTHROW -> decltype(ptr)
+    { return ptr; }
+};
+template <typename... Args>
+struct QOverload : QConstOverload<Args...>, QNonConstOverload<Args...>
+{
+    using QConstOverload<Args...>::of;
+    using QConstOverload<Args...>::operator();
+    using QNonConstOverload<Args...>::of;
+    using QNonConstOverload<Args...>::operator();
+    template <typename R>
+    Q_DECL_CONSTEXPR auto operator()(R (*ptr)(Args...)) const Q_DECL_NOTHROW -> decltype(ptr)
+    { return ptr; }
+    template <typename R>
+    static Q_DECL_CONSTEXPR auto of(R (*ptr)(Args...)) Q_DECL_NOTHROW -> decltype(ptr)
+    { return ptr; }
+};
+#endif
+
 #endif // TYPEDEF_H


### PR DESCRIPTION
YUView no longer build on Ubuntu 16.04, due to QOverload which requires a newer Qt version than is available. I backported the QOverload macro. Possibly we don't have to use QOverload at all, what did we use before?