### PR TITLE
Fix upper/lower case of FFmpeg

### DIFF
--- a/source/FFMpegLibrariesHandling.cpp
+++ b/source/FFMpegLibrariesHandling.cpp
@@ -1212,10 +1212,10 @@ bool FFmpegVersionHandler::loadFFmpegLibraries()
   // First try the specific FFMpeg libraries (if set)
   QSettings settings;
   settings.beginGroup("Decoders");
-  QString avFormatLib = settings.value("FFMpeg.avformat", "").toString();
-  QString avCodecLib = settings.value("FFMpeg.avcodec", "").toString();
-  QString avUtilLib = settings.value("FFMpeg.avutil", "").toString();
-  QString swResampleLib = settings.value("FFMpeg.swresample", "").toString();
+  QString avFormatLib = settings.value("FFmpeg.avformat", "").toString();
+  QString avCodecLib = settings.value("FFmpeg.avcodec", "").toString();
+  QString avUtilLib = settings.value("FFmpeg.avutil", "").toString();
+  QString swResampleLib = settings.value("FFmpeg.swresample", "").toString();
   if (!avFormatLib.isEmpty() && !avCodecLib.isEmpty() && !avUtilLib.isEmpty() && !swResampleLib.isEmpty())
   {
     LOG("Trying to load the libraries specified in the settings.");

--- a/source/decoderFFmpeg.cpp
+++ b/source/decoderFFmpeg.cpp
@@ -81,7 +81,7 @@ decoderFFmpeg::decoderFFmpeg(AVCodecIDWrapper codecID, QSize size, QByteArray ex
   for (int i=0; i<AV_INPUT_BUFFER_PADDING_SIZE; i++)
     avPacketPaddingData.append((char)0);
 
-  DEBUG_FFMPEG("Created new FFMpeg decoder - codec %s%s", ff.getCodecName(codec), cachingDecoder ? " - caching" : "");
+  DEBUG_FFMPEG("Created new FFmpeg decoder - codec %s%s", ff.getCodecName(codec), cachingDecoder ? " - caching" : "");
 }
 
 decoderFFmpeg::decoderFFmpeg(AVCodecParametersWrapper codecpar, bool cachingDecoder) :
@@ -102,7 +102,7 @@ decoderFFmpeg::decoderFFmpeg(AVCodecParametersWrapper codecpar, bool cachingDeco
   flushing = false;
   internalsSupported = true;
 
-  DEBUG_FFMPEG("Created new FFMpeg decoder - codec %s%s", ff.getCodecName(codec), cachingDecoder ? " - caching" : "");
+  DEBUG_FFMPEG("Created new FFmpeg decoder - codec %s%s", ff.getCodecName(codec), cachingDecoder ? " - caching" : "");
 }
 
 decoderFFmpeg::~decoderFFmpeg()

--- a/source/playlistItemCompressedVideo.cpp
+++ b/source/playlistItemCompressedVideo.cpp
@@ -371,7 +371,7 @@ infoData playlistItemCompressedVideo::getInfo() const
   }
   info.items.append(infoItem("NAL units", "Bitstream Analysis", "Show a detailed list of all NAL units.", true, 0));
   if (decoderEngineType == decoderEngineFFMpeg)
-    info.items.append(infoItem("FFMpeg Log", "Show FFmpeg Log", "Show the log messages from FFmpeg.", true, 1));
+    info.items.append(infoItem("FFmpeg Log", "Show FFmpeg Log", "Show the log messages from FFmpeg.", true, 1));
 
   return info;
 }
@@ -890,7 +890,7 @@ void playlistItemCompressedVideo::getSupportedFileExtensions(QStringList &allExt
   ext << "hevc" << "h265" << "265" << "avc" << "h264" << "264" << "avi" << "avr" << "cdxl" << "xl" << "dv" << "dif" << "flm" << "flv" << "flv" << "h261" << "h26l" << "cgi" << "ivf" << "ivr" << "lvf"
       << "m4v" << "mkv" << "mk3d" << "mka" << "mks" << "mjpg" << "mjpeg" << "mpg" << "mpo" << "j2k" << "mov" << "mp4" << "m4a" << "3gp" << "3g2" << "mj2" << "mvi" << "mxg" << "v" << "ogg" 
       << "mjpg" << "viv" << "webm" << "xmv" << "ts" << "mxf";
-  QString filtersString = "FFMpeg files (";
+  QString filtersString = "FFmpeg files (";
   for (QString e : ext)
     filtersString.append(QString("*.%1").arg(e));
   filtersString.append(")");

--- a/source/settingsDialog.cpp
+++ b/source/settingsDialog.cpp
@@ -135,10 +135,10 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
   ui.lineEditLibHMFile->setText(settings.value("libHMFile", "").toString());
   ui.lineEditLibDav1d->setText(settings.value("libDav1dFile", "").toString());
   ui.lineEditLibJEMFile->setText(settings.value("libJEMFile", "").toString());
-  ui.lineEditAVFormat->setText(settings.value("FFMpeg.avformat", "").toString());
-  ui.lineEditAVCodec->setText(settings.value("FFMpeg.avcodec", "").toString());
-  ui.lineEditAVUtil->setText(settings.value("FFMpeg.avutil", "").toString());
-  ui.lineEditSWResample->setText(settings.value("FFMpeg.swresample", "").toString());
+  ui.lineEditAVFormat->setText(settings.value("FFmpeg.avformat", "").toString());
+  ui.lineEditAVCodec->setText(settings.value("FFmpeg.avcodec", "").toString());
+  ui.lineEditAVUtil->setText(settings.value("FFmpeg.avutil", "").toString());
+  ui.lineEditSWResample->setText(settings.value("FFmpeg.swresample", "").toString());
   settings.endGroup();
 }
 
