### PR TITLE
Issue/211 packed indicator from file name

### DIFF
--- a/YUViewLib/src/filesource/fileSource.cpp
+++ b/YUViewLib/src/filesource/fileSource.cpp
@@ -143,9 +143,6 @@ QList<infoItem> fileSource::getFileInfoList() const
 fileSource::fileFormat_t fileSource::formatFromFilename(QFileInfo fileInfo)
 {
   fileSource::fileFormat_t format;
-  format.frameSize = QSize();
-  format.frameRate = -1;
-  format.bitDepth = -1;
 
   // We are going to check two strings (one after the other) for indicators on the frames size, fps and bit depth.
   // 1: The file name, 2: The folder name that the file is contained in.
@@ -270,6 +267,16 @@ fileSource::fileFormat_t fileSource::formatFromFilename(QFileInfo fileInfo)
           format.bitDepth = bd;
           break;
         }
+      }
+    }
+
+    // If we were able to get a frame size, try to get an indicator for packed formats
+    if (format.frameSize.isValid())
+    {
+      QRegExp exp("(?:_|\\.|-)packed(?:_|\\.|-)");
+      if (exp.indexIn(name) > -1)
+      {
+        format.packed = true;
       }
     }
   }

--- a/YUViewLib/src/filesource/fileSource.h
+++ b/YUViewLib/src/filesource/fileSource.h
@@ -74,13 +74,14 @@ public:
   virtual bool seek(int64_t pos) { return !isFileOpened ? false : srcFile.seek(pos); }
   int64_t pos() { return !isFileOpened ? 0 : srcFile.pos(); }
 
-  // Guess the format (width, height, frameTate...) from the file name.
+  // Guess the format (width, height, framerate, packed/planar) from the file name.
   // Certain patterns are recognized. E.g: "something_352x288_24.yuv"
   struct fileFormat_t
   {
     QSize frameSize;
-    int frameRate;
-    int bitDepth;
+    int frameRate {-1};
+    int bitDepth {-1};
+    bool packed {false};
   };
   static fileFormat_t formatFromFilename(QFileInfo fileInfo);
 

--- a/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
@@ -367,7 +367,7 @@ void playlistItemRawFile::setFormatFromFileName()
 
     // We were able to extract width and height from the file name using
     // regular expressions. Try to get the pixel format by checking with the file size.
-    video->setFormatFromSizeAndName(fileFormat.frameSize, fileFormat.bitDepth, dataSource.getFileSize(), dataSource.getFileInfo());
+    video->setFormatFromSizeAndName(fileFormat.frameSize, fileFormat.bitDepth, fileFormat.packed, dataSource.getFileSize(), dataSource.getFileInfo());
     if (fileFormat.frameRate != -1)
       frameRate = fileFormat.frameRate;
   }

--- a/YUViewLib/src/video/videoHandler.h
+++ b/YUViewLib/src/video/videoHandler.h
@@ -82,7 +82,7 @@ public:
 
   // If you know the frame size and the bit depth and the file size then we can try to guess
   // the format from that. You can override this for a specific raw format. The default implementation does nothing.
-  virtual void setFormatFromSizeAndName(const QSize size, int bitDepth, int64_t fileSize, const QFileInfo &fileInfo) { Q_UNUSED(size); Q_UNUSED(bitDepth); Q_UNUSED(fileSize); Q_UNUSED(fileInfo); }
+  virtual void setFormatFromSizeAndName(const QSize size, int bitDepth, bool packed, int64_t fileSize, const QFileInfo &fileInfo) { Q_UNUSED(size); Q_UNUSED(bitDepth); Q_UNUSED(packed); Q_UNUSED(fileSize); Q_UNUSED(fileInfo); }
 
   // The input frame buffer. After the signal signalRequestFrame(int) is emitted, the corresponding frame should be in here and
   // requestedFrame_idx should be set.

--- a/YUViewLib/src/video/videoHandlerRGB.cpp
+++ b/YUViewLib/src/video/videoHandlerRGB.cpp
@@ -894,7 +894,7 @@ videoHandlerRGB::rgba_t videoHandlerRGB::getPixelValue(const QPoint &pixelPos) c
   return value;
 }
 
