### PR TITLE
Specify desktop file to avoid a broken icon in title bar

### DIFF
--- a/source/yuviewapp.cpp
+++ b/source/yuviewapp.cpp
@@ -61,6 +61,9 @@ int main(int argc, char *argv[])
   QApplication::setApplicationVersion(versionString);
   QApplication::setOrganizationName("Institut für Nachrichtentechnik, RWTH Aachen University");
   QApplication::setOrganizationDomain("ient.rwth-aachen.de");
+#ifdef Q_OS_LINUX
+  QGuiApplication::setDesktopFileName("YUView");
+#endif
 
   QStringList args = app.arguments();
 


### PR DESCRIPTION
Otherwise, a generic X11/Wayland icon is shown.

The flatpak manifest will have to be adapted like this:
```
      - type: shell
        commands:
        - sed -i 's|setDesktopFileName("YUView")|setDesktopFileName("de.rwth_aachen.ient.YUView")|' source/yuviewapp.cpp
```