@@ -387,10 +387,10 @@ void SettingsDialog::on_pushButtonSave_clicked()
   settings.setValue("libJEMFile", ui.lineEditLibJEMFile->text());
   settings.setValue("libDav1dFile", ui.lineEditLibDav1d->text());
   // FFMpeg files
-  settings.setValue("FFMpeg.avformat", ui.lineEditAVFormat->text());
-  settings.setValue("FFMpeg.avcodec", ui.lineEditAVCodec->text());
-  settings.setValue("FFMpeg.avutil", ui.lineEditAVUtil->text());
-  settings.setValue("FFMpeg.swresample", ui.lineEditSWResample->text());
+  settings.setValue("FFmpeg.avformat", ui.lineEditAVFormat->text());
+  settings.setValue("FFmpeg.avcodec", ui.lineEditAVCodec->text());
+  settings.setValue("FFmpeg.avutil", ui.lineEditAVUtil->text());
+  settings.setValue("FFmpeg.swresample", ui.lineEditSWResample->text());
   settings.endGroup();
   
   accept();

--- a/source/typedef.cpp
+++ b/source/typedef.cpp
@@ -69,13 +69,13 @@ QString getInputFormatName(inputFormat i)
 {
   if (i == inputInvalid || i == input_NUM)
     return "";
-  QStringList l = QStringList() << "annexBHEVC" << "annexBAVC" << "FFMpeg";
+  QStringList l = QStringList() << "annexBHEVC" << "annexBAVC" << "FFmpeg";
   return l.at((int)i);
 }
 
 inputFormat getInputFormatFromName(QString name)
 {
-  QStringList l = QStringList() << "annexBHEVC" << "annexBAVC" << "FFMpeg";
+  QStringList l = QStringList() << "annexBHEVC" << "annexBAVC" << "FFmpeg";
   int idx = l.indexOf(name);
   return (idx < 0 || idx >= input_NUM) ? inputInvalid : (inputFormat)idx;
 }
@@ -84,13 +84,13 @@ QString getDecoderEngineName(decoderEngine e)
 {
   if (e <= decoderEngineInvalid || e >= decoderEngineNum)
     return "";
-  QStringList l = QStringList() << "libDe265" << "HM" << "Dav1d" << "FFMpeg";
+  QStringList l = QStringList() << "libDe265" << "HM" << "Dav1d" << "FFmpeg";
   return l.at((int)e);
 }
 
 decoderEngine getDecoderEngineFromName(QString name)
 {
-  QStringList l = QStringList() << "libDe265" << "HM" << "Dav1d" << "FFMpeg";
+  QStringList l = QStringList() << "libDe265" << "HM" << "Dav1d" << "FFmpeg";
   int idx = l.indexOf(name);
   return (idx < 0 || idx >= decoderEngineNum) ? decoderEngineInvalid : (decoderEngine)idx;
 }

--- a/ui/settingsDialog.ui
+++ b/ui/settingsDialog.ui
@@ -845,13 +845,13 @@
        <item>
         <widget class="QGroupBox" name="groupBoxFFMpeg">
          <property name="toolTip">
-          <string>Specify the individual FFMpeg libraries to use. These will always be tried first.</string>
+          <string>Specify the individual FFmpeg libraries to use. These will always be tried first.</string>
          </property>
          <property name="whatsThis">
-          <string>Specify the individual FFMpeg libraries to use. These will always be tried first.</string>
+          <string>Specify the individual FFmpeg libraries to use. These will always be tried first.</string>
          </property>
          <property name="title">
-          <string>Specific FFMpeg Libraries</string>
+          <string>Specific FFmpeg Libraries</string>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>


### PR DESCRIPTION
The upper/lower case of FFmpeg library should be "FFmpeg" not "FFMpeg" as in
https://ffmpeg.org/

The "FFMpeg" strings only in UI is fixed to "FFmpeg".