### PR TITLE
fix VUI parsing and initialize some constant inferred values

### DIFF
--- a/source/fileSourceHEVCAnnexBFile.cpp
+++ b/source/fileSourceHEVCAnnexBFile.cpp
@@ -281,14 +281,20 @@ void fileSourceHEVCAnnexBFile::hrd_parameters::parse_hrd_parameters(sub_byte_rea
   if (maxNumSubLayersMinus1 >= 8)
     throw std::logic_error("The value of maxNumSubLayersMinus1 must be in the range of 0 to 7");
 
-  for(int i = 0; i <= maxNumSubLayersMinus1; i++) 
+  for(int i = 0; i <= maxNumSubLayersMinus1; i++)
   {
     READFLAG(fixed_pic_rate_general_flag[i]);
     if (!fixed_pic_rate_general_flag[i])
+    {
       READFLAG(fixed_pic_rate_within_cvs_flag[i]);
+    }
+    else
+    {
+      fixed_pic_rate_within_cvs_flag[i] = 1;
+    }
     if (fixed_pic_rate_within_cvs_flag[i])
     {
-      READFLAG(elemental_duration_in_tc_minus1[i]);
+      READUEV(elemental_duration_in_tc_minus1[i]);
       low_delay_hrd_flag[i] = false;
     }
     else

--- a/source/fileSourceHEVCAnnexBFile.h
+++ b/source/fileSourceHEVCAnnexBFile.h
@@ -178,27 +178,27 @@ protected:
     hrd_parameters();
     void parse_hrd_parameters(sub_byte_reader &reader, bool commonInfPresentFlag, int maxNumSubLayersMinus1, TreeItem *root);
 
-    bool nal_hrd_parameters_present_flag;
-    bool vcl_hrd_parameters_present_flag;
-    bool sub_pic_hrd_params_present_flag;
+    bool nal_hrd_parameters_present_flag = 0;
+    bool vcl_hrd_parameters_present_flag = 0;
+    bool sub_pic_hrd_params_present_flag = 0;
 
     int tick_divisor_minus2;
     int du_cpb_removal_delay_increment_length_minus1;
-    int sub_pic_cpb_params_in_pic_timing_sei_flag;
+    int sub_pic_cpb_params_in_pic_timing_sei_flag = 0;
     int dpb_output_delay_du_length_minus1;
 
     int bit_rate_scale;
     int cpb_size_scale;
     int cpb_size_du_scale;
-    int initial_cpb_removal_delay_length_minus1;
-    int au_cpb_removal_delay_length_minus1;
-    int dpb_output_delay_length_minus1;
+    int initial_cpb_removal_delay_length_minus1 = 23;
+    int au_cpb_removal_delay_length_minus1      = 23;
+    int dpb_output_delay_length_minus1          = 23;
 
-    bool fixed_pic_rate_general_flag[8];
-    bool fixed_pic_rate_within_cvs_flag[8];
-    bool elemental_duration_in_tc_minus1[8];
-    bool low_delay_hrd_flag[8];
-    int cpb_cnt_minus1[8];
+    bool fixed_pic_rate_general_flag[8]    = {0, 0, 0, 0, 0, 0, 0, 0};
+    bool fixed_pic_rate_within_cvs_flag[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    int elemental_duration_in_tc_minus1[8];
+    bool low_delay_hrd_flag[8]             = {0, 0, 0, 0, 0, 0, 0, 0};
+    int cpb_cnt_minus1[8]                  = {0, 0, 0, 0, 0, 0, 0, 0};
 
     sub_layer_hrd_parameters nal_sub_hrd[8];
     sub_layer_hrd_parameters vcl_sub_hrd[8];


### PR DESCRIPTION
now playback of HEVC-bitstreams containing VIUs is possible

... now hopefully based on the correct branch.