### PR TITLE
Add missing include for assert

### DIFF
--- a/source/parserCommon.cpp
+++ b/source/parserCommon.cpp
@@ -31,6 +31,7 @@
 */
 
 #include "parserCommon.h"
+#include <assert.h>
 
 #include <QString>
 


### PR DESCRIPTION
My compiler (gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04) complain about the assertion. Adding header fix it.
```C++
source/parserCommon.cpp:80:7: error: ‘assert’ was not declared in this scope
       assert(nrBits < 8 && nrBits < curBitsLeft);
```