-void videoHandlerRGB::setFormatFromSizeAndName(const QSize size, int bitDepth, int64_t fileSize, const QFileInfo &fileInfo)
+void videoHandlerRGB::setFormatFromSizeAndName(const QSize size, int bitDepth, bool packed, int64_t fileSize, const QFileInfo &fileInfo)
 {
   // Get the file extension
   QString ext = fileInfo.suffix().toLower();
@@ -941,6 +941,7 @@ void videoHandlerRGB::setFormatFromSizeAndName(const QSize size, int bitDepth, i
       rgbPixelFormat cFormat;
       cFormat.setRGBFormatFromString(i == 0 ? subFormat : subFormat + "a");
       cFormat.bitsPerValue = bitDepth;
+      cFormat.planar = !packed;
 
       // Check if the file size and the assumed format match
       int bpf = cFormat.bytesPerFrame(size);
@@ -956,7 +957,7 @@ void videoHandlerRGB::setFormatFromSizeAndName(const QSize size, int bitDepth, i
 
   // Still no match. Set RGB 8 bit planar not alpha channel.
   // This will probably be wrong but we are out of options
-  rgbPixelFormat cFormat(8, true);
+  rgbPixelFormat cFormat(8, !packed);
   setSrcPixelFormat(cFormat);
 }
 

--- a/YUViewLib/src/video/videoHandlerRGB.h
+++ b/YUViewLib/src/video/videoHandlerRGB.h
@@ -122,7 +122,7 @@ public:
   // If you know the frame size of the video, the file size (and optionally the bit depth) we can guess
   // the remaining values. The rate value is set if a matching format could be found.
   // The sub format can be one of: "RGB", "GBR" or "BGR"
-  virtual void setFormatFromSizeAndName(const QSize size, int bitDepth, int64_t fileSize, const QFileInfo &fileInfo) Q_DECL_OVERRIDE;
+  virtual void setFormatFromSizeAndName(const QSize size, int bitDepth, bool packed, int64_t fileSize, const QFileInfo &fileInfo) Q_DECL_OVERRIDE;
 
   // Draw the pixel values of the visible pixels in the center of each pixel. Only draw values for the given range of pixels.
   // Overridden from playlistItemVideo. This is a RGB source, so we can draw the source RGB values from the source data.

--- a/YUViewLib/src/video/videoHandlerYUV.h
+++ b/YUViewLib/src/video/videoHandlerYUV.h
@@ -90,7 +90,7 @@ namespace YUV_Internals
     YUV_400,  // Luma only
     YUV_NUM_SUBSAMPLINGS
   } YUVSubsamplingType;
-
+  
   typedef enum
   {
     Order_YUV,
@@ -315,9 +315,11 @@ private:
 
   // Set the new pixel format thread save (lock the mutex). We should also emit that something changed (can be disabled).
   void setSrcPixelFormat(YUV_Internals::yuvPixelFormat newFormat, bool emitChangedSignal=true);
+  // Check the given format against the file size. Set the format if this is a match.
+  bool checkAndSetFormat(const YUV_Internals::yuvPixelFormat format, const QSize frameSize, const int64_t fileSize);
 
-  bool setFormatFromSizeAndNamePlanar(QString name, const QSize size, int bitDepth, int64_t fileSize);
-  bool setFormatFromSizeAndNamePacked(QString name, const QSize size, int bitDepth, int64_t fileSize);
+  bool setFormatFromSizeAndNamePlanar(QString name, const QSize size, int bitDepth, YUV_Internals::YUVSubsamplingType subsampling, int64_t fileSize);
+  bool setFormatFromSizeAndNamePacked(QString name, const QSize size, int bitDepth, YUV_Internals::YUVSubsamplingType subsampling, int64_t fileSize);
 
   bool canConvertToRGB(YUV_Internals::yuvPixelFormat format, QSize imageSize, QString *whyNot=nullptr) const;
 

--- a/YUViewLib/src/video/videoHandlerYUV.h
+++ b/YUViewLib/src/video/videoHandlerYUV.h
@@ -218,7 +218,7 @@ public:
   // If you know the frame size of the video, the file size (and optionally the bit depth) we can guess
   // the remaining values. The rate value is set if a matching format could be found.
   // If the sub format is "444" we will assume 4:4:4 input. Otherwise 4:2:0 will be assumed.
-  virtual void setFormatFromSizeAndName(const QSize size, int bitDepth, int64_t fileSize, const QFileInfo &fileInfo) Q_DECL_OVERRIDE;
+  virtual void setFormatFromSizeAndName(const QSize size, int bitDepth, bool packed, int64_t fileSize, const QFileInfo &fileInfo) Q_DECL_OVERRIDE;
 
   // Try to guess and set the format (frameSize/srcPixelFormat) from the raw YUV data.
   // If a file size is given, it is tested if the YUV format and the file size match.
@@ -315,6 +315,9 @@ private:
 
   // Set the new pixel format thread save (lock the mutex). We should also emit that something changed (can be disabled).
   void setSrcPixelFormat(YUV_Internals::yuvPixelFormat newFormat, bool emitChangedSignal=true);
+
+  bool setFormatFromSizeAndNamePlanar(QString name, const QSize size, int bitDepth, int64_t fileSize);
+  bool setFormatFromSizeAndNamePacked(QString name, const QSize size, int bitDepth, int64_t fileSize);
 
   bool canConvertToRGB(YUV_Internals::yuvPixelFormat format, QSize imageSize, QString *whyNot=nullptr) const;
 

--- a/YUViewUnitTest/filesource/filesource/tst_filesource.cpp
+++ b/YUViewUnitTest/filesource/filesource/tst_filesource.cpp
@@ -31,63 +31,69 @@ void fileSourceTest::testFormatFromFilename_data()
     QTest::addColumn<int>("height");
     QTest::addColumn<int>("framerate");
     QTest::addColumn<int>("bitDepth");
+    QTest::addColumn<bool>("packed");
 
     // Things that should work
-    QTest::newRow("testResolutionOnly1") << "something_1920x1080.yuv" << 1920 << 1080 << -1 << -1;
-    QTest::newRow("testResolutionOnly2") << "something_295x289.yuv" << 295 << 289 << -1 << -1;
-    QTest::newRow("testResolutionOnly3") << "something_295234x289234.yuv" << 295234 << 289234 << -1 << -1;
-    QTest::newRow("testResolutionOnly4") << "something_1920X1080.yuv" << 1920 << 1080 << -1 << -1;
-    QTest::newRow("testResolutionOnly5") << "something_1920*1080.yuv" << 1920 << 1080 << -1 << -1;
-    QTest::newRow("testResolutionOnly6") << "something_1920x1080_something.yuv" << 1920 << 1080 << -1 << -1;
+    QTest::newRow("testResolutionOnly1") << "something_1920x1080.yuv" << 1920 << 1080 << -1 << -1 << false;
+    QTest::newRow("testResolutionOnly2") << "something_295x289.yuv" << 295 << 289 << -1 << -1 << false;
+    QTest::newRow("testResolutionOnly3") << "something_295234x289234.yuv" << 295234 << 289234 << -1 << -1 << false;
+    QTest::newRow("testResolutionOnly4") << "something_1920X1080.yuv" << 1920 << 1080 << -1 << -1 << false;
+    QTest::newRow("testResolutionOnly5") << "something_1920*1080.yuv" << 1920 << 1080 << -1 << -1 << false;
+    QTest::newRow("testResolutionOnly6") << "something_1920x1080_something.yuv" << 1920 << 1080 << -1 << -1 << false;
     // Things that should not work
-    QTest::newRow("testResolutionOnly7") << "something_1920_1080.yuv" << -1 << -1 << -1 << -1;
-    QTest::newRow("testResolutionOnly8") << "something_19201080.yuv" << -1 << -1 << -1 << -1;
-    QTest::newRow("testResolutionOnly9") << "something_1920-1080.yuv" << -1 << -1 << -1 << -1;
-    QTest::newRow("testResolutionOnly10") << "something_1920-1080_something.yuv" << -1 << -1 << -1 << -1;
+    QTest::newRow("testResolutionOnly7") << "something_1920_1080.yuv" << -1 << -1 << -1 << -1 << false;
+    QTest::newRow("testResolutionOnly8") << "something_19201080.yuv" << -1 << -1 << -1 << -1 << false;
+    QTest::newRow("testResolutionOnly9") << "something_1920-1080.yuv" << -1 << -1 << -1 << -1 << false;
+    QTest::newRow("testResolutionOnly10") << "something_1920-1080_something.yuv" << -1 << -1 << -1 << -1 << false;
 
     // Things that should work
-    QTest::newRow("testResolutionAndFPS1") << "something_1920x1080_25.yuv" << 1920 << 1080 << 25 << -1;
-    QTest::newRow("testResolutionAndFPS2") << "something_1920x1080_999.yuv" << 1920 << 1080 << 999 << -1;
-    QTest::newRow("testResolutionAndFPS3") << "something_1920x1080_60Hz.yuv" << 1920 << 1080 << 60 << -1;
-    QTest::newRow("testResolutionAndFPS4") << "something_1920x1080_999_something.yuv" << 1920 << 1080 << 999 << -1;
-    QTest::newRow("testResolutionAndFPS5") << "something_1920x1080_60hz.yuv" << 1920 << 1080 << 60 << -1;
-    QTest::newRow("testResolutionAndFPS6") << "something_1920x1080_60HZ.yuv" << 1920 << 1080 << 60 << -1;
-    QTest::newRow("testResolutionAndFPS7") << "something_1920x1080_60fps.yuv" << 1920 << 1080 << 60 << -1;
-    QTest::newRow("testResolutionAndFPS8") << "something_1920x1080_60FPS.yuv" << 1920 << 1080 << 60 << -1;
+    QTest::newRow("testResolutionAndFPS1") << "something_1920x1080_25.yuv" << 1920 << 1080 << 25 << -1 << false;
+    QTest::newRow("testResolutionAndFPS2") << "something_1920x1080_999.yuv" << 1920 << 1080 << 999 << -1 << false;
+    QTest::newRow("testResolutionAndFPS3") << "something_1920x1080_60Hz.yuv" << 1920 << 1080 << 60 << -1 << false;
+    QTest::newRow("testResolutionAndFPS4") << "something_1920x1080_999_something.yuv" << 1920 << 1080 << 999 << -1 << false;
+    QTest::newRow("testResolutionAndFPS5") << "something_1920x1080_60hz.yuv" << 1920 << 1080 << 60 << -1 << false;
+    QTest::newRow("testResolutionAndFPS6") << "something_1920x1080_60HZ.yuv" << 1920 << 1080 << 60 << -1 << false;
+    QTest::newRow("testResolutionAndFPS7") << "something_1920x1080_60fps.yuv" << 1920 << 1080 << 60 << -1 << false;
+    QTest::newRow("testResolutionAndFPS8") << "something_1920x1080_60FPS.yuv" << 1920 << 1080 << 60 << -1 << false;
 
-    QTest::newRow("testResolutionAndFPSAndBitDepth1") << "something_1920x1080_25_8.yuv" << 1920 << 1080 << 25 << 8;
-    QTest::newRow("testResolutionAndFPSAndBitDepth2") << "something_1920x1080_25_12.yuv" << 1920 << 1080 << 25 << 12;
-    QTest::newRow("testResolutionAndFPSAndBitDepth3") << "something_1920x1080_25_8b.yuv" << 1920 << 1080 << 25 << 8;
-    QTest::newRow("testResolutionAndFPSAndBitDepth4") << "something_1920x1080_25_8b_something.yuv" << 1920 << 1080 << 25 << 8;
+    QTest::newRow("testResolutionAndFPSAndBitDepth1") << "something_1920x1080_25_8.yuv" << 1920 << 1080 << 25 << 8 << false;
+    QTest::newRow("testResolutionAndFPSAndBitDepth2") << "something_1920x1080_25_12.yuv" << 1920 << 1080 << 25 << 12 << false;
+    QTest::newRow("testResolutionAndFPSAndBitDepth3") << "something_1920x1080_25_8b.yuv" << 1920 << 1080 << 25 << 8 << false;
+    QTest::newRow("testResolutionAndFPSAndBitDepth4") << "something_1920x1080_25_8b_something.yuv" << 1920 << 1080 << 25 << 8 << false;
 
-    QTest::newRow("testResolutionIndicator1") << "something1080p.yuv" << 1920 << 1080 << -1 << -1;
-    QTest::newRow("testResolutionIndicator2") << "something1080pSomething.yuv" << 1920 << 1080 << -1 << -1;
-    QTest::newRow("testResolutionIndicator3") << "something1080p33.yuv" << 1920 << 1080 << 33 << -1;
-    QTest::newRow("testResolutionIndicator4") << "something1080p33Something.yuv" << 1920 << 1080 << 33 << -1;
-    QTest::newRow("testResolutionIndicator5") << "something720p.yuv" << 1280 << 720 << -1 << -1;
-    QTest::newRow("testResolutionIndicator6") << "something720pSomething.yuv" << 1280 << 720 << -1 << -1;
-    QTest::newRow("testResolutionIndicator7") << "something720p44.yuv" << 1280 << 720 << 44 << -1;
-    QTest::newRow("testResolutionIndicator8") << "something720p44Something.yuv" << 1280 << 720 << 44 << -1;
+    QTest::newRow("testResolutionIndicator1") << "something1080p.yuv" << 1920 << 1080 << -1 << -1 << false;
+    QTest::newRow("testResolutionIndicator2") << "something1080pSomething.yuv" << 1920 << 1080 << -1 << -1 << false;
+    QTest::newRow("testResolutionIndicator3") << "something1080p33.yuv" << 1920 << 1080 << 33 << -1 << false;
+    QTest::newRow("testResolutionIndicator4") << "something1080p33Something.yuv" << 1920 << 1080 << 33 << -1 << false;
+    QTest::newRow("testResolutionIndicator5") << "something720p.yuv" << 1280 << 720 << -1 << -1 << false;
+    QTest::newRow("testResolutionIndicator6") << "something720pSomething.yuv" << 1280 << 720 << -1 << -1 << false;
+    QTest::newRow("testResolutionIndicator7") << "something720p44.yuv" << 1280 << 720 << 44 << -1 << false;
+    QTest::newRow("testResolutionIndicator8") << "something720p44Something.yuv" << 1280 << 720 << 44 << -1 << false;
 
-    QTest::newRow("testResolutionKeyword1") << "something_cif.yuv" << 352 << 288 << -1 << -1;
-    QTest::newRow("testResolutionKeyword2") << "something_cifSomething.yuv" << 352 << 288 << -1 << -1;
-    QTest::newRow("testResolutionKeyword3") << "something_qcif.yuv" << 176 << 144 << -1 << -1;
-    QTest::newRow("testResolutionKeyword4") << "something_qcifSomething.yuv" << 176 << 144 << -1 << -1;
-    QTest::newRow("testResolutionKeyword5") << "something_4cif.yuv" << 704 << 576 << -1 << -1;
-    QTest::newRow("testResolutionKeyword6") << "something_4cifSomething.yuv" << 704 << 576 << -1 << -1;
-    QTest::newRow("testResolutionKeyword7") << "somethingUHDSomething.yuv" << 3840 << 2160 << -1 << -1;
-    QTest::newRow("testResolutionKeyword8") << "somethingHDSomething.yuv" << 1920 << 1080 << -1 << -1;
-    QTest::newRow("testResolutionKeyword9") << "something1080pSomething.yuv" << 1920 << 1080 << -1 << -1;
-    QTest::newRow("testResolutionKeyword10") << "something720pSomething.yuv" << 1280 << 720 << -1 << -1;
+    QTest::newRow("testResolutionKeyword1") << "something_cif.yuv" << 352 << 288 << -1 << -1 << false;
+    QTest::newRow("testResolutionKeyword2") << "something_cifSomething.yuv" << 352 << 288 << -1 << -1 << false;
+    QTest::newRow("testResolutionKeyword3") << "something_qcif.yuv" << 176 << 144 << -1 << -1 << false;
+    QTest::newRow("testResolutionKeyword4") << "something_qcifSomething.yuv" << 176 << 144 << -1 << -1 << false;
+    QTest::newRow("testResolutionKeyword5") << "something_4cif.yuv" << 704 << 576 << -1 << -1 << false;
+    QTest::newRow("testResolutionKeyword6") << "something_4cifSomething.yuv" << 704 << 576 << -1 << -1 << false;
+    QTest::newRow("testResolutionKeyword7") << "somethingUHDSomething.yuv" << 3840 << 2160 << -1 << -1 << false;
+    QTest::newRow("testResolutionKeyword8") << "somethingHDSomething.yuv" << 1920 << 1080 << -1 << -1 << false;
+    QTest::newRow("testResolutionKeyword9") << "something1080pSomething.yuv" << 1920 << 1080 << -1 << -1 << false;
+    QTest::newRow("testResolutionKeyword10") << "something720pSomething.yuv" << 1280 << 720 << -1 << -1 << false;
 
-    QTest::newRow("testBitDepthIndicator1") << "something_1920x1080_8Bit.yuv" << 1920 << 1080 << -1 << 8;
-    QTest::newRow("testBitDepthIndicator2") << "something_1920x1080_10Bit.yuv" << 1920 << 1080 << -1 << 10;
-    QTest::newRow("testBitDepthIndicator3") << "something_1920x1080_12Bit.yuv" << 1920 << 1080 << -1 << 12;
-    QTest::newRow("testBitDepthIndicator4") << "something_1920x1080_16Bit.yuv" << 1920 << 1080 << -1 << 16;
-    QTest::newRow("testBitDepthIndicator5") << "something_1920x1080_8bit.yuv" << 1920 << 1080 << -1 << 8;
-    QTest::newRow("testBitDepthIndicator6") << "something_1920x1080_8BIT.yuv" << 1920 << 1080 << -1 << 8;
-    QTest::newRow("testBitDepthIndicator7") << "something_1920x1080_8-Bit.yuv" << 1920 << 1080 << -1 << 8;
-    QTest::newRow("testBitDepthIndicator8") << "something_1920x1080_8-BIT.yuv" << 1920 << 1080 << -1 << 8;
+    QTest::newRow("testBitDepthIndicator1") << "something_1920x1080_8Bit.yuv" << 1920 << 1080 << -1 << 8 << false;
+    QTest::newRow("testBitDepthIndicator2") << "something_1920x1080_10Bit.yuv" << 1920 << 1080 << -1 << 10 << false;
+    QTest::newRow("testBitDepthIndicator3") << "something_1920x1080_12Bit.yuv" << 1920 << 1080 << -1 << 12 << false;
+    QTest::newRow("testBitDepthIndicator4") << "something_1920x1080_16Bit.yuv" << 1920 << 1080 << -1 << 16 << false;
+    QTest::newRow("testBitDepthIndicator5") << "something_1920x1080_8bit.yuv" << 1920 << 1080 << -1 << 8 << false;
+    QTest::newRow("testBitDepthIndicator6") << "something_1920x1080_8BIT.yuv" << 1920 << 1080 << -1 << 8 << false;
+    QTest::newRow("testBitDepthIndicator7") << "something_1920x1080_8-Bit.yuv" << 1920 << 1080 << -1 << 8 << false;
+    QTest::newRow("testBitDepthIndicator8") << "something_1920x1080_8-BIT.yuv" << 1920 << 1080 << -1 << 8 << false;
+
+    QTest::newRow("testPackedIndicator1") << "something_1920x1080_packed.yuv" << 1920 << 1080 << -1 << -1 << true;
+    QTest::newRow("testPackedIndicator2") << "something_1920x1080_packed-something.yuv" << 1920 << 1080 << -1 << -1 << true;
+    QTest::newRow("testPackedIndicator3") << "something_1920x1080packed.yuv" << 1920 << 1080 << -1 << -1 << false;
+    QTest::newRow("testPackedIndicator4") << "packed_something_1920x1080.yuv" << 1920 << 1080 << -1 << -1 << false;
 }
 
 void fileSourceTest::testFormatFromFilename()
@@ -97,6 +103,7 @@ void fileSourceTest::testFormatFromFilename()
     QFETCH(int, height);
     QFETCH(int, framerate);
     QFETCH(int, bitDepth);
+    QFETCH(bool, packed);
 
     QFileInfo fileInfo(filename);
     auto fileFormat = fileSource::formatFromFilename(fileInfo);
@@ -105,6 +112,7 @@ void fileSourceTest::testFormatFromFilename()
     QCOMPARE(fileFormat.frameSize.height(), height);
     QCOMPARE(fileFormat.frameRate, framerate);
     QCOMPARE(fileFormat.bitDepth, bitDepth);
+    QCOMPARE(fileFormat.packed, packed);
 }
 
 QTEST_MAIN(fileSourceTest)


### PR DESCRIPTION
Issue: https://github.com/IENT/YUView/issues/211

Things done: 
 - Add logic to handle the keyword "packed" in file names and then test various different formats around this for packed yuv/rgb files.