### PR TITLE
class declaration missed in playlistTreeWidget.cpp

### DIFF
--- a/source/playlistTreeWidget.cpp
+++ b/source/playlistTreeWidget.cpp
@@ -41,6 +41,7 @@
 #include <QPainter>
 #include <QScopedValueRollback>
 #include <QSettings>
+#include <QHeaderView>
 #include "playlistItems.h"
 
 class bufferStatusWidget : public QWidget


### PR DESCRIPTION
	modified:   source/playlistTreeWidget.cpp

Class declaration missed, that causes compilation error.