### PR TITLE
Feature/smart properties memory

### DIFF
--- a/YUViewLib/src/decoder/decoderDav1d.cpp
+++ b/YUViewLib/src/decoder/decoderDav1d.cpp
@@ -41,6 +41,7 @@
 #include "common/typedef.h"
 
 using namespace YUView;
+using namespace YUV_Internals;
 
 // Debug the decoder (0:off 1:interactive deocder only 2:caching decoder only 3:both)
 #define DECODERDAV1D_DEBUG_OUTPUT 0
@@ -254,7 +255,7 @@ bool decoderDav1d::decodeFrame()
     if (!s.isValid())
       DEBUG_DAV1D("decoderDav1d::decodeFrame got invalid frame size");
     auto subsampling = curPicture.getSubsampling();
-    if (subsampling == YUV_NUM_SUBSAMPLINGS)
+    if (subsampling == Subsampling::UNKNOWN)
       DEBUG_DAV1D("decoderDav1d::decodeFrame got invalid subsampling");
     int bitDepth = curPicture.getBitDepth();
     if (bitDepth < 8 || bitDepth > 16)
@@ -352,7 +353,7 @@ bool decoderDav1d::pushData(QByteArray &data)
       if (!s.isValid())
         DEBUG_DAV1D("decoderDav1d::pushData got invalid frame size");
       auto subsampling = convertFromInternalSubsampling(seq.layout);
-      if (subsampling == YUV_NUM_SUBSAMPLINGS)
+      if (subsampling == Subsampling::UNKNOWN)
         DEBUG_DAV1D("decoderDav1d::pushData got invalid subsampling");
       int bitDepth = (seq.hbd == 0 ? 8 : (seq.hbd == 1 ? 10 : (seq.hbd == 2 ? 12 : -1)));
       if (bitDepth < 8 || bitDepth > 16)
@@ -413,18 +414,18 @@ void decoderDav1d::copyImgToByteArray(const Dav1dPictureWrapper &src, QByteArray
 #endif
 {
   // How many image planes are there?
-  int nrPlanes = (src.getSubsampling() == YUV_400) ? 1 : 3;
+  int nrPlanes = (src.getSubsampling() == Subsampling::YUV_400) ? 1 : 3;
   
   // At first get how many bytes we are going to write
-  const int nrBytesPerSample = (src.getBitDepth() > 8) ? 2 : 1;
-  const QSize framSize = src.getFrameSize();
+  const auto nrBytesPerSample = (src.getBitDepth() > 8) ? 2 : 1;
+  const auto framSize = src.getFrameSize();
   int nrBytes = frameSize.width() * frameSize.height() * nrBytesPerSample;
-  YUVSubsamplingType layout = src.getSubsampling();
-  if (layout == YUV_420)
+  auto layout = src.getSubsampling();
+  if (layout == Subsampling::YUV_420)
     nrBytes += (frameSize.width() / 2) * (frameSize.height() / 2) * 2 * nrBytesPerSample;
-  else if (layout == YUV_422)
+  else if (layout == Subsampling::YUV_422)
     nrBytes += (frameSize.width() / 2) * frameSize.height() * 2 * nrBytesPerSample;
-  else if (layout == YUV_444)
+  else if (layout == Subsampling::YUV_444)
     nrBytes += frameSize.width() * frameSize.height() * 2 * nrBytesPerSample;
 
   DEBUG_DAV1D("decoderDav1d::copyImgToByteArray nrBytes %d", nrBytes);
@@ -442,9 +443,9 @@ void decoderDav1d::copyImgToByteArray(const Dav1dPictureWrapper &src, QByteArray
     int height = framSize.height();
     if (c != 0)
     {
-      if (layout == YUV_420 || layout == YUV_422)
+      if (layout == Subsampling::YUV_420 || layout == Subsampling::YUV_422)
         width /= 2;
-      if (layout == YUV_420)
+      if (layout == Subsampling::YUV_420)
         height /= 2;
     }
     const size_t widthInBytes = width * nrBytesPerSample;
@@ -514,19 +515,18 @@ QStringList decoderDav1d::getLibraryNames()
     return QStringList() << "libdav1d-internals" << "libdav1d";
 }
 
-YUVSubsamplingType decoderDav1d::convertFromInternalSubsampling(Dav1dPixelLayout layout)
+Subsampling decoderDav1d::convertFromInternalSubsampling(Dav1dPixelLayout layout)
 {
   if (layout == DAV1D_PIXEL_LAYOUT_I400)
-    return YUV_400;
+    return Subsampling::YUV_400;
   else if (layout == DAV1D_PIXEL_LAYOUT_I420)
-    return YUV_420;
+    return Subsampling::YUV_420;
   else if (layout == DAV1D_PIXEL_LAYOUT_I422)
-    return YUV_422;
+    return Subsampling::YUV_422;
   else if (layout == DAV1D_PIXEL_LAYOUT_I444)
-    return YUV_444;
+    return Subsampling::YUV_444;
 
-  // Invalid
-  return YUV_NUM_SUBSAMPLINGS;
+  return Subsampling::UNKNOWN;
 }
 
 void decoderDav1d::fillStatisticList(statisticHandler &statSource) const

--- a/YUViewLib/src/decoder/decoderDav1d.h
+++ b/YUViewLib/src/decoder/decoderDav1d.h
@@ -115,7 +115,7 @@ private:
   // If this is true, a frame is waiting from that step and decodeNextFrame will not actually decode a new frame.
   bool decodedFrameWaiting {false};
 
-  static YUVSubsamplingType convertFromInternalSubsampling(Dav1dPixelLayout layout);
+  static YUV_Internals::Subsampling convertFromInternalSubsampling(Dav1dPixelLayout layout);
 
   // Try to decode a frame. If successfull, the frame will be in curPicture.
   bool decodeFrame();
@@ -130,7 +130,7 @@ private:
     void clear() { memset(&curPicture, 0, sizeof(Dav1dPicture)); }
     QSize getFrameSize() const { return QSize(curPicture.p.w, curPicture.p.h); }
     Dav1dPicture *getPicture() const { return (Dav1dPicture*)(&curPicture); }
-    YUVSubsamplingType getSubsampling() const { return decoderDav1d::convertFromInternalSubsampling(curPicture.p.layout); }
+    YUV_Internals::Subsampling getSubsampling() const { return decoderDav1d::convertFromInternalSubsampling(curPicture.p.layout); }
     int getBitDepth() const { return curPicture.p.bpc; }
     uint8_t *getData(int component) const { return (uint8_t*)curPicture.data[component]; }
     ptrdiff_t getStride(int component) const { return curPicture.stride[component]; }

--- a/YUViewLib/src/decoder/decoderHM.cpp
+++ b/YUViewLib/src/decoder/decoderHM.cpp
@@ -228,7 +228,7 @@ bool decoderHM::getNextFrameFromDecoder()
   if (!picSize.isValid())
     DEBUG_DECHM("decoderHM::getNextFrameFromDecoder got invalid size");
   auto subsampling = convertFromInternalSubsampling(libHMDEC_get_chroma_format(currentHMPic));
-  if (subsampling == YUV_NUM_SUBSAMPLINGS)
+  if (subsampling == Subsampling::UNKNOWN)
     DEBUG_DECHM("decoderHM::getNextFrameFromDecoder got invalid chroma format");
   int bitDepth = libHMDEC_get_internal_bit_depth(currentHMPic, LIBHMDEC_LUMA);
   if (bitDepth < 8 || bitDepth > 16)
@@ -578,15 +578,14 @@ bool decoderHM::checkLibraryFile(QString libFilePath, QString &error)
   return !testDecoder.errorInDecoder();
 }
 
-YUVSubsamplingType decoderHM::convertFromInternalSubsampling(libHMDec_ChromaFormat fmt)
+Subsampling decoderHM::convertFromInternalSubsampling(libHMDec_ChromaFormat fmt)
 {
   if (fmt == LIBHMDEC_CHROMA_400)
-    return YUV_400;
+    return Subsampling::YUV_400;
   if (fmt == LIBHMDEC_CHROMA_420)
-    return YUV_420;
+    return Subsampling::YUV_420;
   if (fmt == LIBHMDEC_CHROMA_422)
-    return YUV_422;
+    return Subsampling::YUV_422;
 
-  // Invalid
-  return YUV_NUM_SUBSAMPLINGS;
+  return Subsampling::UNKNOWN;
 }

--- a/YUViewLib/src/decoder/decoderHM.h
+++ b/YUViewLib/src/decoder/decoderHM.h
@@ -131,7 +131,7 @@ private:
   int nrSignals { 0 };
 
   // Convert from libde265 types to YUView types
-  YUVSubsamplingType convertFromInternalSubsampling(libHMDec_ChromaFormat fmt);
+  YUV_Internals::Subsampling convertFromInternalSubsampling(libHMDec_ChromaFormat fmt);
 
   // Add the statistics supported by the HM decoder
   void fillStatisticList(statisticHandler &statSource) const Q_DECL_OVERRIDE;

--- a/YUViewLib/src/decoder/decoderLibde265.cpp
+++ b/YUViewLib/src/decoder/decoderLibde265.cpp
@@ -283,7 +283,7 @@ bool decoderLibde265::decodeFrame()
     if (!s.isValid())
       DEBUG_LIBDE265("decoderLibde265::decodeFrame got invalid frame size");
     auto subsampling = convertFromInternalSubsampling(de265_get_chroma_format(curImage));
-    if (subsampling == YUV_NUM_SUBSAMPLINGS)
+    if (subsampling == Subsampling::UNKNOWN)
       DEBUG_LIBDE265("decoderLibde265::decodeFrame got invalid subsampling");
     int bitDepth = de265_get_bits_per_pixel(curImage, 0);
     if (bitDepth < 8 || bitDepth > 16)
@@ -915,17 +915,16 @@ QStringList decoderLibde265::getLibraryNames()
   return libNames;
 }
 
-YUVSubsamplingType decoderLibde265::convertFromInternalSubsampling(de265_chroma fmt)
+Subsampling decoderLibde265::convertFromInternalSubsampling(de265_chroma fmt)
 {
   if (fmt == de265_chroma_mono)
-    return YUV_400;
+    return Subsampling::YUV_400;
   else if (fmt == de265_chroma_420)
-    return YUV_420;
+    return Subsampling::YUV_420;
   else if (fmt == de265_chroma_422)
-    return YUV_422;
+    return Subsampling::YUV_422;
   else if (fmt == de265_chroma_444)
-    return YUV_444;
+    return Subsampling::YUV_444;
   
-  // Invalid
-  return YUV_NUM_SUBSAMPLINGS;
+  return Subsampling::UNKNOWN;
 }

--- a/YUViewLib/src/decoder/decoderLibde265.h
+++ b/YUViewLib/src/decoder/decoderLibde265.h
@@ -141,7 +141,7 @@ private:
   const de265_image* curImage {nullptr};
 
   // Convert from libde265 types to YUView types
-  YUVSubsamplingType convertFromInternalSubsampling(de265_chroma fmt);
+  YUV_Internals::Subsampling convertFromInternalSubsampling(de265_chroma fmt);
   
   // Statistics caching
   void cacheStatistics(const de265_image *img);

--- a/YUViewLib/src/decoder/decoderVTM.cpp
+++ b/YUViewLib/src/decoder/decoderVTM.cpp
@@ -228,7 +228,7 @@ bool decoderVTM::getNextFrameFromDecoder()
   if (!picSize.isValid())
     DEBUG_DECVTM("decoderVTM::getNextFrameFromDecoder got invalid size");
   auto subsampling = convertFromInternalSubsampling(libVTMDec_get_chroma_format(currentVTMPic));
-  if (subsampling == YUV_NUM_SUBSAMPLINGS)
+  if (subsampling == Subsampling::UNKNOWN)
     DEBUG_DECVTM("decoderVTM::getNextFrameFromDecoder got invalid chroma format");
   int bitDepth = libVTMDec_get_internal_bit_depth(currentVTMPic, LIBVTMDEC_LUMA);
   if (bitDepth < 8 || bitDepth > 16)
@@ -575,17 +575,16 @@ bool decoderVTM::checkLibraryFile(QString libFilePath, QString &error)
   return !testDecoder.errorInDecoder();
 }
 
-YUVSubsamplingType decoderVTM::convertFromInternalSubsampling(libVTMDec_ChromaFormat fmt)
+Subsampling decoderVTM::convertFromInternalSubsampling(libVTMDec_ChromaFormat fmt)
 {
   if (fmt == LIBVTMDEC_CHROMA_400)
-    return YUV_400;
+    return Subsampling::YUV_400;
   if (fmt == LIBVTMDEC_CHROMA_420)
-    return YUV_420;
+    return Subsampling::YUV_420;
   if (fmt == LIBVTMDEC_CHROMA_422)
-    return YUV_422;
+    return Subsampling::YUV_422;
   if (fmt == LIBVTMDEC_CHROMA_444)
-    return YUV_444;
+    return Subsampling::YUV_444;
 
-  // Invalid
-  return YUV_NUM_SUBSAMPLINGS;
+  return Subsampling::UNKNOWN;
 }

--- a/YUViewLib/src/decoder/decoderVTM.h
+++ b/YUViewLib/src/decoder/decoderVTM.h
@@ -125,7 +125,7 @@ private:
   int nrSignals { 0 };
 
   // Convert from libde265 types to YUView types
-  YUVSubsamplingType convertFromInternalSubsampling(libVTMDec_ChromaFormat fmt);
+  YUV_Internals::Subsampling convertFromInternalSubsampling(libVTMDec_ChromaFormat fmt);
 
   // Add the statistics supported by the HM decoder
   void fillStatisticList(statisticHandler &statSource) const Q_DECL_OVERRIDE;

--- a/YUViewLib/src/ffmpeg/FFMpegLibrariesHandling.cpp
+++ b/YUViewLib/src/ffmpeg/FFMpegLibrariesHandling.cpp
@@ -49,8 +49,6 @@
 #endif
 
 using namespace YUView;
-using namespace YUV_Internals;
-using namespace RGB_Internals;
 
 namespace
 {
@@ -1520,38 +1518,38 @@ AVPixFmtDescriptorWrapper FFmpegVersionHandler::getAvPixFmtDescriptionFromAvPixe
   return AVPixFmtDescriptorWrapper(lib.av_pix_fmt_desc_get(pixFmt), libVersion);
 }
 
-yuvPixelFormat AVPixFmtDescriptorWrapper::getYUVPixelFormat()
+YUV_Internals::yuvPixelFormat AVPixFmtDescriptorWrapper::getYUVPixelFormat()
 {
   if (getRawFormat() == raw_RGB || !flagsSupported())
-    return yuvPixelFormat();
+    return YUV_Internals::yuvPixelFormat();
 
-  YUVSubsamplingType subsampling;
+  YUV_Internals::Subsampling subsampling;
   if (nb_components == 1)
-    subsampling = YUV_400;
+    subsampling = YUV_Internals::Subsampling::YUV_400;
   else if (log2_chroma_w == 0 && log2_chroma_h == 0)
-    subsampling = YUV_444;
+    subsampling = YUV_Internals::Subsampling::YUV_444;
   else if (log2_chroma_w == 1 && log2_chroma_h == 0)
-    subsampling = YUV_422;
+    subsampling = YUV_Internals::Subsampling::YUV_422;
   else if (log2_chroma_w == 1 && log2_chroma_h == 1)
-    subsampling = YUV_420;
+    subsampling = YUV_Internals::Subsampling::YUV_420;
   else if (log2_chroma_w == 0 && log2_chroma_h == 1)
-    subsampling = YUV_440;
+    subsampling = YUV_Internals::Subsampling::YUV_440;
   else if (log2_chroma_w == 2 && log2_chroma_h == 2)
-    subsampling = YUV_410;
+    subsampling = YUV_Internals::Subsampling::YUV_410;
   else if (log2_chroma_w == 0 && log2_chroma_h == 2)
-    subsampling = YUV_411;
+    subsampling = YUV_Internals::Subsampling::YUV_411;
   else
-    return yuvPixelFormat();
+    return YUV_Internals::yuvPixelFormat();
   
-  YUVPlaneOrder planeOrder;
+  YUV_Internals::PlaneOrder planeOrder;
   if (nb_components == 1)
-    planeOrder = Order_YUV;
+    planeOrder = YUV_Internals::PlaneOrder::YUV;
   else if (nb_components == 3 && !flagHasAlphaPlane())
-    planeOrder = Order_YUV;
+    planeOrder = YUV_Internals::PlaneOrder::YUV;
   else if (nb_components == 4 && flagHasAlphaPlane())
-    planeOrder = Order_YUVA;
+    planeOrder = YUV_Internals::PlaneOrder::YUVA;
   else
-    return yuvPixelFormat();
+    return YUV_Internals::yuvPixelFormat();
     
   bool bigEndian = flagIsBigEndian();
 
@@ -1559,83 +1557,83 @@ yuvPixelFormat AVPixFmtDescriptorWrapper::getYUVPixelFormat()
   for (int i=1; i<nb_components; i++)
     if (comp[i].depth != bitsPerSample)
       // Varying bit depths for components is not supported
-      return yuvPixelFormat();
+      return YUV_Internals::yuvPixelFormat();
   
   if (flagIsBitWisePacked() || !flagIsPlanar())
     // Maybe this could be supported but I don't think that any decoder actually uses this.
     // If you encounter a format that does not work because of this check please let us know.
-    return yuvPixelFormat();
+    return YUV_Internals::yuvPixelFormat();
 
-  return yuvPixelFormat(subsampling, bitsPerSample, planeOrder, bigEndian);
+  return YUV_Internals::yuvPixelFormat(subsampling, bitsPerSample, planeOrder, bigEndian);
 }
 
-rgbPixelFormat AVPixFmtDescriptorWrapper::getRGBPixelFormat()
+RGB_Internals::rgbPixelFormat AVPixFmtDescriptorWrapper::getRGBPixelFormat()
 {
   if (getRawFormat() == raw_YUV || !flagsSupported())
-    return rgbPixelFormat();
+    return RGB_Internals::rgbPixelFormat();
 
   int bitsPerSample = comp[0].depth;
   for (int i=1; i<nb_components; i++)
     if (comp[i].depth != bitsPerSample)
       // Varying bit depths for components is not supported
-      return rgbPixelFormat();
+      return RGB_Internals::rgbPixelFormat();
 
   if (flagIsBitWisePacked() || !flagIsPlanar())
     // Maybe this could be supported but I don't think that any decoder actually uses this.
     // If you encounter a format that does not work because of this check please let us know.
-    return rgbPixelFormat();
+    return RGB_Internals::rgbPixelFormat();
 
   // The only possible order of planes seems to be RGB(A)
-  return rgbPixelFormat(bitsPerSample, true, 0, 1, 2, flagHasAlphaPlane() ? 3 : -1);
+  return RGB_Internals::rgbPixelFormat(bitsPerSample, true, 0, 1, 2, flagHasAlphaPlane() ? 3 : -1);
 }
 
 bool AVPixFmtDescriptorWrapper::setValuesFromYUVPixelFormat(YUV_Internals::yuvPixelFormat fmt)
 {
-  if (fmt.planeOrder == Order_YVU || fmt.planeOrder == Order_YVUA)
+  if (fmt.planeOrder == YUV_Internals::PlaneOrder::YVU || fmt.planeOrder == YUV_Internals::PlaneOrder::YVUA)
     return false;
 
-  if (fmt.subsampling == YUV_422)
+  if (fmt.subsampling == YUV_Internals::Subsampling::YUV_422)
   {
     log2_chroma_w = 1;
     log2_chroma_h = 0;
   }
-  else if (fmt.subsampling == YUV_422)
+  else if (fmt.subsampling == YUV_Internals::Subsampling::YUV_422)
   {
     log2_chroma_w = 1;
     log2_chroma_h = 0;
   }
-  else if (fmt.subsampling == YUV_420)
+  else if (fmt.subsampling == YUV_Internals::Subsampling::YUV_420)
   {
     log2_chroma_w = 1;
     log2_chroma_h = 1;
   }
-  else if (fmt.subsampling == YUV_440)
+  else if (fmt.subsampling == YUV_Internals::Subsampling::YUV_440)
   {
     log2_chroma_w = 0;
     log2_chroma_h = 1;
   }
-  else if (fmt.subsampling == YUV_410)
+  else if (fmt.subsampling == YUV_Internals::Subsampling::YUV_410)
   {
     log2_chroma_w = 2;
     log2_chroma_h = 2;
   }
-  else if (fmt.subsampling == YUV_411)
+  else if (fmt.subsampling == YUV_Internals::Subsampling::YUV_411)
   {
     log2_chroma_w = 0;
     log2_chroma_h = 2;
   }
-  else if (fmt.subsampling == YUV_400)
+  else if (fmt.subsampling == YUV_Internals::Subsampling::YUV_400)
     nb_components = 1;
   else
     return false;
 
-  nb_components = fmt.subsampling == YUV_400 ? 1 : 3;
+  nb_components = fmt.subsampling == YUV_Internals::Subsampling::YUV_400 ? 1 : 3;
 
   if (fmt.bigEndian)
     flags += (1 << 0);
   if (fmt.planar)
     flags += (1 << 4);
-  if (fmt.planeOrder == Order_YUVA)
+  if (fmt.planeOrder == YUV_Internals::PlaneOrder::YUVA)
     // Has alpha channel
     flags += (1 << 7);
 
@@ -1693,7 +1691,7 @@ bool AVPixFmtDescriptorWrapper::operator==(const AVPixFmtDescriptorWrapper &othe
   return true;
 }
 
-AVPixelFormat FFmpegVersionHandler::getAVPixelFormatFromYUVPixelFormat(yuvPixelFormat pixFmt)
+AVPixelFormat FFmpegVersionHandler::getAVPixelFormatFromYUVPixelFormat(YUV_Internals::yuvPixelFormat pixFmt)
 {
   AVPixFmtDescriptorWrapper wrapper;
   wrapper.setValuesFromYUVPixelFormat(pixFmt);

--- a/YUViewLib/src/filesource/fileSourceFFmpegFile.cpp
+++ b/YUViewLib/src/filesource/fileSourceFFmpegFile.cpp
@@ -516,11 +516,11 @@ void fileSourceFFmpegFile::openFileAndFindVideoStream(QString fileName)
   frameSize.setHeight(h);
 
   if (colSpace == AVCOL_SPC_BT2020_NCL || colSpace == AVCOL_SPC_BT2020_CL)
-    colorConversionType = BT2020_LimitedRange;
+    colorConversionType = ColorConversion::BT2020_LimitedRange;
   else if (colSpace == AVCOL_SPC_BT470BG || colSpace == AVCOL_SPC_SMPTE170M)
-    colorConversionType = BT601_LimitedRange;
+    colorConversionType = ColorConversion::BT601_LimitedRange;
   else
-    colorConversionType = BT709_LimitedRange;
+    colorConversionType = ColorConversion::BT709_LimitedRange;
 
   isFileOpened = true;
 }

--- a/YUViewLib/src/handler/itemMemoryHandler.cpp
+++ b/YUViewLib/src/handler/itemMemoryHandler.cpp
@@ -1,0 +1,125 @@
+/*  This file is part of YUView - The YUV player with advanced analytics toolset
+*   <https://github.com/IENT/YUView>
+*   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   In addition, as a special exception, the copyright holders give
+*   permission to link the code of portions of this program with the
+*   OpenSSL library under certain conditions as described in each
+*   individual source file, and distribute linked combinations including
+*   the two.
+*   
+*   You must obey the GNU General Public License in all respects for all
+*   of the code used other than OpenSSL. If you modify file(s) with this
+*   exception, you may extend this exception to your version of the
+*   file(s), but you are not obligated to do so. If you do not wish to do
+*   so, delete this exception statement from your version. If you delete
+*   this exception statement from all source files in the program, then
+*   also delete it here.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "itemMemoryHandler.h"
+
+#include <QDateTime>
+#include <QSettings>
+
+namespace itemMemoryHandler
+{
+
+struct ItemData
+{
+  QString filePath;
+  QDateTime itemChangedLast;
+  QString format;
+};
+
+QList<ItemData> getAllValidItems()
+{
+  QSettings settings;
+  QList<ItemData> validItems;
+  auto timeYesterday = QDateTime::currentDateTime().addDays(-1);
+
+  auto size = settings.beginReadArray("itemMemory");
+  for (int i = 0; i < size; ++i) 
+  {
+    settings.setArrayIndex(i);
+    ItemData data;
+    data.filePath = settings.value("filePath").toString();
+    data.itemChangedLast = settings.value("dateChanged").toDateTime();
+    data.format = settings.value("format").toString();
+    if (data.itemChangedLast >= timeYesterday)
+      validItems.append(data);
+  }
+  settings.endArray();
+
+  return validItems;
+}
+
+void writeNewItemList(QList<ItemData> newItemList)
+{
+  QSettings settings;
+  settings.remove("itemMemory");  // Delete the old list
+
+  settings.beginWriteArray("logins");
+  for (int i = 0; i < newItemList.size(); ++i) 
+  {
+    const auto &item = newItemList[i];
+    settings.setArrayIndex(i);
+    settings.setValue("filePath", item.filePath);
+    settings.setValue("dateChanged", QVariant(item.itemChangedLast));
+    settings.setValue("format", item.format);
+  }
+  settings.endArray();
+}
+
+void itemMemoryAddFormat(QString filePath, QString format)
+{
+  auto validItems = getAllValidItems();
+
+  bool itemUpdated = false;
+  for (auto item : validItems)
+  {
+    if (item.filePath == filePath)
+    {
+      item.itemChangedLast = QDateTime::currentDateTime();
+      item.format = format;
+      itemUpdated = true;
+    }
+  }
+
+  if (!itemUpdated)
+  {
+    ItemData newItem;
+    newItem.filePath = filePath;
+    newItem.itemChangedLast = QDateTime::currentDateTime();
+    newItem.format = format;
+    validItems.append(newItem);
+  }
+  
+  writeNewItemList(validItems);
+}
+
+QString itemMemoryGetFormat(QString filePath)
+{
+  auto validItems = getAllValidItems();
+
+  for (auto item : validItems)
+    if (item.filePath == filePath)
+      return item.format;
+
+  return {};
+}
+
+} // namespace itemMemoryHandler

--- a/YUViewLib/src/handler/itemMemoryHandler.cpp
+++ b/YUViewLib/src/handler/itemMemoryHandler.cpp
@@ -58,7 +58,7 @@ QList<ItemData> getAllValidItems()
 {
   QSettings settings;
   QList<ItemData> validItems;
-  auto timeYesterday = QDateTime::currentDateTime().addDays(-1);
+  auto timeYesterday = QDateTime::currentDateTime().addDays(-2);
 
   auto size = settings.beginReadArray("itemMemory");
   for (int i = 0; i < size; ++i) 
@@ -106,14 +106,14 @@ void itemMemoryAddFormat(QString filePath, QString format)
   auto validItems = getAllValidItems();
 
   bool itemUpdated = false;
-  for (auto item : validItems)
+  for (int i = 0; i < validItems.size(); i++)
   {
-    if (item.filePath == filePath)
+    if (validItems[i].filePath == filePath)
     {
-      item.itemChangedLast = QDateTime::currentDateTime();
-      item.format = format;
+      validItems[i].itemChangedLast = QDateTime::currentDateTime();
+      validItems[i].format = format;
       itemUpdated = true;
-      DEBUG_MEMORY("itemMemoryAddFormat Modified item " << item.toString());
+      DEBUG_MEMORY("itemMemoryAddFormat Modified item " << validItems[i].toString());
       break;
     }
   }

--- a/YUViewLib/src/handler/itemMemoryHandler.h
+++ b/YUViewLib/src/handler/itemMemoryHandler.h
@@ -38,7 +38,7 @@ namespace itemMemoryHandler
 {
 
 /* Simple memory that uses QSettings to save the format for a file.
- * Entries older then 24 hours are automatically deleted.
+ * Entries older then 48 hours are automatically deleted.
  */
 void itemMemoryAddFormat(QString filePath, QString format);
 QString itemMemoryGetFormat(QString filePath);

--- a/YUViewLib/src/handler/itemMemoryHandler.h
+++ b/YUViewLib/src/handler/itemMemoryHandler.h
@@ -37,6 +37,9 @@
 namespace itemMemoryHandler
 {
 
+/* Simple memory that uses QSettings to save the format for a file.
+ * Entries older then 24 hours are automatically deleted.
+ */
 void itemMemoryAddFormat(QString filePath, QString format);
 QString itemMemoryGetFormat(QString filePath);
 

--- a/YUViewLib/src/handler/itemMemoryHandler.h
+++ b/YUViewLib/src/handler/itemMemoryHandler.h
@@ -1,0 +1,43 @@
+/*  This file is part of YUView - The YUV player with advanced analytics toolset
+*   <https://github.com/IENT/YUView>
+*   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   In addition, as a special exception, the copyright holders give
+*   permission to link the code of portions of this program with the
+*   OpenSSL library under certain conditions as described in each
+*   individual source file, and distribute linked combinations including
+*   the two.
+*   
+*   You must obey the GNU General Public License in all respects for all
+*   of the code used other than OpenSSL. If you modify file(s) with this
+*   exception, you may extend this exception to your version of the
+*   file(s), but you are not obligated to do so. If you do not wish to do
+*   so, delete this exception statement from your version. If you delete
+*   this exception statement from all source files in the program, then
+*   also delete it here.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <QString>
+
+namespace itemMemoryHandler
+{
+
+void itemMemoryAddFormat(QString filePath, QString format);
+QString itemMemoryGetFormat(QString filePath);
+
+} // namespace itemMemoryHandler

--- a/YUViewLib/src/parser/parserAnnexBAVC.cpp
+++ b/YUViewLib/src/parser/parserAnnexBAVC.cpp
@@ -98,7 +98,7 @@ yuvPixelFormat parserAnnexBAVC::getPixelFormat() const
   // Get the subsampling and bit-depth from the sps
   int bitDepthY = -1;
   int bitDepthC = -1;
-  YUVSubsamplingType subsampling = YUV_NUM_SUBSAMPLINGS;
+  auto subsampling = Subsampling::UNKNOWN;
   for (auto nal : nalUnitList)
   {
     // This should be an hevc nal
@@ -108,19 +108,19 @@ yuvPixelFormat parserAnnexBAVC::getPixelFormat() const
     {
       auto s = nal_avc.dynamicCast<sps>();
       if (s->chroma_format_idc == 0)
-        subsampling = YUV_400;
+        subsampling = Subsampling::YUV_400;
       else if (s->chroma_format_idc == 1)
-        subsampling = YUV_420;
+        subsampling = Subsampling::YUV_420;
       else if (s->chroma_format_idc == 2)
-        subsampling = YUV_422;
+        subsampling = Subsampling::YUV_422;
       else if (s->chroma_format_idc == 3)
-        subsampling = YUV_444;
+        subsampling = Subsampling::YUV_444;
 
       bitDepthY = s->bit_depth_luma_minus8 + 8;
       bitDepthC = s->bit_depth_chroma_minus8 + 8;
     }
 
-    if (bitDepthY != -1 && bitDepthC != -1 && subsampling != YUV_NUM_SUBSAMPLINGS)
+    if (bitDepthY != -1 && bitDepthC != -1 && subsampling != Subsampling::UNKNOWN)
     {
       if (bitDepthY != bitDepthC)
       {

--- a/YUViewLib/src/parser/parserAnnexBHEVC.cpp
+++ b/YUViewLib/src/parser/parserAnnexBHEVC.cpp
@@ -115,7 +115,7 @@ yuvPixelFormat parserAnnexBHEVC::getPixelFormat() const
   // Get the subsampling and bit-depth from the sps
   int bitDepthY = -1;
   int bitDepthC = -1;
-  YUVSubsamplingType subsampling = YUV_NUM_SUBSAMPLINGS;
+  auto subsampling = Subsampling::UNKNOWN;
   for (auto nal : nalUnitList)
   {
     // This should be an hevc nal
@@ -125,19 +125,19 @@ yuvPixelFormat parserAnnexBHEVC::getPixelFormat() const
     {
       auto s = nal_hevc.dynamicCast<sps>();
       if (s->chroma_format_idc == 0)
-        subsampling = YUV_400;
+        subsampling = Subsampling::YUV_400;
       else if (s->chroma_format_idc == 1)
-        subsampling = YUV_420;
+        subsampling = Subsampling::YUV_420;
       else if (s->chroma_format_idc == 2)
-        subsampling = YUV_422;
+        subsampling = Subsampling::YUV_422;
       else if (s->chroma_format_idc == 3)
-        subsampling = YUV_444;
+        subsampling = Subsampling::YUV_444;
 
       bitDepthY = s->bit_depth_luma_minus8 + 8;
       bitDepthC = s->bit_depth_chroma_minus8 + 8;
     }
 
-    if (bitDepthY != -1 && bitDepthC != -1 && subsampling != YUV_NUM_SUBSAMPLINGS)
+    if (bitDepthY != -1 && bitDepthC != -1 && subsampling != Subsampling::UNKNOWN)
     {
       if (bitDepthY != bitDepthC)
       {

--- a/YUViewLib/src/parser/parserAnnexBMpeg2.cpp
+++ b/YUViewLib/src/parser/parserAnnexBMpeg2.cpp
@@ -648,11 +648,11 @@ yuvPixelFormat parserAnnexBMpeg2::getPixelFormat() const
   {
     int c = first_sequence_extension->chroma_format;
     if (c == 1)
-      return yuvPixelFormat(YUV_420, 8);
+      return yuvPixelFormat(Subsampling::YUV_420, 8);
     if (c == 2)
-      return yuvPixelFormat(YUV_422, 8);
+      return yuvPixelFormat(Subsampling::YUV_422, 8);
     if (c == 3)
-      return yuvPixelFormat(YUV_444, 8);
+      return yuvPixelFormat(Subsampling::YUV_444, 8);
   }
   return yuvPixelFormat();
 }

--- a/YUViewLib/src/parser/parserAnnexBVVC.cpp
+++ b/YUViewLib/src/parser/parserAnnexBVVC.cpp
@@ -59,7 +59,7 @@ QSize parserAnnexBVVC::getSequenceSizeSamples() const
 
 yuvPixelFormat parserAnnexBVVC::getPixelFormat() const
 {
-  return yuvPixelFormat(YUV_420, 8);
+  return yuvPixelFormat(Subsampling::YUV_420, 8);
 }
 
 QList<QByteArray> parserAnnexBVVC::getSeekFrameParamerSets(int iFrameNr, uint64_t &filePos)

--- a/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
@@ -191,7 +191,7 @@ bool playlistItemRawFile::parseY4MFile()
   int64_t offset = 9;
   int width = -1;
   int height = -1;
-  yuvPixelFormat format = yuvPixelFormat(YUV_420, 8, Order_YUV);
+  yuvPixelFormat format = yuvPixelFormat(Subsampling::YUV_420, 8, PlaneOrder::YUV);
 
   while (rawData.at(offset++) == ' ')
   {
@@ -270,9 +270,9 @@ bool playlistItemRawFile::parseY4MFile()
       // 'C420jpeg' = 4:2 : 0 with biaxially - displaced chroma planes
       // 'C420paldv' = 4 : 2 : 0 with vertically - displaced chroma planes
       if (formatName == "422")
-        format.subsampling = YUV_422;
+        format.subsampling = Subsampling::YUV_422;
       else if (formatName == "444")
-        format.subsampling = YUV_444;
+        format.subsampling = Subsampling::YUV_444;
 
       if (rawData.at(offset) == 'p' && rawData.at(offset+1) == '1' && rawData.at(offset+2) == '0')
       {
@@ -308,9 +308,9 @@ bool playlistItemRawFile::parseY4MFile()
 
   // The offset in bytes to the next frame
   int stride = width * height * 3 / 2;
-  if (format.subsampling == YUV_422)
+  if (format.subsampling == Subsampling::YUV_422)
     stride = width * height * 2;
-  else if (format.subsampling == YUV_444)
+  else if (format.subsampling == Subsampling::YUV_444)
     stride = width * height * 3;
   if (format.bitsPerSample > 8)
     stride *= 2;

--- a/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
@@ -88,12 +88,18 @@ playlistItemRawFile::playlistItemRawFile(const QString &rawFilePath, const QSize
   else
     Q_ASSERT_X(false, "playlistItemRawFile()", "No video handler for the raw file format found.");
 
+  auto pixelFormatFromMemory = itemMemoryHandler::itemMemoryGetFormat(rawFilePath);
   if (ext == "y4m")
   {
     // A y4m file has a header and indicators for ever frame
     isY4MFile = true;
     if (!parseY4MFile())
       return;
+  }
+  else if (!pixelFormatFromMemory.isEmpty())
+  {
+    // Use the format that we got from the memory. Don't do any auto detection.
+    video->setFormatFromString(pixelFormatFromMemory);
   }
   else if (frameSize == QSize(-1,-1) && sourcePixelFormat.isEmpty())
   {

--- a/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
@@ -43,7 +43,7 @@ using namespace YUView;
 using namespace YUV_Internals;
 
 // Activate this if you want to know when which buffer is loaded/converted to image and so on.
-#define PLAYLISTITEMRAWFILE_DEBUG_LOADING 1
+#define PLAYLISTITEMRAWFILE_DEBUG_LOADING 0
 #if PLAYLISTITEMRAWFILE_DEBUG_LOADING && !NDEBUG
 #define DEBUG_RAWFILE qDebug
 #else

--- a/YUViewLib/src/playlistitem/playlistItemRawFile.h
+++ b/YUViewLib/src/playlistitem/playlistItemRawFile.h
@@ -33,7 +33,6 @@
 #ifndef PLAYLISTITEMRAWFILE_H
 #define PLAYLISTITEMRAWFILE_H
 
-#include <QFileInfo>
 #include <QFuture>
 #include <QString>
 

--- a/YUViewLib/src/playlistitem/playlistItemRawFile.h
+++ b/YUViewLib/src/playlistitem/playlistItemRawFile.h
@@ -33,6 +33,7 @@
 #ifndef PLAYLISTITEMRAWFILE_H
 #define PLAYLISTITEMRAWFILE_H
 
+#include <QFileInfo>
 #include <QFuture>
 #include <QString>
 
@@ -79,10 +80,12 @@ public:
   // Cache the given frame
   virtual void cacheFrame(int idx, bool testMode) Q_DECL_OVERRIDE { if (testMode) dataSource.clearFileCache(); playlistItemWithVideo::cacheFrame(idx, testMode); }
 
-public slots:
+private slots:
   // Load the raw data for the given frame index from file. This slot is called by the videoHandler if the frame that is
   // requested to be drawn has not been loaded yet.
-  virtual void loadRawData(int frameIdxInternal);
+  void loadRawData(int frameIdxInternal);
+
+  void slotVideoPropertiesChanged();
 
 protected:
   // Override from playlistItemIndexed. For a raw file the index range is 0...numFrames-1. 
@@ -110,6 +113,8 @@ private:
   bool parseY4MFile();
   bool isY4MFile;
   QList<uint64_t> y4mFrameIndices;
+
+  QString pixelFormatAfterLoading;
 };
 
 #endif // PLAYLISTITEMRAWFILE_H

--- a/YUViewLib/src/video/frameHandler.cpp
+++ b/YUViewLib/src/video/frameHandler.cpp
@@ -410,7 +410,7 @@ bool frameHandler::setFormatFromString(QString format)
   if (!ok)
     return false;
 
-  auto newHeight = split[0].toInt(&ok);
+  auto newHeight = split[1].toInt(&ok);
   if (!ok)
     return false;
 

--- a/YUViewLib/src/video/frameHandler.cpp
+++ b/YUViewLib/src/video/frameHandler.cpp
@@ -402,3 +402,22 @@ QStringPairList frameHandler::getPixelValues(const QPoint &pixelPos, int frameId
 
   return values;
 }
+
+bool frameHandler::setFormatFromString(QString format)
+{
+  auto split = format.split(";");
+  if (split.length() != 2)
+    return false;
+
+  bool ok;
+  auto newWidth = split[0].toInt(&ok);
+  if (!ok)
+    return false;
+
+  auto newHeight = split[0].toInt(&ok);
+  if (!ok)
+    return false;
+
+  this->setFrameSize(QSize(newWidth, newHeight));
+  return true;
+}

--- a/YUViewLib/src/video/frameHandler.cpp
+++ b/YUViewLib/src/video/frameHandler.cpp
@@ -37,7 +37,13 @@
 #include "common/functions.h"
 #include "playlistitem/playlistItem.h"
 
-// ------ Initialize the static list of frame size presets ----------
+// Activate this if you want to know when which buffer is loaded/converted to image and so on.
+#define FRAMEHANDLER_DEBUG_LOADING 0
+#if FRAMEHANDLER_DEBUG_LOADING && !NDEBUG
+#define DEBUG_FRAME qDebug
+#else
+#define DEBUG_FRAME(fmt,...) ((void)0)
+#endif
 
 class frameHandler::frameSizePresetList
 {
@@ -79,16 +85,6 @@ QStringList frameHandler::frameSizePresetList::getFormattedNames() const
 }
 
 frameHandler::frameSizePresetList frameHandler::presetFrameSizes;
-
-// ---------------- frameHandler ---------------------------------
-
-// Activate this if you want to know when which buffer is loaded/converted to image and so on.
-#define FRAMEHANDLER_DEBUG_LOADING 0
-#if FRAMEHANDLER_DEBUG_LOADING && !NDEBUG
-#define DEBUG_FRAME qDebug
-#else
-#define DEBUG_FRAME(fmt,...) ((void)0)
-#endif
 
 frameHandler::frameHandler()
 {

--- a/YUViewLib/src/video/frameHandler.h
+++ b/YUViewLib/src/video/frameHandler.h
@@ -79,6 +79,9 @@ public:
   // checks if a valid YUV format is set.
   virtual bool isFormatValid() const { return frameSize.width() > 0 && frameSize.height() > 0; }
 
+  virtual QString getFormatAsString() const { return QString("%1;%2").arg(this->frameSize.width()).arg(this->frameSize.height()); }
+  virtual bool setFormatFromString(QString format);
+
   // Calculate the difference of this frameHandler to another frameHandler. This
   // function can be overloaded by more specialized video items. For example the videoHandlerYUV
   // overloads this and calculates the difference directly on the YUV values (if possible).

--- a/YUViewLib/src/video/rgbPixelFormat.cpp
+++ b/YUViewLib/src/video/rgbPixelFormat.cpp
@@ -1,0 +1,138 @@
+/*  This file is part of YUView - The YUV player with advanced analytics toolset
+*   <https://github.com/IENT/YUView>
+*   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   In addition, as a special exception, the copyright holders give
+*   permission to link the code of portions of this program with the
+*   OpenSSL library under certain conditions as described in each
+*   individual source file, and distribute linked combinations including
+*   the two.
+*   
+*   You must obey the GNU General Public License in all respects for all
+*   of the code used other than OpenSSL. If you modify file(s) with this
+*   exception, you may extend this exception to your version of the
+*   file(s), but you are not obligated to do so. If you do not wish to do
+*   so, delete this exception statement from your version. If you delete
+*   this exception statement from all source files in the program, then
+*   also delete it here.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "rgbPixelFormat.h"
+
+// Activate this if you want to know when which buffer is loaded/converted to image and so on.
+#define RGBPIXELFORMAT_DEBUG 0
+#if RGBPIXELFORMAT_DEBUG && !NDEBUG
+#include <QDebug>
+#define DEBUG_RGB_FORMAT qDebug
+#else
+#define DEBUG_RGB_FORMAT(fmt,...) ((void)0)
+#endif
+
+namespace RGB_Internals
+{
+
+rgbPixelFormat::rgbPixelFormat(int bitsPerValue, bool planar, int posR, int posG, int posB, int posA)
+  : posR(posR), posG(posG), posB(posB), posA(posA), bitsPerValue(bitsPerValue), planar(planar)
+{
+  Q_ASSERT_X(posR != posG && posR != posB && posG != posB, "rgbPixelFormat", "Invalid RGB format set"); 
+  Q_ASSERT_X(posA != posR && posA != posG && posA != posB, "rgbPixelFormat", "Invalid alpha component for RGB format set"); 
+}
+
+rgbPixelFormat::rgbPixelFormat(const QString &name)
+{
+  if (name == "Unknown Pixel Format")
+  {
+    posR = 0;
+    posG = 0;
+    posB = 0;
+    posA = -1;
+    bitsPerValue = 0;
+    planar = false;
+  }
+  else
+  {
+    setRGBFormatFromString(name.left(4));
+    int bitIdx = name.indexOf("bit");
+    bitsPerValue = name.mid(bitIdx-2, 2).toInt();
+    planar = name.contains("planar");
+  }
+}
+
+QString rgbPixelFormat::getName() const
+{
+  if (bitsPerValue == 0)
+    return "Unknown Pixel Format";
+
+  QString name = getRGBFormatString();
+  name.append(QString(" %1bit").arg(bitsPerValue));
+  if (planar)
+    name.append(" planar");
+
+  return name;
+}
+
+QString rgbPixelFormat::getRGBFormatString() const
+{
+  QString name;
+  for (int i = 0; i < nrChannels(); i++)
+  {
+    if (posR == i)
+      name.append("R");
+    if (posG == i)
+      name.append("G");
+    if (posB == i)
+      name.append("B");
+    if (posA == i)
+      name.append("A");
+  }
+  return name;
+}
+
+void rgbPixelFormat::setRGBFormatFromString(const QString &format)
+{
+  int n = format.length();
+  if (n < 3)
+    return;
+  if (n > 4)
+    n = 4;
+
+  for (int i = 0; i < n; i++)
+  {
+    if (format[i].toLower() == 'r')
+      posR = i;
+    else if (format[i].toLower() == 'g')
+      posG = i;
+    else if (format[i].toLower() == 'b')
+      posB = i;
+    else if (format[i].toLower() == 'a')
+      posA = i;
+  }
+}
+
+/* Get the number of bytes for a frame with this RGB format and the given size
+*/
+int64_t rgbPixelFormat::bytesPerFrame(const QSize &frameSize) const
+{
+  if (bitsPerValue == 0 || !frameSize.isValid())
+    return 0;
+
+  int64_t numSamples = frameSize.height() * frameSize.width();
+  int64_t nrBytes = numSamples * nrChannels() * ((bitsPerValue + 7) / 8);
+  DEBUG_RGB_FORMAT("rgbPixelFormat::bytesPerFrame samples %d channels %d bytes %d", int(numSamples), nrChannels(), nrBytes);
+  return nrBytes;
+}
+
+} // namespace RGB_Internals

--- a/YUViewLib/src/video/rgbPixelFormat.cpp
+++ b/YUViewLib/src/video/rgbPixelFormat.cpp
@@ -71,6 +71,20 @@ rgbPixelFormat::rgbPixelFormat(const QString &name)
   }
 }
 
+bool rgbPixelFormat::isValid() const 
+{ 
+  if (bitsPerValue <= 0 || bitsPerValue > 16)
+    return false;
+
+  if (posR == posG || posR == posB || posG == posB)
+    return false;
+
+  if (posA != -1 && (posA == posR || posA == posG || posA == posB))
+    return false;
+
+  return true;
+}
+
 QString rgbPixelFormat::getName() const
 {
   if (bitsPerValue == 0)

--- a/YUViewLib/src/video/rgbPixelFormat.h
+++ b/YUViewLib/src/video/rgbPixelFormat.h
@@ -1,0 +1,72 @@
+/*  This file is part of YUView - The YUV player with advanced analytics toolset
+*   <https://github.com/IENT/YUView>
+*   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   In addition, as a special exception, the copyright holders give
+*   permission to link the code of portions of this program with the
+*   OpenSSL library under certain conditions as described in each
+*   individual source file, and distribute linked combinations including
+*   the two.
+*   
+*   You must obey the GNU General Public License in all respects for all
+*   of the code used other than OpenSSL. If you modify file(s) with this
+*   exception, you may extend this exception to your version of the
+*   file(s), but you are not obligated to do so. If you do not wish to do
+*   so, delete this exception statement from your version. If you delete
+*   this exception statement from all source files in the program, then
+*   also delete it here.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <QSize>
+#include <QString>
+
+namespace RGB_Internals
+{
+
+// This class defines a specific RGB format with all properties like order of R/G/B, bitsPerValue, planarity...
+class rgbPixelFormat
+{
+public:
+  // The default constructor (will create an "Unknown Pixel Format")
+  rgbPixelFormat() {}
+  rgbPixelFormat(const QString &name);
+  rgbPixelFormat(int bitsPerValue, bool planar, int posR=0, int posG=1, int posB=2, int posA=-1);
+  bool operator==(const rgbPixelFormat &a) const { return getName() == a.getName(); } // Comparing names should be enough since you are not supposed to create your own rgbPixelFormat instances anyways.
+  bool operator!=(const rgbPixelFormat &a) const { return getName()!= a.getName(); }
+  bool operator==(const QString &a) const { return getName() == a; }
+  bool operator!=(const QString &a) const { return getName() != a; }
+  bool isValid() const { return bitsPerValue > 0 && posR != posG && posR != posB && posG != posB; }
+  int  nrChannels() const { return posA == -1 ? 3 : 4; }
+  bool hasAlphaChannel() const { return posA != -1; }
+  // Get a name representation of this item (this will be unique for the set parameters)
+  QString getName() const;
+  // Get/Set the RGB format from string (accepted string are: "RGB", "BGR", ...)
+  QString getRGBFormatString() const;
+  void setRGBFormatFromString(const QString &sFormat);
+  // Get the number of bytes for a frame with this rgbPixelFormat and the given size
+  int64_t bytesPerFrame(const QSize &frameSize) const;
+  // The order of each component (E.g. for GBR this is posR=2,posG=0,posB=1)
+  int posR {0};
+  int posG {1};
+  int posB {2};
+  int posA {-1};  // The position of alpha can be -1 (no alpha channel)
+  int bitsPerValue {-1};
+  bool planar {false};
+};
+
+} // namespace RGB_Internals

--- a/YUViewLib/src/video/rgbPixelFormat.h
+++ b/YUViewLib/src/video/rgbPixelFormat.h
@@ -50,7 +50,7 @@ public:
   bool operator!=(const rgbPixelFormat &a) const { return getName()!= a.getName(); }
   bool operator==(const QString &a) const { return getName() == a; }
   bool operator!=(const QString &a) const { return getName() != a; }
-  bool isValid() const { return bitsPerValue > 0 && posR != posG && posR != posB && posG != posB; }
+  bool isValid() const;
   int  nrChannels() const { return posA == -1 ? 3 : 4; }
   bool hasAlphaChannel() const { return posA != -1; }
   // Get a name representation of this item (this will be unique for the set parameters)
@@ -60,6 +60,7 @@ public:
   void setRGBFormatFromString(const QString &sFormat);
   // Get the number of bytes for a frame with this rgbPixelFormat and the given size
   int64_t bytesPerFrame(const QSize &frameSize) const;
+  
   // The order of each component (E.g. for GBR this is posR=2,posG=0,posB=1)
   int posR {0};
   int posG {1};

--- a/YUViewLib/src/video/videoHandlerDifference.cpp
+++ b/YUViewLib/src/video/videoHandlerDifference.cpp
@@ -398,8 +398,8 @@ bool videoHandlerDifference::hierarchicalPositionYUV(int x, int y, int blockSize
   if (blockSize == 4)
   {
       const unsigned char * srcY1 = (unsigned char*)diffYUV.data();
-      const unsigned char * srcU1 = (diffYUVFormat.planeOrder == YUV_Internals::Order_YUV || diffYUVFormat.planeOrder == YUV_Internals::Order_YUVA) ? srcY1 + nrBytesLumaPlane_In : srcY1 + nrBytesLumaPlane_In + nrBytesChromaPlane_In;
-      const unsigned char * srcV1 = (diffYUVFormat.planeOrder == YUV_Internals::Order_YUV || diffYUVFormat.planeOrder == YUV_Internals::Order_YUVA) ? srcY1 + nrBytesLumaPlane_In + nrBytesChromaPlane_In: srcY1 + nrBytesLumaPlane_In;
+      const unsigned char * srcU1 = (diffYUVFormat.planeOrder == YUV_Internals::PlaneOrder::YUV || diffYUVFormat.planeOrder == YUV_Internals::PlaneOrder::YUVA) ? srcY1 + nrBytesLumaPlane_In : srcY1 + nrBytesLumaPlane_In + nrBytesChromaPlane_In;
+      const unsigned char * srcV1 = (diffYUVFormat.planeOrder == YUV_Internals::PlaneOrder::YUV || diffYUVFormat.planeOrder == YUV_Internals::PlaneOrder::YUVA) ? srcY1 + nrBytesLumaPlane_In + nrBytesChromaPlane_In: srcY1 + nrBytesLumaPlane_In;
 
     // adjust source pointer according to block position
     srcY1 += y*stride_in;

--- a/YUViewLib/src/video/videoHandlerRGB.cpp
+++ b/YUViewLib/src/video/videoHandlerRGB.cpp
@@ -70,20 +70,7 @@ rgbPixelFormat::rgbPixelFormat(int bitsPerValue, bool planar, int posR, int posG
   Q_ASSERT_X(posA != posR && posA != posG && posA != posB, "rgbPixelFormat", "Invalid alpha component for RGB format set"); 
 }
 
-QString rgbPixelFormat::getName() const
-{
-  if (bitsPerValue == 0)
-    return "Unknown Pixel Format";
-
-  QString name = getRGBFormatString();
-  name.append(QString(" %1bit").arg(bitsPerValue));
-  if (planar)
-    name.append(" planar");
-
-  return name;
-}
-
-void rgbPixelFormat::setFromName(const QString &name)
+rgbPixelFormat::rgbPixelFormat(const QString &name)
 {
   if (name == "Unknown Pixel Format")
   {
@@ -101,6 +88,19 @@ void rgbPixelFormat::setFromName(const QString &name)
     bitsPerValue = name.mid(bitIdx-2, 2).toInt();
     planar = name.contains("planar");
   }
+}
+
+QString rgbPixelFormat::getName() const
+{
+  if (bitsPerValue == 0)
+    return "Unknown Pixel Format";
+
+  QString name = getRGBFormatString();
+  name.append(QString(" %1bit").arg(bitsPerValue));
+  if (planar)
+    name.append(" planar");
+
+  return name;
 }
 
 QString rgbPixelFormat::getRGBFormatString() const
@@ -328,6 +328,25 @@ QStringPairList videoHandlerRGB::getPixelValues(const QPoint &pixelPos, int fram
   }
 
   return values;
+}
+
+bool videoHandlerRGB::setFormatFromString(QString format)
+{
+  DEBUG_RGB("videoHandlerRGB::setFormatFromString " << format << "\n");
+
+  auto split = format.split(";");
+  if (split.length() != 4 || split[2] != "RGB")
+    return false;
+
+  if (!frameHandler::setFormatFromString(split[0] + ";" + split[1]))
+    return false;
+
+  auto fmt = RGB_Internals::rgbPixelFormat(split[3]);
+  if (!fmt.isValid())
+    return false;
+
+  this->setRGBPixelFormat(fmt, false);
+  return true;
 }
 
 QLayout *videoHandlerRGB::createVideoHandlerControls(bool isSizeFixed)

--- a/YUViewLib/src/video/videoHandlerRGB.cpp
+++ b/YUViewLib/src/video/videoHandlerRGB.cpp
@@ -36,6 +36,7 @@
 
 #include "common/functions.h"
 #include "common/fileInfo.h"
+#include "videoHandlerRGBCustomFormatDialog.h"
 
 using namespace RGB_Internals;
 
@@ -62,154 +63,6 @@ using namespace RGB_Internals;
 #        endif
 #    endif
 #endif
-
-rgbPixelFormat::rgbPixelFormat(int bitsPerValue, bool planar, int posR, int posG, int posB, int posA)
-  : posR(posR), posG(posG), posB(posB), posA(posA), bitsPerValue(bitsPerValue), planar(planar)
-{
-  Q_ASSERT_X(posR != posG && posR != posB && posG != posB, "rgbPixelFormat", "Invalid RGB format set"); 
-  Q_ASSERT_X(posA != posR && posA != posG && posA != posB, "rgbPixelFormat", "Invalid alpha component for RGB format set"); 
-}
-
-rgbPixelFormat::rgbPixelFormat(const QString &name)
-{
-  if (name == "Unknown Pixel Format")
-  {
-    posR = 0;
-    posG = 0;
-    posB = 0;
-    posA = -1;
-    bitsPerValue = 0;
-    planar = false;
-  }
-  else
-  {
-    setRGBFormatFromString(name.left(4));
-    int bitIdx = name.indexOf("bit");
-    bitsPerValue = name.mid(bitIdx-2, 2).toInt();
-    planar = name.contains("planar");
-  }
-}
-
-QString rgbPixelFormat::getName() const
-{
-  if (bitsPerValue == 0)
-    return "Unknown Pixel Format";
-
-  QString name = getRGBFormatString();
-  name.append(QString(" %1bit").arg(bitsPerValue));
-  if (planar)
-    name.append(" planar");
-
-  return name;
-}
-
-QString rgbPixelFormat::getRGBFormatString() const
-{
-  QString name;
-  for (int i = 0; i < nrChannels(); i++)
-  {
-    if (posR == i)
-      name.append("R");
-    if (posG == i)
-      name.append("G");
-    if (posB == i)
-      name.append("B");
-    if (posA == i)
-      name.append("A");
-  }
-  return name;
-}
-
-void rgbPixelFormat::setRGBFormatFromString(const QString &format)
-{
-  int n = format.length();
-  if (n < 3)
-    return;
-  if (n > 4)
-    n = 4;
-
-  for (int i = 0; i < n; i++)
-  {
-    if (format[i].toLower() == 'r')
-      posR = i;
-    else if (format[i].toLower() == 'g')
-      posG = i;
-    else if (format[i].toLower() == 'b')
-      posB = i;
-    else if (format[i].toLower() == 'a')
-      posA = i;
-  }
-}
-
-/* Get the number of bytes for a frame with this RGB format and the given size
-*/
-int64_t rgbPixelFormat::bytesPerFrame(const QSize &frameSize) const
-{
-  if (bitsPerValue == 0 || !frameSize.isValid())
-    return 0;
-
-  int64_t numSamples = frameSize.height() * frameSize.width();
-  int64_t nrBytes = numSamples * nrChannels() * ((bitsPerValue + 7) / 8);
-  DEBUG_RGB("rgbPixelFormat::bytesPerFrame samples %d channels %d bytes %d", int(numSamples), nrChannels(), nrBytes);
-  return nrBytes;
-}
-
-/// ---------------------------- videoHandlerRGB_CustomFormatDialog ---------------------
-
-videoHandlerRGB_CustomFormatDialog::videoHandlerRGB_CustomFormatDialog(const QString &rgbFormat, int bitDepth, bool planar)
-{
-  setupUi(this);
-
-  // Set the default (RGB no alpha)
-  rgbOrderComboBox->setCurrentIndex(0);
-  alphaChannelGroupBox->setChecked(false);
-  afterRGBRadioButton->setChecked(false);
-
-  QString f = rgbFormat.toLower();
-  if (f.length() == 3 || f.length() == 4)
-  {
-    if (f.length() == 4 && f.at(0) == 'a')
-    {
-      alphaChannelGroupBox->setChecked(true);
-      beforeRGBRadioButton->setChecked(true);
-      f.remove(0, 1); // Remove the 'a'
-    }
-    else if (f.length() == 4 && f.at(3) == 'a')
-    {
-      alphaChannelGroupBox->setChecked(true);
-      afterRGBRadioButton->setChecked(true);
-      f.remove(3, 1); // Remove the 'a'
-    }
-
-    for (int i = 0; i < rgbOrderComboBox->count(); i++)
-      if (rgbOrderComboBox->itemText(i).toLower() == f)
-      {
-        rgbOrderComboBox->setCurrentIndex(i);
-        break;
-      }
-  }
-
-  if (bitDepth == 0)
-    bitDepth = 8;
-  bitDepthSpinBox->setValue(bitDepth);
-
-  planarCheckBox->setChecked(planar);
-}
-
-QString videoHandlerRGB_CustomFormatDialog::getRGBFormat() const
-{ 
-  QString f = rgbOrderComboBox->currentText(); 
-  if (alphaChannelGroupBox->isChecked())
-  {
-    if (beforeRGBRadioButton->isChecked())
-      f.prepend("A");
-    if (afterRGBRadioButton->isChecked())
-      f.append("A");
-  }
-  return f;
-}
-
-/// ------------------------- videoHandlerRGB -------------------
 
 /* The default constructor of the RGBFormatList will fill the list with all supported RGB file formats.
  * Don't forget to implement actual support for all of them in the conversion functions.
@@ -246,8 +99,6 @@ rgbPixelFormat videoHandlerRGB::RGBFormatList::getFromName(const QString &name) 
 
 // Initialize the static rgbPresetList
 videoHandlerRGB::RGBFormatList videoHandlerRGB::rgbPresetList;
-
-// --------------------- videoHandlerRGB ----------------------------------
 
 videoHandlerRGB::videoHandlerRGB() : videoHandler()
 {
@@ -449,7 +300,7 @@ void videoHandlerRGB::slotRGBFormatControlChanged()
     DEBUG_RGB("videoHandlerRGB::slotRGBFormatControlChanged custom format");
 
     // The user selected the "custom format..." option
-    videoHandlerRGB_CustomFormatDialog dialog(srcPixelFormat.getRGBFormatString(), srcPixelFormat.bitsPerValue, srcPixelFormat.planar);
+    videoHandlerRGBCustomFormatDialog dialog(srcPixelFormat.getRGBFormatString(), srcPixelFormat.bitsPerValue, srcPixelFormat.planar);
     if (dialog.exec() == QDialog::Accepted)
     {
       // Set the custom format

--- a/YUViewLib/src/video/videoHandlerRGB.h
+++ b/YUViewLib/src/video/videoHandlerRGB.h
@@ -45,6 +45,7 @@ namespace RGB_Internals
   public:
     // The default constructor (will create an "Unknown Pixel Format")
     rgbPixelFormat() {}
+    rgbPixelFormat(const QString &name);
     rgbPixelFormat(int bitsPerValue, bool planar, int posR=0, int posG=1, int posB=2, int posA=-1);
     bool operator==(const rgbPixelFormat &a) const { return getName() == a.getName(); } // Comparing names should be enough since you are not supposed to create your own rgbPixelFormat instances anyways.
     bool operator!=(const rgbPixelFormat &a) const { return getName()!= a.getName(); }
@@ -55,7 +56,6 @@ namespace RGB_Internals
     bool hasAlphaChannel() const { return posA != -1; }
     // Get a name representation of this item (this will be unique for the set parameters)
     QString getName() const;
-    void setFromName(const QString &name);
     // Get/Set the RGB format from string (accepted string are: "RGB", "BGR", ...)
     QString getRGBFormatString() const;
     void setRGBFormatFromString(const QString &sFormat);
@@ -107,6 +107,9 @@ public:
   // If a file size is given, it is tested if the RGB format and the file size match.
   virtual void setFormatFromCorrelation(const QByteArray &rawRGBData, int64_t fileSize=-1) Q_DECL_OVERRIDE { /* TODO */ Q_UNUSED(rawRGBData); Q_UNUSED(fileSize); }
 
+  virtual QString getFormatAsString() const override { return frameHandler::getFormatAsString() + ";RGB;" + this->srcPixelFormat.getName(); }
+  virtual bool setFormatFromString(QString format) override;
+
   // Create the RGB controls and return a pointer to the layout.
   // rgbFormatFixed: For example a RGB file does not have a fixed format (the user can change this),
   // other sources might provide a fixed format which the user cannot change.
@@ -116,8 +119,8 @@ public:
   virtual QString getRawRGBPixelFormatName() const { return srcPixelFormat.getName(); }
   // Set the current raw format and update the control. Only emit a signalHandlerChanged signal
   // if emitSignal is true.
-  virtual void setRGBPixelFormatByName(const QString &name, bool emitSignal=false) { srcPixelFormat.setFromName(name); if (emitSignal) emit signalHandlerChanged(true, RECACHE_NONE); }
-  void setRGBPixelFormat(const RGB_Internals::rgbPixelFormat &format, bool emitSignal=false) { setSrcPixelFormat(format); if (emitSignal) emit signalHandlerChanged(true, RECACHE_NONE); }
+  virtual void setRGBPixelFormat(const RGB_Internals::rgbPixelFormat &format, bool emitSignal=false) { setSrcPixelFormat(format); if (emitSignal) emit signalHandlerChanged(true, RECACHE_NONE); }
+  virtual void setRGBPixelFormatByName(const QString &name, bool emitSignal=false) { this->setRGBPixelFormat(RGB_Internals::rgbPixelFormat(name), emitSignal); }
 
   // If you know the frame size of the video, the file size (and optionally the bit depth) we can guess
   // the remaining values. The rate value is set if a matching format could be found.

--- a/YUViewLib/src/video/videoHandlerRGB.h
+++ b/YUViewLib/src/video/videoHandlerRGB.h
@@ -30,57 +30,11 @@
 *   along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef VIDEOHANDLERRGB_H
-#define VIDEOHANDLERRGB_H
+#pragma once
 
 #include "ui_videoHandlerRGB.h"
-#include "ui_videoHandlerRGB_CustomFormatDialog.h"
 #include "videoHandler.h"
-
-namespace RGB_Internals
-{
-  // This class defines a specific RGB format with all properties like order of R/G/B, bitsPerValue, planarity...
-  class rgbPixelFormat
-  {
-  public:
-    // The default constructor (will create an "Unknown Pixel Format")
-    rgbPixelFormat() {}
-    rgbPixelFormat(const QString &name);
-    rgbPixelFormat(int bitsPerValue, bool planar, int posR=0, int posG=1, int posB=2, int posA=-1);
-    bool operator==(const rgbPixelFormat &a) const { return getName() == a.getName(); } // Comparing names should be enough since you are not supposed to create your own rgbPixelFormat instances anyways.
-    bool operator!=(const rgbPixelFormat &a) const { return getName()!= a.getName(); }
-    bool operator==(const QString &a) const { return getName() == a; }
-    bool operator!=(const QString &a) const { return getName() != a; }
-    bool isValid() const { return bitsPerValue > 0 && posR != posG && posR != posB && posG != posB; }
-    int  nrChannels() const { return posA == -1 ? 3 : 4; }
-    bool hasAlphaChannel() const { return posA != -1; }
-    // Get a name representation of this item (this will be unique for the set parameters)
-    QString getName() const;
-    // Get/Set the RGB format from string (accepted string are: "RGB", "BGR", ...)
-    QString getRGBFormatString() const;
-    void setRGBFormatFromString(const QString &sFormat);
-    // Get the number of bytes for a frame with this rgbPixelFormat and the given size
-    int64_t bytesPerFrame(const QSize &frameSize) const;
-    // The order of each component (E.g. for GBR this is posR=2,posG=0,posB=1)
-    int posR {0};
-    int posG {1};
-    int posB {2};
-    int posA {-1};  // The position of alpha can be -1 (no alpha channel)
-    int bitsPerValue {-1};
-    bool planar {false};
-  };
-}
-
-class videoHandlerRGB_CustomFormatDialog : public QDialog, private Ui::CustomRGBFormatDialog
-{
-  Q_OBJECT
-
-public:
-  videoHandlerRGB_CustomFormatDialog(const QString &rgbFormat, int bitDepth, bool planar);
-  QString getRGBFormat() const;
-  int getBitDepth() const { return bitDepthSpinBox->value(); }
-  bool getPlanar() const { return planarCheckBox->isChecked(); }
-};
+#include "rgbPixelFormat.h"
 
 /** The videoHandlerRGB can be used in any playlistItem to read/display RGB data. A playlistItem could even provide multiple RGB videos.
   * A videoHandlerRGB supports handling of RGB data and can return a specific frame as a image by calling getOneFrame.
@@ -218,5 +172,3 @@ private slots:
   void slotDisplayOptionsChanged();
 
 };
-
-#endif // VIDEOHANDLERRGB_H

--- a/YUViewLib/src/video/videoHandlerRGBCustomFormatDialog.cpp
+++ b/YUViewLib/src/video/videoHandlerRGBCustomFormatDialog.cpp
@@ -1,0 +1,86 @@
+/*  This file is part of YUView - The YUV player with advanced analytics toolset
+*   <https://github.com/IENT/YUView>
+*   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   In addition, as a special exception, the copyright holders give
+*   permission to link the code of portions of this program with the
+*   OpenSSL library under certain conditions as described in each
+*   individual source file, and distribute linked combinations including
+*   the two.
+*   
+*   You must obey the GNU General Public License in all respects for all
+*   of the code used other than OpenSSL. If you modify file(s) with this
+*   exception, you may extend this exception to your version of the
+*   file(s), but you are not obligated to do so. If you do not wish to do
+*   so, delete this exception statement from your version. If you delete
+*   this exception statement from all source files in the program, then
+*   also delete it here.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "videoHandlerRGBCustomFormatDialog.h"
+
+videoHandlerRGBCustomFormatDialog::videoHandlerRGBCustomFormatDialog(const QString &rgbFormat, int bitDepth, bool planar)
+{
+  setupUi(this);
+
+  // Set the default (RGB no alpha)
+  rgbOrderComboBox->setCurrentIndex(0);
+  alphaChannelGroupBox->setChecked(false);
+  afterRGBRadioButton->setChecked(false);
+
+  QString f = rgbFormat.toLower();
+  if (f.length() == 3 || f.length() == 4)
+  {
+    if (f.length() == 4 && f.at(0) == 'a')
+    {
+      alphaChannelGroupBox->setChecked(true);
+      beforeRGBRadioButton->setChecked(true);
+      f.remove(0, 1); // Remove the 'a'
+    }
+    else if (f.length() == 4 && f.at(3) == 'a')
+    {
+      alphaChannelGroupBox->setChecked(true);
+      afterRGBRadioButton->setChecked(true);
+      f.remove(3, 1); // Remove the 'a'
+    }
+
+    for (int i = 0; i < rgbOrderComboBox->count(); i++)
+      if (rgbOrderComboBox->itemText(i).toLower() == f)
+      {
+        rgbOrderComboBox->setCurrentIndex(i);
+        break;
+      }
+  }
+
+  if (bitDepth == 0)
+    bitDepth = 8;
+  bitDepthSpinBox->setValue(bitDepth);
+
+  planarCheckBox->setChecked(planar);
+}
+
+QString videoHandlerRGBCustomFormatDialog::getRGBFormat() const
+{ 
+  QString f = rgbOrderComboBox->currentText(); 
+  if (alphaChannelGroupBox->isChecked())
+  {
+    if (beforeRGBRadioButton->isChecked())
+      f.prepend("A");
+    if (afterRGBRadioButton->isChecked())
+      f.append("A");
+  }
+  return f;
+}

--- a/YUViewLib/src/video/videoHandlerRGBCustomFormatDialog.h
+++ b/YUViewLib/src/video/videoHandlerRGBCustomFormatDialog.h
@@ -1,0 +1,48 @@
+/*  This file is part of YUView - The YUV player with advanced analytics toolset
+*   <https://github.com/IENT/YUView>
+*   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   In addition, as a special exception, the copyright holders give
+*   permission to link the code of portions of this program with the
+*   OpenSSL library under certain conditions as described in each
+*   individual source file, and distribute linked combinations including
+*   the two.
+*   
+*   You must obey the GNU General Public License in all respects for all
+*   of the code used other than OpenSSL. If you modify file(s) with this
+*   exception, you may extend this exception to your version of the
+*   file(s), but you are not obligated to do so. If you do not wish to do
+*   so, delete this exception statement from your version. If you delete
+*   this exception statement from all source files in the program, then
+*   also delete it here.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <QDialog>
+
+#include "ui_videoHandlerRGB_CustomFormatDialog.h"
+
+class videoHandlerRGBCustomFormatDialog : public QDialog, private Ui::CustomRGBFormatDialog
+{
+  Q_OBJECT
+
+public:
+  videoHandlerRGBCustomFormatDialog(const QString &rgbFormat, int bitDepth, bool planar);
+  QString getRGBFormat() const;
+  int getBitDepth() const { return bitDepthSpinBox->value(); }
+  bool getPlanar() const { return planarCheckBox->isChecked(); }
+};

--- a/YUViewLib/src/video/videoHandlerYUV.cpp
+++ b/YUViewLib/src/video/videoHandlerYUV.cpp
@@ -48,9 +48,9 @@ using namespace YUV_Internals;
 #define VIDEOHANDLERYUV_DEBUG_LOADING 0
 #if VIDEOHANDLERYUV_DEBUG_LOADING && !NDEBUG
 #include <QDebug>
-#define DEBUG_YUV qDebug
+#define DEBUG_YUV(message) qDebug() << message;
 #else
-#define DEBUG_YUV(fmt,...) ((void)0)
+#define DEBUG_YUV(message) ((void)0)
 #endif
 
 // Restrict is basically a promise to the compiler that for the scope of the pointer, the target of the pointer will only be accessed through that pointer (and pointers copied from it).
@@ -1222,7 +1222,7 @@ bool videoHandlerYUV::setFormatFromString(QString format)
 
 void videoHandlerYUV::loadFrame(int frameIndex, bool loadToDoubleBuffer)
 {
-  DEBUG_YUV("videoHandlerYUV::loadFrame %d\n", frameIndex);
+  DEBUG_YUV("videoHandlerYUV::loadFrame " << frameIndex);
 
   if (!isFormatValid())
     // We cannot load a frame if the format is not known
@@ -1254,7 +1254,7 @@ void videoHandlerYUV::loadFrame(int frameIndex, bool loadToDoubleBuffer)
 
 void videoHandlerYUV::loadFrameForCaching(int frameIndex, QImage &frameToCache)
 {
-  DEBUG_YUV("videoHandlerYUV::loadFrameForCaching %d", frameIndex);
+  DEBUG_YUV("videoHandlerYUV::loadFrameForCaching " << frameIndex);
 
   // Get the YUV format and the size here, so that the caching process does not crash if this changes.
   yuvPixelFormat yuvFormat = srcPixelFormat;
@@ -1283,7 +1283,7 @@ bool videoHandlerYUV::loadRawYUVData(int frameIndex)
     // Buffer already up to date
     return true;
 
-  DEBUG_YUV("videoHandlerYUV::loadRawYUVData %d", frameIndex);
+  DEBUG_YUV("videoHandlerYUV::loadRawYUVData " << frameIndex);
 
   // The function loadFrameForCaching also uses the signalRequesRawYUVData to request raw data.
   // However, only one thread can use this at a time.
@@ -1302,7 +1302,7 @@ bool videoHandlerYUV::loadRawYUVData(int frameIndex)
   currentFrameRawData_frameIdx = frameIndex;
   requestDataMutex.unlock();
   
-  DEBUG_YUV("videoHandlerYUV::loadRawYUVData %d Done", frameIndex);
+  DEBUG_YUV("videoHandlerYUV::loadRawYUVData " << frameIndex << " Done");
   return true;
 }
 
@@ -3214,7 +3214,7 @@ QImage videoHandlerYUV::calculateDifference(frameHandler *item2, const int frame
     return QImage();  // Loading failed
 
   // Both YUV buffers are up to date. Really calculate the difference.
-  DEBUG_YUV("videoHandlerYUV::calculateDifference frame idx item 0 %d - item 1 %d", frameIdxItem0, frameIdxItem1);
+  DEBUG_YUV("videoHandlerYUV::calculateDifference frame idx item 0 " << frameIdxItem0 << " - item 1 " << frameIdxItem1);
 
   // The items can be of different size (we then calculate the difference of the top left aligned part)
   const int w_in[2] = {frameSize.width(), yuvItem2->frameSize.width()};

--- a/YUViewLib/src/video/videoHandlerYUVCustomFormatDialog.cpp
+++ b/YUViewLib/src/video/videoHandlerYUVCustomFormatDialog.cpp
@@ -1,0 +1,195 @@
+/*  This file is part of YUView - The YUV player with advanced analytics toolset
+*   <https://github.com/IENT/YUView>
+*   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   In addition, as a special exception, the copyright holders give
+*   permission to link the code of portions of this program with the
+*   OpenSSL library under certain conditions as described in each
+*   individual source file, and distribute linked combinations including
+*   the two.
+*
+*   You must obey the GNU General Public License in all respects for all
+*   of the code used other than OpenSSL. If you modify file(s) with this
+*   exception, you may extend this exception to your version of the
+*   file(s), but you are not obligated to do so. If you do not wish to do
+*   so, delete this exception statement from your version. If you delete
+*   this exception statement from all source files in the program, then
+*   also delete it here.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "videoHandlerYUVCustomFormatDialog.h"
+
+using namespace YUV_Internals;
+
+videoHandlerYUVCustomFormatDialog::videoHandlerYUVCustomFormatDialog(const yuvPixelFormat &yuvFormat)
+{
+  setupUi(this);
+
+  // Fill the comboBoxes and set all values correctly from the given yuvFormat
+
+  // Chroma subsampling
+  comboBoxChromaSubsampling->addItems(subsamplingTextList);
+  if (yuvFormat.subsampling != Subsampling::UNKNOWN)
+  {
+    auto subsamplingText = subsamplingToString(yuvFormat.subsampling);
+    comboBoxChromaSubsampling->setCurrentText(subsamplingText);
+    // The Q_Object auto connection is performed later so call the slot manually.
+    // This will fill comboBoxPackingOrder
+    on_comboBoxChromaSubsampling_currentIndexChanged(comboBoxChromaSubsampling->currentIndex());
+  }
+
+  // Bit depth
+  for (auto bitDepth : bitDepthList)
+    comboBoxBitDepth->addItem(QString("%1").arg(bitDepth));
+  {
+    auto idx = bitDepthList.indexOf(yuvFormat.bitsPerSample);
+    if (idx == -1)
+      idx = 0;
+    comboBoxBitDepth->setCurrentIndex(idx);
+    comboBoxEndianess->setEnabled(idx != 0);
+  }
+
+  // Endianess
+  comboBoxEndianess->setCurrentIndex(yuvFormat.bigEndian ? 0 : 1);
+
+  // Chroma offsets
+  comboBoxChromaOffsetX->setCurrentIndex(yuvFormat.chromaOffset[0]);
+  comboBoxChromaOffsetY->setCurrentIndex(yuvFormat.chromaOffset[1]);
+
+  // Plane order
+  comboBoxPlaneOrder->addItems(planeOrderNameList);
+
+  if (yuvFormat.planar)
+  {
+    // Set the plane order
+    groupBoxPlanar->setChecked(true);
+    const auto idx = planeOrderList.indexOf(yuvFormat.planeOrder);
+    if (idx == -1)
+      comboBoxPlaneOrder->setCurrentIndex(idx);
+    // Set UV(A) interleaved
+    checkBoxUVInterleaved->setChecked(yuvFormat.uvInterleaved);
+  }
+  else
+  {
+    // Set the packing order
+    groupBoxPacked->setChecked(true);
+    const auto supportedPackingFormats = getSupportedPackingFormats(yuvFormat.subsampling);
+    const auto idx = supportedPackingFormats.indexOf(yuvFormat.packingOrder);
+    if (idx != -1)
+      comboBoxPackingOrder->setCurrentIndex(idx);
+  }
+}
+
+void videoHandlerYUVCustomFormatDialog::on_comboBoxChromaSubsampling_currentIndexChanged(int idx)
+{
+  // What packing types are supported?
+  Subsampling subsampling = static_cast<Subsampling>(idx);
+  QList<PackingOrder> packingTypes = getSupportedPackingFormats(subsampling);
+  comboBoxPackingOrder->clear();
+  for (PackingOrder packing : packingTypes)
+    comboBoxPackingOrder->addItem(getPackingFormatString(packing));
+
+  bool packedSupported = (packingTypes.count() != 0);
+  if (!packedSupported)
+    // No packing supported for this subsampling. Select planar.
+    groupBoxPlanar->setChecked(true);
+  else
+    comboBoxPackingOrder->setCurrentIndex(0);
+
+  // What chroma offsets are possible?
+  comboBoxChromaOffsetX->clear();
+  int maxValsX = getMaxPossibleChromaOffsetValues(true, subsampling);
+  if (maxValsX >= 1)
+    comboBoxChromaOffsetX->addItems(QStringList() << "0" << "1/2");
+  if (maxValsX >= 3)
+    comboBoxChromaOffsetX->addItems(QStringList() << "1" << "3/2");
+  if (maxValsX >= 7)
+    comboBoxChromaOffsetX->addItems(QStringList() << "2" << "5/2" << "3" << "7/2");
+  comboBoxChromaOffsetY->clear();
+  int maxValsY = getMaxPossibleChromaOffsetValues(false, subsampling);
+  if (maxValsY >= 1)
+    comboBoxChromaOffsetY->addItems(QStringList() << "0" << "1/2");
+  if (maxValsY >= 3)
+    comboBoxChromaOffsetY->addItems(QStringList() << "1" << "3/2");
+  if (maxValsY >= 7)
+    comboBoxChromaOffsetY->addItems(QStringList() << "2" << "5/2" << "3" << "7/2");
+
+  // Disable the combo boxes if there are no chroma components
+  bool chromaPresent = (subsampling != Subsampling::YUV_400);
+  groupBoxPacked->setEnabled(chromaPresent && packedSupported);
+  groupBoxPlanar->setEnabled(chromaPresent);
+  comboBoxChromaOffsetX->setEnabled(chromaPresent);
+  comboBoxChromaOffsetY->setEnabled(chromaPresent);
+}
+
+void videoHandlerYUVCustomFormatDialog::on_groupBoxPlanar_toggled(bool checked)
+{ 
+  if (!checked && !groupBoxPacked->isEnabled())
+    // If a packed format is not supported, do not allow the user to activate this
+    groupBoxPlanar->setChecked(true); 
+  else 
+    groupBoxPacked->setChecked(!checked); 
+}
+
+yuvPixelFormat videoHandlerYUVCustomFormatDialog::getYUVFormat() const
+{
+  // Get all the values from the controls
+  yuvPixelFormat format;
+
+  // Set the subsampling format
+  int idx = comboBoxChromaSubsampling->currentIndex();
+  Q_ASSERT(idx >= 0);
+  format.subsampling = subsamplingList[idx];
+
+  // Set the bit depth
+  idx = comboBoxBitDepth->currentIndex();
+  Q_ASSERT(idx >= 0);
+  format.bitsPerSample = bitDepthList[idx];
+
+  // Set the endianess
+  format.bigEndian = (comboBoxEndianess->currentIndex() == 0);
+
+  // Set the chroma offset
+  format.chromaOffset[0] = comboBoxChromaOffsetX->currentIndex();
+  format.chromaOffset[1] = comboBoxChromaOffsetY->currentIndex();
+
+  // Planar or packed format?
+  format.planar = (groupBoxPlanar->isChecked());
+  if (format.planar)
+  {
+    idx = comboBoxPlaneOrder->currentIndex();
+    Q_ASSERT(idx >= 0);
+    format.planeOrder = planeOrderList[idx];
+    format.uvInterleaved = checkBoxUVInterleaved->isChecked();
+  }
+  else
+  {
+    idx = comboBoxPackingOrder->currentIndex();
+    Q_ASSERT(idx >= 0);
+    const auto supportedPackingFormats = getSupportedPackingFormats(format.subsampling);
+    format.packingOrder = supportedPackingFormats[idx];
+    format.bytePacking = (checkBoxBytePacking->isChecked());
+  }
+
+  return format;
+}
+
+void videoHandlerYUVCustomFormatDialog::on_comboBoxBitDepth_currentIndexChanged(int idx)
+{
+  // Endianess only makes sense when the bit depth is > 8bit.
+  bool bitDepth8 = (idx == 0);
+  comboBoxEndianess->setEnabled(!bitDepth8);
+}

--- a/YUViewLib/src/video/videoHandlerYUVCustomFormatDialog.h
+++ b/YUViewLib/src/video/videoHandlerYUVCustomFormatDialog.h
@@ -1,0 +1,53 @@
+/*  This file is part of YUView - The YUV player with advanced analytics toolset
+*   <https://github.com/IENT/YUView>
+*   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   In addition, as a special exception, the copyright holders give
+*   permission to link the code of portions of this program with the
+*   OpenSSL library under certain conditions as described in each
+*   individual source file, and distribute linked combinations including
+*   the two.
+*
+*   You must obey the GNU General Public License in all respects for all
+*   of the code used other than OpenSSL. If you modify file(s) with this
+*   exception, you may extend this exception to your version of the
+*   file(s), but you are not obligated to do so. If you do not wish to do
+*   so, delete this exception statement from your version. If you delete
+*   this exception statement from all source files in the program, then
+*   also delete it here.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "yuvPixelFormat.h"
+
+#include "ui_videoHandlerYUV_CustomFormatDialog.h"
+
+class videoHandlerYUVCustomFormatDialog : public QDialog, public Ui::CustomYUVFormatDialog
+{
+  Q_OBJECT
+
+public:
+  videoHandlerYUVCustomFormatDialog() = delete;
+  videoHandlerYUVCustomFormatDialog(const YUV_Internals::yuvPixelFormat &yuvFormat);
+  YUV_Internals::yuvPixelFormat getYUVFormat() const;
+
+private slots:
+  void on_groupBoxPlanar_toggled(bool checked);
+  void on_groupBoxPacked_toggled(bool checked) { groupBoxPlanar->setChecked(!checked); }
+  void on_comboBoxChromaSubsampling_currentIndexChanged(int idx);
+  void on_comboBoxBitDepth_currentIndexChanged(int idx);
+};

--- a/YUViewLib/src/video/yuvPixelFormat.cpp
+++ b/YUViewLib/src/video/yuvPixelFormat.cpp
@@ -1,0 +1,432 @@
+/*  This file is part of YUView - The YUV player with advanced analytics toolset
+*   <https://github.com/IENT/YUView>
+*   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   In addition, as a special exception, the copyright holders give
+*   permission to link the code of portions of this program with the
+*   OpenSSL library under certain conditions as described in each
+*   individual source file, and distribute linked combinations including
+*   the two.
+*   
+*   You must obey the GNU General Public License in all respects for all
+*   of the code used other than OpenSSL. If you modify file(s) with this
+*   exception, you may extend this exception to your version of the
+*   file(s), but you are not obligated to do so. If you do not wish to do
+*   so, delete this exception statement from your version. If you delete
+*   this exception statement from all source files in the program, then
+*   also delete it here.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "yuvPixelFormat.h"
+
+namespace YUV_Internals
+{
+
+void getColorConversionCoefficients(ColorConversion colorConversion, int RGBConv[5])
+{
+  // The conversion parameters for the components of the different supported YUV->RGB conversions
+  // The first index is the index of the ColorConversion enum. The second index is [Y, cRV, cGU, cGV, cBU].
+  const int yuvRgbConvCoeffs[6][5] =
+  {
+    {76309, 117489, -13975, -34925, 138438}, // BT709_LimitedRange
+    {65536, 103206, -12276, -30679, 121608}, // BT709_FullRange
+    {76309, 104597, -25675, -53279, 132201}, // BT601_LimitedRange
+    {65536,  91881, -22553, -46802, 116129}, // BT601_FullRange
+    {76309, 110013, -12276, -42626, 140363}, // BT2020_LimitedRange
+    {65536,  96638, -10783, -37444, 123299}  // BT2020_FullRange
+  };
+  const auto index = colorConversionList.indexOf(colorConversion);
+  for (unsigned int i = 0; i < 5; i++)
+    RGBConv[i] = yuvRgbConvCoeffs[index][i];
+}
+
+// All values between 0 and this value are possible for the subsampling.
+int getMaxPossibleChromaOffsetValues(bool horizontal, Subsampling subsampling)
+{
+if (subsampling == Subsampling::YUV_444)
+  return 1;
+else if (subsampling == Subsampling::YUV_422)
+  return (horizontal) ? 3 : 1;
+else if (subsampling == Subsampling::YUV_420)
+  return 3;
+else if (subsampling == Subsampling::YUV_440)
+  return (horizontal) ? 1 : 3;
+else if (subsampling == Subsampling::YUV_410)
+  return 7;
+else if (subsampling == Subsampling::YUV_411)
+  return (horizontal) ? 7 : 1;
+return 0;
+}
+
+// Return a list with all the packing formats that are supported with this subsampling
+QList<PackingOrder> getSupportedPackingFormats(Subsampling subsampling)
+{
+  if (subsampling == Subsampling::YUV_422)
+    return QList<PackingOrder>() << PackingOrder::UYVY << PackingOrder::VYUY << PackingOrder::YUYV << PackingOrder::YVYU;
+  if (subsampling == Subsampling::YUV_444)
+    return QList<PackingOrder>() << PackingOrder::YUV << PackingOrder::YVU << PackingOrder::AYUV << PackingOrder::YUVA;
+
+  return QList<PackingOrder>();
+}
+
+QString subsamplingToString(Subsampling type)
+{
+  if (subsamplingList.contains(type))
+  {
+    const auto index = subsamplingList.indexOf(type);
+    return subsamplingNameList[index];
+  }
+  return {};
+}
+
+Subsampling stringToSubsampling(QString typeString)
+{
+  if (subsamplingNameList.contains(typeString))
+  {
+    const auto index = subsamplingNameList.indexOf(typeString);
+    return Subsampling(index);
+  }
+  return Subsampling::UNKNOWN;
+}
+
+QString getPackingFormatString(PackingOrder packing)
+{
+  if (packingOrderList.contains(packing))
+  {
+    const auto index = packingOrderList.indexOf(packing);
+    return packingOrderNameList[index];
+  }
+  return {};
+}
+
+// Is this the default chroma offset for the subsampling type?
+bool isDefaultChromaFormat(int chromaOffset, bool offsetX, Subsampling subsampling)
+{
+if (subsampling == Subsampling::YUV_420 && !offsetX)
+  // The default subsampling for YUV 420 has a Y offset of 1/2
+  return chromaOffset == 1;
+else if (subsampling == Subsampling::YUV_400)
+  return true;
+return chromaOffset == 0;
+}
+
+yuvPixelFormat::yuvPixelFormat(const QString &name)
+{
+  QRegExp rxYUVFormat("([YUVA]{3,6}(?:\\(IL\\))?) (4:[4210]{1}:[4210]{1}) ([0-9]{1,2})-bit[ ]?([BL]{1}E)?[ ]?(packed|packed-B)?[ ]?(Cx[0-9]+)?[ ]?(Cy[0-9]+)?");
+
+  if (rxYUVFormat.exactMatch(name))
+  {
+    yuvPixelFormat newFormat;
+
+    // Is this a packed format or not?
+    QString packed = rxYUVFormat.cap(5);
+    newFormat.planar = packed.isEmpty();
+    if (!newFormat.planar)
+      newFormat.bytePacking = (packed == "packed-B");
+
+    // Parse the YUV order (planar or packed)
+    if (newFormat.planar)
+    {
+      QString yuvName = rxYUVFormat.cap(1);
+      if (yuvName.endsWith("(IL)"))
+      {
+        newFormat.uvInterleaved = true;
+        yuvName.chop(4);
+      }
+
+      int idx = planeOrderNameList.indexOf(yuvName);
+      if (idx == -1)
+        return;
+      newFormat.planeOrder = planeOrderList[idx];
+    }
+    else
+    {
+      int idx = packingOrderNameList.indexOf(rxYUVFormat.cap(1));
+      if (idx == -1)
+        return;
+      newFormat.packingOrder = packingOrderList[idx];
+    }
+
+    // Parse the subsampling
+    int idx = subsamplingTextList.indexOf(rxYUVFormat.cap(2));
+    if (idx == -1)
+      return;
+    newFormat.subsampling = subsamplingList[idx];
+
+    // Get the bit depth
+    bool ok;
+    int bitDepth = rxYUVFormat.cap(3).toInt(&ok);
+    if (!ok || bitDepth <= 0)
+      return;
+    newFormat.bitsPerSample = bitDepth;
+
+    // Get the endianess. If not in the name, assume LE
+    newFormat.bigEndian = (rxYUVFormat.cap(4) == "BE");
+
+    // Get the chroma offsets
+    newFormat.setDefaultChromaOffset();
+    if (rxYUVFormat.cap(6).startsWith("Cx"))
+    {
+      QString test = rxYUVFormat.cap(6);
+      QString test2 = rxYUVFormat.cap(6).mid(2);
+      newFormat.chromaOffset[0] = rxYUVFormat.cap(6).mid(2).toInt();
+    }
+    if (rxYUVFormat.cap(7).startsWith("Cy"))
+      newFormat.chromaOffset[1] = rxYUVFormat.cap(7).mid(2).toInt();
+
+    // Check if the format is valid.
+    if (newFormat.isValid())
+    {
+      // Set all the values from the new format
+      subsampling = newFormat.subsampling;
+      bitsPerSample = newFormat.bitsPerSample;
+      bigEndian = newFormat.bigEndian;
+      planar = newFormat.planar;
+      planeOrder = newFormat.planeOrder;
+      uvInterleaved = newFormat.uvInterleaved;
+      packingOrder = newFormat.packingOrder;
+      bytePacking = newFormat.bytePacking;
+      chromaOffset[0] = newFormat.chromaOffset[0];
+      chromaOffset[1] = newFormat.chromaOffset[1];
+    }
+  }
+}
+
+yuvPixelFormat::yuvPixelFormat(Subsampling subsampling, int bitsPerSample, PlaneOrder planeOrder, bool bigEndian) : 
+  subsampling(subsampling), bitsPerSample(bitsPerSample), bigEndian(bigEndian), planar(true), planeOrder(planeOrder), uvInterleaved(false) 
+{ 
+  this->setDefaultChromaOffset();
+}
+
+yuvPixelFormat::yuvPixelFormat(Subsampling subsampling, int bitsPerSample, PackingOrder packingOrder, bool bytePacking, bool bigEndian) : 
+  subsampling(subsampling), bitsPerSample(bitsPerSample), bigEndian(bigEndian), planar(false), uvInterleaved(false), packingOrder(packingOrder), bytePacking(bytePacking)
+{ 
+  this->setDefaultChromaOffset();
+}
+
+bool yuvPixelFormat::isValid() const
+{
+  if (!planar)
+  {
+    // Check the packing mode
+    if ((packingOrder == PackingOrder::YUV || packingOrder == PackingOrder::YVU || packingOrder == PackingOrder::AYUV || packingOrder == PackingOrder::YUVA) && subsampling != Subsampling::YUV_444)
+      return false;
+    if ((packingOrder == PackingOrder::UYVY || packingOrder == PackingOrder::VYUY || packingOrder == PackingOrder::YUYV || packingOrder == PackingOrder::YVYU) && subsampling != Subsampling::YUV_422)
+      return false;
+    if (packingOrder == PackingOrder::UNKNOWN)
+      return false;
+    /*if ((packingOrder == Packing_YYYYUV || packingOrder == Packing_YYUYYV || packingOrder == Packing_UYYVYY || packingOrder == Packing_VYYUYY) && subsampling == Subsampling::YUV_420)
+      return false;*/
+    if (subsampling == Subsampling::YUV_420 || subsampling == Subsampling::YUV_440 || subsampling == Subsampling::YUV_410 || subsampling == Subsampling::YUV_411 || subsampling == Subsampling::YUV_400)
+      // No support for packed formats with this subsampling (yet)
+      return false;
+    if (uvInterleaved)
+      // This can only be set for planar formats
+      return false;
+  }
+  if (subsampling != Subsampling::YUV_400)
+  {
+    // There are chroma components. Check the chroma offsets.
+    if (chromaOffset[0] < 0 || chromaOffset[0] > getMaxPossibleChromaOffsetValues(true, subsampling))
+      return false;
+    if (chromaOffset[1] < 0 || chromaOffset[1] > getMaxPossibleChromaOffsetValues(false, subsampling))
+      return false;
+  }
+  // Check the bit depth
+  if (bitsPerSample < 7)
+    return false;
+  return true;
+}
+
+bool yuvPixelFormat::canConvertToRGB(QSize imageSize, QString *whyNot) const
+{
+  if (!this->isValid())
+    return false;
+
+  // Check the bit depth
+  const int bps = this->bitsPerSample;
+  bool canConvert = true;
+  if (bps < 8 || bps > 16)
+  {
+    if (whyNot)
+      whyNot->append(QString("The currently set bit depth (%1) is not supported.\n").arg(bps));
+    canConvert = false;
+  }
+  if (imageSize.width() % this->getSubsamplingHor() != 0)
+  {
+    if (whyNot)
+      whyNot->append(QString("The item width (%1) must be divisible by the horizontal subsampling factor (%2).\n").arg(imageSize.width()).arg(this->getSubsamplingHor()));
+    canConvert = false;
+  }
+  if (imageSize.height() % this->getSubsamplingVer() != 0)
+  {
+    if (whyNot)
+      whyNot->append(QString("The item height (%1) must be divisible by the vertical subsampling factor (%2).\n").arg(imageSize.height()).arg(this->getSubsamplingVer()));
+    canConvert = false;
+  }
+  if (this->subsampling == Subsampling::UNKNOWN)
+  {
+    if (whyNot)
+      whyNot->append("The current yuv subsampling is unknown.\n");
+    canConvert = false;
+  }
+  if (!this->planar && this->subsampling != Subsampling::YUV_422 && this->subsampling != Subsampling::YUV_444)
+  { 
+    if (whyNot)
+      whyNot->append("Packed YUV formats are onyl supported for 4:2:2 and 4:4:4 subsampling.\n");
+    canConvert = false;
+  }
+  return canConvert;
+}
+
+// Generate a unique name for the YUV format
+QString yuvPixelFormat::getName() const
+{
+  if (!isValid())
+    return "Invalid";
+
+  QString name;
+
+  // Start with the YUV order
+  if (planar)
+  {
+    int idx = int(planeOrder);
+    static const QString orderNames[] = {"YUV", "YVU", "YUVA", "YVUA"};
+    Q_ASSERT(idx >= 0 && idx < 4);
+    name += orderNames[idx];
+
+    if (uvInterleaved)
+      name += "(IL)";
+  }
+  else
+    name += getPackingFormatString(packingOrder);
+
+  // Next add the subsampling
+  assert(subsampling != Subsampling::UNKNOWN);
+  name += " " + subsamplingTextList[subsamplingList.indexOf(subsampling)];
+
+  // Add the bits
+  name += QString(" %1-bit").arg(bitsPerSample);
+
+  // Add the endianess (if the bit depth is greater 8)
+  if (bitsPerSample > 8)
+    name += (bigEndian) ? " BE" : " LE";
+
+  if (!planar && subsampling != Subsampling::YUV_400)
+    name += bytePacking ? " packed-B" : " packed";
+
+  // Add the Chroma offsets (if it is not the default offset)
+  if (!isDefaultChromaFormat(chromaOffset[0], true, subsampling))
+    name += QString(" Cx%1").arg(chromaOffset[0]);
+  if (!isDefaultChromaFormat(chromaOffset[1], false, subsampling))
+    name += QString(" Cy%1").arg(chromaOffset[1]);
+
+  return name;
+}
+
+int64_t yuvPixelFormat::bytesPerFrame(const QSize &frameSize) const
+{
+  int64_t bytes = 0;
+  if (planar || !bytePacking)
+  {
+    // Add the bytes of the 3 (or 4) planes.
+    // This also works for packed formats without byte packing. For these formats the number of bytes are identical to
+    // the not packed formats, the bytes are just sorted in another way.
+
+    int bytesPerSample = (bitsPerSample + 7) / 8; // Round to bytes
+    bytes += frameSize.width() * frameSize.height() * bytesPerSample; // Luma plane
+    if (subsampling == Subsampling::YUV_444)
+      bytes += frameSize.width() * frameSize.height() * bytesPerSample * 2; // U/V planes
+    else if (subsampling == Subsampling::YUV_422 || subsampling == Subsampling::YUV_440)
+      bytes += (frameSize.width() / 2) * frameSize.height() * bytesPerSample * 2; // U/V planes, half the width
+    else if (subsampling == Subsampling::YUV_420)
+      bytes += (frameSize.width() / 2) * (frameSize.height() / 2) * bytesPerSample * 2; // U/V planes, half the width and height
+    else if (subsampling == Subsampling::YUV_410)
+      bytes += (frameSize.width() / 4) * (frameSize.height() / 4) * bytesPerSample * 2; // U/V planes, half the width and height
+    else if (subsampling == Subsampling::YUV_411)
+      bytes += (frameSize.width() / 4) * frameSize.height() * bytesPerSample * 2; // U/V planes, quarter the width
+    else if (subsampling == Subsampling::YUV_400)
+      bytes += 0; // No chroma components
+    else
+      return -1;  // Unknown subsampling
+
+    if (planar && (planeOrder == PlaneOrder::YUVA || planeOrder == PlaneOrder::YVUA))
+      // There is an additional alpha plane. The alpha plane is not subsampled
+      bytes += frameSize.width() * frameSize.height() * bytesPerSample; // Alpha plane
+    if (!planar && subsampling == Subsampling::YUV_444 && (packingOrder == PackingOrder::AYUV || packingOrder == PackingOrder::YUVA))
+      // There is an additional alpha plane. The alpha plane is not subsampled
+      bytes += frameSize.width() * frameSize.height() * bytesPerSample; // Alpha plane
+  }
+  else
+  {
+    // This is a packed format with byte packing
+    if (subsampling == Subsampling::YUV_422)
+    {
+      // All packing orders have 4 values per packed value (which has 2 Y samples)
+      int bitsPerPixel = bitsPerSample * 4;
+      return ((bitsPerPixel + 7) / 8) * (frameSize.width() / 2) * frameSize.height();
+    }
+    // This is a packed format. The added number of bytes might be lower because of the packing.
+    if (subsampling == Subsampling::YUV_444)
+    {
+      int bitsPerPixel = bitsPerSample * 3;
+      if (packingOrder == PackingOrder::AYUV || packingOrder == PackingOrder::YUVA)
+        bitsPerPixel += bitsPerSample;
+      return ((bitsPerPixel + 7) / 8) * frameSize.width() * frameSize.height();
+    }
+    //else if (subsampling == Subsampling::YUV_422 || subsampling == Subsampling::YUV_440)
+    //{
+    //  // All packing orders have 4 values per packed value (which has 2 Y samples)
+    //  int bitsPerPixel = bitsPerSample * 4;
+    //  return ((bitsPerPixel + 7) / 8) * (frameSize.width() / 2) * frameSize.height();
+    //}
+    //else if (subsampling == Subsampling::YUV_420)
+    //{
+    //  // All packing orders have 6 values per packed sample (which has 4 Y samples)
+    //  int bitsPerPixel = bitsPerSample * 6;
+    //  return ((bitsPerPixel + 7) / 8) * (frameSize.width() / 2) * (frameSize.height() / 2);
+    //}
+    //else
+    //  return -1;  // Unknown subsampling
+  }
+  return bytes;
+}
+
+int yuvPixelFormat::getSubsamplingHor() const
+{
+  if (subsampling == Subsampling::YUV_410 || subsampling == Subsampling::YUV_411)
+    return 4;
+  if (subsampling == Subsampling::YUV_422 || subsampling == Subsampling::YUV_420)
+    return 2;
+  return 1;
+}
+int yuvPixelFormat::getSubsamplingVer() const
+{
+  if (subsampling == Subsampling::YUV_410)
+    return 4;
+  if (subsampling == Subsampling::YUV_420 || subsampling == Subsampling::YUV_440)
+    return 2;
+  return 1;
+}
+void yuvPixelFormat::setDefaultChromaOffset()
+{
+  this->chromaOffset[0] = 0;
+  this->chromaOffset[1] = 0;
+  if (this->subsampling == Subsampling::YUV_420)
+    this->chromaOffset[1] = 1;
+}
+
+} // namespace YUV_Internals

--- a/YUViewLib/src/video/yuvPixelFormat.cpp
+++ b/YUViewLib/src/video/yuvPixelFormat.cpp
@@ -32,6 +32,8 @@
 
 #include "yuvPixelFormat.h"
 
+#include <QSize>
+
 namespace YUV_Internals
 {
 

--- a/YUViewLib/src/video/yuvPixelFormat.cpp
+++ b/YUViewLib/src/video/yuvPixelFormat.cpp
@@ -317,7 +317,7 @@ QString yuvPixelFormat::getName() const
     name += getPackingFormatString(packingOrder);
 
   // Next add the subsampling
-  assert(subsampling != Subsampling::UNKNOWN);
+  Q_ASSERT(subsampling != Subsampling::UNKNOWN);
   name += " " + subsamplingTextList[subsamplingList.indexOf(subsampling)];
 
   // Add the bits

--- a/YUViewLib/src/video/yuvPixelFormat.h
+++ b/YUViewLib/src/video/yuvPixelFormat.h
@@ -1,0 +1,177 @@
+/*  This file is part of YUView - The YUV player with advanced analytics toolset
+*   <https://github.com/IENT/YUView>
+*   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   In addition, as a special exception, the copyright holders give
+*   permission to link the code of portions of this program with the
+*   OpenSSL library under certain conditions as described in each
+*   individual source file, and distribute linked combinations including
+*   the two.
+*
+*   You must obey the GNU General Public License in all respects for all
+*   of the code used other than OpenSSL. If you modify file(s) with this
+*   exception, you may extend this exception to your version of the
+*   file(s), but you are not obligated to do so. If you do not wish to do
+*   so, delete this exception statement from your version. If you delete
+*   this exception statement from all source files in the program, then
+*   also delete it here.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <QDialog>
+#include <QObject>
+#include <QString>
+
+// The YUV_Internals namespace. We use this namespace because of the dialog. We want to be able to pass a yuvPixelFormat to the dialog and keep the
+// global namespace clean but we are not able to use nested classes because of the Q_OBJECT macro. So the dialog and the yuvPixelFormat is inside
+// of this namespace.
+namespace YUV_Internals
+{
+  
+enum class Component
+{
+  Luma = 0,
+  Chroma = 1
+};
+
+enum class ColorConversion
+{
+  BT709_LimitedRange,
+  BT709_FullRange,
+  BT601_LimitedRange,
+  BT601_FullRange,
+  BT2020_LimitedRange,
+  BT2020_FullRange,
+};
+const auto colorConversionList = QList<ColorConversion>() << ColorConversion::BT709_LimitedRange << ColorConversion::BT709_FullRange << ColorConversion::BT601_LimitedRange << ColorConversion::BT601_FullRange << ColorConversion::BT2020_LimitedRange << ColorConversion::BT2020_FullRange;
+const auto colorConversionNameList = QStringList() << "ITU-R.BT709" << "ITU-R.BT709 Full Range" << "ITU-R.BT601" << "ITU-R.BT601 Full Range" << "ITU-R.BT2020" << "ITU-R.BT2020 Full Range";
+void getColorConversionCoefficients(ColorConversion colorConversion, int RGBConv[5]);
+
+// How to perform up-sampling (chroma subsampling)
+enum class ChromaInterpolation
+{
+  NearestNeighbor,
+  Bilinear,
+  Interstitial
+};
+const auto chromaInterpolationList = QList<ChromaInterpolation>() << ChromaInterpolation::NearestNeighbor << ChromaInterpolation::Bilinear << ChromaInterpolation::Interstitial;
+const auto chromaInterpolationNameList = QStringList() << "Nearest Neighbor" << "Bilinear" << "Interstitial";
+
+class MathParameters
+{
+public:
+  MathParameters() : scale(1), offset(128), invert(false) {}
+  MathParameters(int scale, int offset, bool invert) : scale(scale), offset(offset), invert(invert) {}
+  // Do we need to apply any transform to the raw YUV data before conversion to RGB?
+  bool mathRequired() const { return scale != 1 || invert; }
+
+  int scale, offset;
+  bool invert;
+};
+
+enum class PackingOrder
+{
+  YUV,      // 444
+  YVU,      // 444
+  AYUV,     // 444
+  YUVA,     // 444
+  UYVY,     // 422
+  VYUY,     // 422
+  YUYV,     // 422
+  YVYU,     // 422
+  //YYYYUV,   // 420
+  //YYUYYV,   // 420
+  //UYYVYY,   // 420
+  //VYYUYY    // 420
+  UNKNOWN
+};
+const auto packingOrderList = QList<PackingOrder>() << PackingOrder::YUV << PackingOrder::YVU << PackingOrder::AYUV << PackingOrder::YUVA << PackingOrder::UYVY << PackingOrder::VYUY << PackingOrder::YUYV << PackingOrder::YVYU;
+const auto packingOrderNameList = QStringList() << "YUV" << "YVU" << "AYUV" << "YUVA" << "UYVY" << "VYUY" << "YUYV" << "YVYU";
+QString getPackingFormatString(PackingOrder packing);
+
+enum class Subsampling
+{
+  YUV_444,  // No subsampling
+  YUV_422,  // Chroma: half horizontal resolution
+  YUV_420,  // Chroma: half vertical and horizontal resolution
+  YUV_440,  // Chroma: half vertical resolution
+  YUV_410,  // Chroma: quarter vertical, quarter horizontal resolution
+  YUV_411,  // Chroma: quarter horizontal resolution
+  YUV_400,  // Luma only
+  UNKNOWN
+};
+const auto subsamplingList = QList<Subsampling>() << Subsampling::YUV_444 << Subsampling::YUV_422 << Subsampling::YUV_420 << Subsampling::YUV_440 << Subsampling::YUV_410 << Subsampling::YUV_411 << Subsampling::YUV_400;
+const auto subsamplingNameList = QStringList() << "444" << "422" << "420" << "440" << "410" << "411" << "400";
+const auto subsamplingTextList = QStringList() << "4:4:4" << "4:2:2" << "4:2:0" << "4:4:0" << "4:1:0" << "4:1:1" << "4:0:0";
+int getMaxPossibleChromaOffsetValues(bool horizontal, Subsampling subsampling);
+QList<PackingOrder> getSupportedPackingFormats(Subsampling subsampling);
+QString subsamplingToString(Subsampling type);
+Subsampling stringToSubsampling(QString typeString);
+
+enum class PlaneOrder
+{
+  YUV,
+  YVU,
+  YUVA,
+  YVUA
+};
+const auto planeOrderList = QList<PlaneOrder>() << PlaneOrder::YUV << PlaneOrder::YVU << PlaneOrder::YUVA << PlaneOrder::YVUA;
+const auto planeOrderNameList = QStringList() << "YUV" << "YVU" << "YUVA" << "YVUA";
+
+const QList<int> bitDepthList = QList<int>() << 8 << 9 << 10 << 12 << 14 << 16;
+
+// This class defines a specific YUV format with all properties like pixels per sample, subsampling of chroma
+// components and so on.
+class yuvPixelFormat
+{
+public:
+  yuvPixelFormat() = default;
+  yuvPixelFormat(const QString &name);  // Set the pixel format by name. The name should have the format that is returned by getName().
+  yuvPixelFormat(Subsampling subsampling, int bitsPerSample, PlaneOrder planeOrder=PlaneOrder::YUV, bool bigEndian=false);
+  yuvPixelFormat(Subsampling subsampling, int bitsPerSample, PackingOrder packingOrder, bool bytePacking, bool bigEndian=false);
+
+  bool isValid() const;
+  bool canConvertToRGB(QSize frameSize, QString *whyNot = nullptr) const;
+  int64_t bytesPerFrame(const QSize &frameSize) const;
+  QString getName() const;
+  int getSubsamplingHor() const;
+  int getSubsamplingVer() const;
+  void setDefaultChromaOffset();
+  bool isChromaSubsampled() const { return subsampling != Subsampling::YUV_444; }
+
+  bool operator==(const yuvPixelFormat& a) const { return getName() == a.getName(); }
+  bool operator!=(const yuvPixelFormat& a) const { return getName() != a.getName(); }
+  bool operator==(const QString& a) const { return getName() == a; }
+  bool operator!=(const QString& a) const { return getName() != a; }
+
+  Subsampling subsampling {Subsampling::YUV_444};
+  int bitsPerSample {-1};
+  bool bigEndian {false};
+  bool planar {false};
+  
+  // The chroma offset in x and y direction. The vales (0...4) define the offsets [0, 1/2, 1, 3/2] samples towards the right and bottom.
+  int chromaOffset[2] {0, 0};
+
+  PlaneOrder planeOrder {PlaneOrder::YUV};
+  bool uvInterleaved {false};       //< If set, the UV (and A if present) planes are interleaved
+
+  // if planar is not set
+  PackingOrder packingOrder {PackingOrder::YUV};
+  bool bytePacking {false};
+};
+
+} // namespace YUV_Internals

--- a/YUViewLib/src/video/yuvPixelFormat.h
+++ b/YUViewLib/src/video/yuvPixelFormat.h
@@ -32,7 +32,6 @@
 
 #pragma once
 
-#include <QDialog>
 #include <QObject>
 #include <QString>
 

--- a/YUViewLib/ui/videoHandlerYUV_CustomFormatDialog.ui
+++ b/YUViewLib/ui/videoHandlerYUV_CustomFormatDialog.ui
@@ -68,41 +68,6 @@
 &lt;b&gt;4:0:0:&lt;/b&gt; Luma only. No chroma components are present.&lt;br /&gt;
 &lt;/p&gt;</string>
        </property>
-       <item>
-        <property name="text">
-         <string>4:4:4</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>4:2:2</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>4:2:0</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>4:4:0</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>4:1:0</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>4:1:1</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>4:0:0 (Luma only)</string>
-        </property>
-       </item>
       </widget>
      </item>
      <item row="2" column="0">
@@ -157,36 +122,6 @@ How is the chroma component subsampled? Various subsamplings are supported:&lt;b
        <property name="whatsThis">
         <string>How many bits per color component are there? If the bit depth is greater than 8, we will assume multiple bytes per component.</string>
        </property>
-       <item>
-        <property name="text">
-         <string>8</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>9</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>10</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>12</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>14</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>16</string>
-        </property>
-       </item>
       </widget>
      </item>
      <item row="2" column="1">
@@ -267,26 +202,6 @@ How is the chroma component subsampled? Various subsamplings are supported:&lt;b
         <property name="whatsThis">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the order of the planes in the file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
-        <item>
-         <property name="text">
-          <string>YUV</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>YVU</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>YUVA</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>YVUA</string>
-         </property>
-        </item>
        </widget>
       </item>
       <item row="0" column="0">

--- a/YUViewUnitTest/YUViewUnitTest.pro
+++ b/YUViewUnitTest/YUViewUnitTest.pro
@@ -2,4 +2,5 @@ TEMPLATE = subdirs
 
 requires(qtHaveModule(testlib))
 
-SUBDIRS = filesource
+SUBDIRS = filesource \
+          video

--- a/YUViewUnitTest/filesource/filesource/tst_filesource.cpp
+++ b/YUViewUnitTest/filesource/filesource/tst_filesource.cpp
@@ -4,15 +4,15 @@
 
 class fileSourceTest : public QObject
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    fileSourceTest();
-    ~fileSourceTest();
+  fileSourceTest();
+  ~fileSourceTest();
 
 private slots:
-    void testFormatFromFilename_data();
-    void testFormatFromFilename();
+  void testFormatFromFilename_data();
+  void testFormatFromFilename();
 
 };
 
@@ -26,93 +26,93 @@ fileSourceTest::~fileSourceTest()
 
 void fileSourceTest::testFormatFromFilename_data()
 {
-    QTest::addColumn<QString>("filename");
-    QTest::addColumn<int>("width");
-    QTest::addColumn<int>("height");
-    QTest::addColumn<int>("framerate");
-    QTest::addColumn<int>("bitDepth");
-    QTest::addColumn<bool>("packed");
+  QTest::addColumn<QString>("filename");
+  QTest::addColumn<int>("width");
+  QTest::addColumn<int>("height");
+  QTest::addColumn<int>("framerate");
+  QTest::addColumn<int>("bitDepth");
+  QTest::addColumn<bool>("packed");
 
-    // Things that should work
-    QTest::newRow("testResolutionOnly1") << "something_1920x1080.yuv" << 1920 << 1080 << -1 << -1 << false;
-    QTest::newRow("testResolutionOnly2") << "something_295x289.yuv" << 295 << 289 << -1 << -1 << false;
-    QTest::newRow("testResolutionOnly3") << "something_295234x289234.yuv" << 295234 << 289234 << -1 << -1 << false;
-    QTest::newRow("testResolutionOnly4") << "something_1920X1080.yuv" << 1920 << 1080 << -1 << -1 << false;
-    QTest::newRow("testResolutionOnly5") << "something_1920*1080.yuv" << 1920 << 1080 << -1 << -1 << false;
-    QTest::newRow("testResolutionOnly6") << "something_1920x1080_something.yuv" << 1920 << 1080 << -1 << -1 << false;
-    // Things that should not work
-    QTest::newRow("testResolutionOnly7") << "something_1920_1080.yuv" << -1 << -1 << -1 << -1 << false;
-    QTest::newRow("testResolutionOnly8") << "something_19201080.yuv" << -1 << -1 << -1 << -1 << false;
-    QTest::newRow("testResolutionOnly9") << "something_1920-1080.yuv" << -1 << -1 << -1 << -1 << false;
-    QTest::newRow("testResolutionOnly10") << "something_1920-1080_something.yuv" << -1 << -1 << -1 << -1 << false;
+  // Things that should work
+  QTest::newRow("testResolutionOnly1") << "something_1920x1080.yuv" << 1920 << 1080 << -1 << -1 << false;
+  QTest::newRow("testResolutionOnly2") << "something_295x289.yuv" << 295 << 289 << -1 << -1 << false;
+  QTest::newRow("testResolutionOnly3") << "something_295234x289234.yuv" << 295234 << 289234 << -1 << -1 << false;
+  QTest::newRow("testResolutionOnly4") << "something_1920X1080.yuv" << 1920 << 1080 << -1 << -1 << false;
+  QTest::newRow("testResolutionOnly5") << "something_1920*1080.yuv" << 1920 << 1080 << -1 << -1 << false;
+  QTest::newRow("testResolutionOnly6") << "something_1920x1080_something.yuv" << 1920 << 1080 << -1 << -1 << false;
+  // Things that should not work
+  QTest::newRow("testResolutionOnly7") << "something_1920_1080.yuv" << -1 << -1 << -1 << -1 << false;
+  QTest::newRow("testResolutionOnly8") << "something_19201080.yuv" << -1 << -1 << -1 << -1 << false;
+  QTest::newRow("testResolutionOnly9") << "something_1920-1080.yuv" << -1 << -1 << -1 << -1 << false;
+  QTest::newRow("testResolutionOnly10") << "something_1920-1080_something.yuv" << -1 << -1 << -1 << -1 << false;
 
-    // Things that should work
-    QTest::newRow("testResolutionAndFPS1") << "something_1920x1080_25.yuv" << 1920 << 1080 << 25 << -1 << false;
-    QTest::newRow("testResolutionAndFPS2") << "something_1920x1080_999.yuv" << 1920 << 1080 << 999 << -1 << false;
-    QTest::newRow("testResolutionAndFPS3") << "something_1920x1080_60Hz.yuv" << 1920 << 1080 << 60 << -1 << false;
-    QTest::newRow("testResolutionAndFPS4") << "something_1920x1080_999_something.yuv" << 1920 << 1080 << 999 << -1 << false;
-    QTest::newRow("testResolutionAndFPS5") << "something_1920x1080_60hz.yuv" << 1920 << 1080 << 60 << -1 << false;
-    QTest::newRow("testResolutionAndFPS6") << "something_1920x1080_60HZ.yuv" << 1920 << 1080 << 60 << -1 << false;
-    QTest::newRow("testResolutionAndFPS7") << "something_1920x1080_60fps.yuv" << 1920 << 1080 << 60 << -1 << false;
-    QTest::newRow("testResolutionAndFPS8") << "something_1920x1080_60FPS.yuv" << 1920 << 1080 << 60 << -1 << false;
+  // Things that should work
+  QTest::newRow("testResolutionAndFPS1") << "something_1920x1080_25.yuv" << 1920 << 1080 << 25 << -1 << false;
+  QTest::newRow("testResolutionAndFPS2") << "something_1920x1080_999.yuv" << 1920 << 1080 << 999 << -1 << false;
+  QTest::newRow("testResolutionAndFPS3") << "something_1920x1080_60Hz.yuv" << 1920 << 1080 << 60 << -1 << false;
+  QTest::newRow("testResolutionAndFPS4") << "something_1920x1080_999_something.yuv" << 1920 << 1080 << 999 << -1 << false;
+  QTest::newRow("testResolutionAndFPS5") << "something_1920x1080_60hz.yuv" << 1920 << 1080 << 60 << -1 << false;
+  QTest::newRow("testResolutionAndFPS6") << "something_1920x1080_60HZ.yuv" << 1920 << 1080 << 60 << -1 << false;
+  QTest::newRow("testResolutionAndFPS7") << "something_1920x1080_60fps.yuv" << 1920 << 1080 << 60 << -1 << false;
+  QTest::newRow("testResolutionAndFPS8") << "something_1920x1080_60FPS.yuv" << 1920 << 1080 << 60 << -1 << false;
 
-    QTest::newRow("testResolutionAndFPSAndBitDepth1") << "something_1920x1080_25_8.yuv" << 1920 << 1080 << 25 << 8 << false;
-    QTest::newRow("testResolutionAndFPSAndBitDepth2") << "something_1920x1080_25_12.yuv" << 1920 << 1080 << 25 << 12 << false;
-    QTest::newRow("testResolutionAndFPSAndBitDepth3") << "something_1920x1080_25_8b.yuv" << 1920 << 1080 << 25 << 8 << false;
-    QTest::newRow("testResolutionAndFPSAndBitDepth4") << "something_1920x1080_25_8b_something.yuv" << 1920 << 1080 << 25 << 8 << false;
+  QTest::newRow("testResolutionAndFPSAndBitDepth1") << "something_1920x1080_25_8.yuv" << 1920 << 1080 << 25 << 8 << false;
+  QTest::newRow("testResolutionAndFPSAndBitDepth2") << "something_1920x1080_25_12.yuv" << 1920 << 1080 << 25 << 12 << false;
+  QTest::newRow("testResolutionAndFPSAndBitDepth3") << "something_1920x1080_25_8b.yuv" << 1920 << 1080 << 25 << 8 << false;
+  QTest::newRow("testResolutionAndFPSAndBitDepth4") << "something_1920x1080_25_8b_something.yuv" << 1920 << 1080 << 25 << 8 << false;
 
-    QTest::newRow("testResolutionIndicator1") << "something1080p.yuv" << 1920 << 1080 << -1 << -1 << false;
-    QTest::newRow("testResolutionIndicator2") << "something1080pSomething.yuv" << 1920 << 1080 << -1 << -1 << false;
-    QTest::newRow("testResolutionIndicator3") << "something1080p33.yuv" << 1920 << 1080 << 33 << -1 << false;
-    QTest::newRow("testResolutionIndicator4") << "something1080p33Something.yuv" << 1920 << 1080 << 33 << -1 << false;
-    QTest::newRow("testResolutionIndicator5") << "something720p.yuv" << 1280 << 720 << -1 << -1 << false;
-    QTest::newRow("testResolutionIndicator6") << "something720pSomething.yuv" << 1280 << 720 << -1 << -1 << false;
-    QTest::newRow("testResolutionIndicator7") << "something720p44.yuv" << 1280 << 720 << 44 << -1 << false;
-    QTest::newRow("testResolutionIndicator8") << "something720p44Something.yuv" << 1280 << 720 << 44 << -1 << false;
+  QTest::newRow("testResolutionIndicator1") << "something1080p.yuv" << 1920 << 1080 << -1 << -1 << false;
+  QTest::newRow("testResolutionIndicator2") << "something1080pSomething.yuv" << 1920 << 1080 << -1 << -1 << false;
+  QTest::newRow("testResolutionIndicator3") << "something1080p33.yuv" << 1920 << 1080 << 33 << -1 << false;
+  QTest::newRow("testResolutionIndicator4") << "something1080p33Something.yuv" << 1920 << 1080 << 33 << -1 << false;
+  QTest::newRow("testResolutionIndicator5") << "something720p.yuv" << 1280 << 720 << -1 << -1 << false;
+  QTest::newRow("testResolutionIndicator6") << "something720pSomething.yuv" << 1280 << 720 << -1 << -1 << false;
+  QTest::newRow("testResolutionIndicator7") << "something720p44.yuv" << 1280 << 720 << 44 << -1 << false;
+  QTest::newRow("testResolutionIndicator8") << "something720p44Something.yuv" << 1280 << 720 << 44 << -1 << false;
 
-    QTest::newRow("testResolutionKeyword1") << "something_cif.yuv" << 352 << 288 << -1 << -1 << false;
-    QTest::newRow("testResolutionKeyword2") << "something_cifSomething.yuv" << 352 << 288 << -1 << -1 << false;
-    QTest::newRow("testResolutionKeyword3") << "something_qcif.yuv" << 176 << 144 << -1 << -1 << false;
-    QTest::newRow("testResolutionKeyword4") << "something_qcifSomething.yuv" << 176 << 144 << -1 << -1 << false;
-    QTest::newRow("testResolutionKeyword5") << "something_4cif.yuv" << 704 << 576 << -1 << -1 << false;
-    QTest::newRow("testResolutionKeyword6") << "something_4cifSomething.yuv" << 704 << 576 << -1 << -1 << false;
-    QTest::newRow("testResolutionKeyword7") << "somethingUHDSomething.yuv" << 3840 << 2160 << -1 << -1 << false;
-    QTest::newRow("testResolutionKeyword8") << "somethingHDSomething.yuv" << 1920 << 1080 << -1 << -1 << false;
-    QTest::newRow("testResolutionKeyword9") << "something1080pSomething.yuv" << 1920 << 1080 << -1 << -1 << false;
-    QTest::newRow("testResolutionKeyword10") << "something720pSomething.yuv" << 1280 << 720 << -1 << -1 << false;
+  QTest::newRow("testResolutionKeyword1") << "something_cif.yuv" << 352 << 288 << -1 << -1 << false;
+  QTest::newRow("testResolutionKeyword2") << "something_cifSomething.yuv" << 352 << 288 << -1 << -1 << false;
+  QTest::newRow("testResolutionKeyword3") << "something_qcif.yuv" << 176 << 144 << -1 << -1 << false;
+  QTest::newRow("testResolutionKeyword4") << "something_qcifSomething.yuv" << 176 << 144 << -1 << -1 << false;
+  QTest::newRow("testResolutionKeyword5") << "something_4cif.yuv" << 704 << 576 << -1 << -1 << false;
+  QTest::newRow("testResolutionKeyword6") << "something_4cifSomething.yuv" << 704 << 576 << -1 << -1 << false;
+  QTest::newRow("testResolutionKeyword7") << "somethingUHDSomething.yuv" << 3840 << 2160 << -1 << -1 << false;
+  QTest::newRow("testResolutionKeyword8") << "somethingHDSomething.yuv" << 1920 << 1080 << -1 << -1 << false;
+  QTest::newRow("testResolutionKeyword9") << "something1080pSomething.yuv" << 1920 << 1080 << -1 << -1 << false;
+  QTest::newRow("testResolutionKeyword10") << "something720pSomething.yuv" << 1280 << 720 << -1 << -1 << false;
 
-    QTest::newRow("testBitDepthIndicator1") << "something_1920x1080_8Bit.yuv" << 1920 << 1080 << -1 << 8 << false;
-    QTest::newRow("testBitDepthIndicator2") << "something_1920x1080_10Bit.yuv" << 1920 << 1080 << -1 << 10 << false;
-    QTest::newRow("testBitDepthIndicator3") << "something_1920x1080_12Bit.yuv" << 1920 << 1080 << -1 << 12 << false;
-    QTest::newRow("testBitDepthIndicator4") << "something_1920x1080_16Bit.yuv" << 1920 << 1080 << -1 << 16 << false;
-    QTest::newRow("testBitDepthIndicator5") << "something_1920x1080_8bit.yuv" << 1920 << 1080 << -1 << 8 << false;
-    QTest::newRow("testBitDepthIndicator6") << "something_1920x1080_8BIT.yuv" << 1920 << 1080 << -1 << 8 << false;
-    QTest::newRow("testBitDepthIndicator7") << "something_1920x1080_8-Bit.yuv" << 1920 << 1080 << -1 << 8 << false;
-    QTest::newRow("testBitDepthIndicator8") << "something_1920x1080_8-BIT.yuv" << 1920 << 1080 << -1 << 8 << false;
+  QTest::newRow("testBitDepthIndicator1") << "something_1920x1080_8Bit.yuv" << 1920 << 1080 << -1 << 8 << false;
+  QTest::newRow("testBitDepthIndicator2") << "something_1920x1080_10Bit.yuv" << 1920 << 1080 << -1 << 10 << false;
+  QTest::newRow("testBitDepthIndicator3") << "something_1920x1080_12Bit.yuv" << 1920 << 1080 << -1 << 12 << false;
+  QTest::newRow("testBitDepthIndicator4") << "something_1920x1080_16Bit.yuv" << 1920 << 1080 << -1 << 16 << false;
+  QTest::newRow("testBitDepthIndicator5") << "something_1920x1080_8bit.yuv" << 1920 << 1080 << -1 << 8 << false;
+  QTest::newRow("testBitDepthIndicator6") << "something_1920x1080_8BIT.yuv" << 1920 << 1080 << -1 << 8 << false;
+  QTest::newRow("testBitDepthIndicator7") << "something_1920x1080_8-Bit.yuv" << 1920 << 1080 << -1 << 8 << false;
+  QTest::newRow("testBitDepthIndicator8") << "something_1920x1080_8-BIT.yuv" << 1920 << 1080 << -1 << 8 << false;
 
-    QTest::newRow("testPackedIndicator1") << "something_1920x1080_packed.yuv" << 1920 << 1080 << -1 << -1 << true;
-    QTest::newRow("testPackedIndicator2") << "something_1920x1080_packed-something.yuv" << 1920 << 1080 << -1 << -1 << true;
-    QTest::newRow("testPackedIndicator3") << "something_1920x1080packed.yuv" << 1920 << 1080 << -1 << -1 << false;
-    QTest::newRow("testPackedIndicator4") << "packed_something_1920x1080.yuv" << 1920 << 1080 << -1 << -1 << false;
+  QTest::newRow("testPackedIndicator1") << "something_1920x1080_packed.yuv" << 1920 << 1080 << -1 << -1 << true;
+  QTest::newRow("testPackedIndicator2") << "something_1920x1080_packed-something.yuv" << 1920 << 1080 << -1 << -1 << true;
+  QTest::newRow("testPackedIndicator3") << "something_1920x1080packed.yuv" << 1920 << 1080 << -1 << -1 << false;
+  QTest::newRow("testPackedIndicator4") << "packed_something_1920x1080.yuv" << 1920 << 1080 << -1 << -1 << false;
 }
 
 void fileSourceTest::testFormatFromFilename()
 {
-    QFETCH(QString, filename);
-    QFETCH(int, width);
-    QFETCH(int, height);
-    QFETCH(int, framerate);
-    QFETCH(int, bitDepth);
-    QFETCH(bool, packed);
+  QFETCH(QString, filename);
+  QFETCH(int, width);
+  QFETCH(int, height);
+  QFETCH(int, framerate);
+  QFETCH(int, bitDepth);
+  QFETCH(bool, packed);
 
-    QFileInfo fileInfo(filename);
-    auto fileFormat = fileSource::formatFromFilename(fileInfo);
+  QFileInfo fileInfo(filename);
+  auto fileFormat = fileSource::formatFromFilename(fileInfo);
 
-    QCOMPARE(fileFormat.frameSize.width(), width);
-    QCOMPARE(fileFormat.frameSize.height(), height);
-    QCOMPARE(fileFormat.frameRate, framerate);
-    QCOMPARE(fileFormat.bitDepth, bitDepth);
-    QCOMPARE(fileFormat.packed, packed);
+  QCOMPARE(fileFormat.frameSize.width(), width);
+  QCOMPARE(fileFormat.frameSize.height(), height);
+  QCOMPARE(fileFormat.frameRate, framerate);
+  QCOMPARE(fileFormat.bitDepth, bitDepth);
+  QCOMPARE(fileFormat.packed, packed);
 }
 
 QTEST_MAIN(fileSourceTest)

--- a/YUViewUnitTest/video/rgbPixelFormatTest.cpp
+++ b/YUViewUnitTest/video/rgbPixelFormatTest.cpp
@@ -1,0 +1,79 @@
+#include <QtTest>
+
+#include <video/rgbPixelFormat.h>
+
+class rgbPixelFormatTest : public QObject
+{
+  Q_OBJECT
+
+public:
+  rgbPixelFormatTest() {};
+  ~rgbPixelFormatTest() {};
+
+private slots:
+  void testFormatFromToString();
+};
+
+QList<RGB_Internals::rgbPixelFormat> getAllFormats()
+{
+  QList<RGB_Internals::rgbPixelFormat> allFormats;
+
+  for (int bitsPerPixel = 1; bitsPerPixel <= 16; bitsPerPixel++)
+  {
+    for (auto planar : {false, true})
+    {
+      // No alpha
+      int positions[] = {0, 1, 2};
+      do {
+        allFormats.append(RGB_Internals::rgbPixelFormat(bitsPerPixel, planar, positions[0], positions[1], positions[2]));
+      } while (std::next_permutation(positions,positions+3));
+
+      // With alpha
+      int positionsA[] = {0, 1, 2, 3};
+      do {
+        allFormats.append(RGB_Internals::rgbPixelFormat(bitsPerPixel, planar, positionsA[0], positionsA[1], positionsA[2], positionsA[3]));
+      } while (std::next_permutation(positionsA,positionsA+4));
+    }
+  }
+
+  return allFormats;
+}
+
+void rgbPixelFormatTest::testFormatFromToString()
+{
+  for (auto fmt : getAllFormats())
+  {
+    QVERIFY(fmt.isValid());
+    auto name = fmt.getName();
+    auto fmtNew = RGB_Internals::rgbPixelFormat(name);
+    if (name.isEmpty())
+    {
+      QFAIL("Name empty");
+    }
+    if (fmt != fmtNew)
+    {
+      QFAIL(QString("Comparison failed. Names: %1").arg(name).toLocal8Bit().data());
+    }
+    if (fmt.posR != fmtNew.posR ||
+        fmt.posG != fmtNew.posG ||
+        fmt.posB != fmtNew.posB ||
+        fmt.posA != fmtNew.posA ||
+        fmt.bitsPerValue != fmtNew.bitsPerValue ||
+        fmt.planar != fmtNew.planar)
+    {
+      QFAIL(QString("Comparison of parameters failed. Names: %1").arg(name).toLocal8Bit().data());
+    }
+    if (fmt.posA != -1 && (fmt.nrChannels() != 4 || !fmt.hasAlphaChannel()))
+    {
+      QFAIL(QString("Alpha channel indicated wrong - %1").arg(name).toLocal8Bit().data());
+    }
+    if (fmt.posA == -1 && (fmt.nrChannels() != 3 || fmt.hasAlphaChannel()))
+    {
+      QFAIL(QString("Alpha channel indicated wrong - %1").arg(name).toLocal8Bit().data());
+    }
+  }
+}
+
+QTEST_MAIN(rgbPixelFormatTest)
+
+#include "rgbPixelFormatTest.moc"

--- a/YUViewUnitTest/video/rgbPixelFormatTest.pro
+++ b/YUViewUnitTest/video/rgbPixelFormatTest.pro
@@ -1,0 +1,15 @@
+TEMPLATE = app
+
+CONFIG += qt console warn_on no_testcase_installs depend_includepath testcase
+CONFIG -= debug_and_release
+CONFIG -= app_bundled
+
+TARGET = rgbPixelFormatTest
+
+QT += testlib
+QT -= gui
+
+INCLUDEPATH += $$top_srcdir/YUViewLib/src
+LIBS += -L$$top_builddir/YUViewLib -lYUViewLib
+
+SOURCES += rgbPixelFormatTest.cpp

--- a/YUViewUnitTest/video/video.pro
+++ b/YUViewUnitTest/video/video.pro
@@ -1,0 +1,3 @@
+TEMPLATE = subdirs
+
+SUBDIRS = videoHandlerYUV

--- a/YUViewUnitTest/video/video.pro
+++ b/YUViewUnitTest/video/video.pro
@@ -1,3 +1,6 @@
 TEMPLATE = subdirs
 
-SUBDIRS = videoHandlerYUV
+requires(qtHaveModule(testlib))
+
+SUBDIRS = yuvPixelFormatTest.pro \
+          rgbPixelFormatTest.pro

--- a/YUViewUnitTest/video/videoHandlerYUV/videoHandlerYUV.pro
+++ b/YUViewUnitTest/video/videoHandlerYUV/videoHandlerYUV.pro
@@ -8,7 +8,7 @@ TARGET = videoHandlerYUVFormatFromToString
 
 QT += testlib
 
-INCLUDEPATH += $$top_srcdir/YUViewLib/src $$top_builddir/YUViewLib
+INCLUDEPATH += $$top_srcdir/YUViewLib/src
 LIBS += -L$$top_builddir/YUViewLib -lYUViewLib
 
 SOURCES += videoHandlerYUVFormatFromToString.cpp

--- a/YUViewUnitTest/video/videoHandlerYUV/videoHandlerYUV.pro
+++ b/YUViewUnitTest/video/videoHandlerYUV/videoHandlerYUV.pro
@@ -7,6 +7,7 @@ CONFIG -= app_bundled
 TARGET = videoHandlerYUVFormatFromToString
 
 QT += testlib
+QT -= gui
 
 INCLUDEPATH += $$top_srcdir/YUViewLib/src
 LIBS += -L$$top_builddir/YUViewLib -lYUViewLib

--- a/YUViewUnitTest/video/videoHandlerYUV/videoHandlerYUV.pro
+++ b/YUViewUnitTest/video/videoHandlerYUV/videoHandlerYUV.pro
@@ -6,7 +6,7 @@ CONFIG -= app_bundled
 
 TARGET = videoHandlerYUVFormatFromToString
 
-QT += testlib gui widgets
+QT += testlib
 
 INCLUDEPATH += $$top_srcdir/YUViewLib/src $$top_builddir/YUViewLib
 LIBS += -L$$top_builddir/YUViewLib -lYUViewLib

--- a/YUViewUnitTest/video/videoHandlerYUV/videoHandlerYUV.pro
+++ b/YUViewUnitTest/video/videoHandlerYUV/videoHandlerYUV.pro
@@ -1,0 +1,14 @@
+TEMPLATE = app
+
+CONFIG += qt console warn_on no_testcase_installs depend_includepath testcase
+CONFIG -= debug_and_release
+CONFIG -= app_bundled
+
+TARGET = videoHandlerYUVFormatFromToString
+
+QT += testlib gui widgets
+
+INCLUDEPATH += $$top_srcdir/YUViewLib/src $$top_builddir/YUViewLib
+LIBS += -L$$top_builddir/YUViewLib -lYUViewLib
+
+SOURCES += videoHandlerYUVFormatFromToString.cpp

--- a/YUViewUnitTest/video/videoHandlerYUV/videoHandlerYUVFormatFromToString.cpp
+++ b/YUViewUnitTest/video/videoHandlerYUV/videoHandlerYUVFormatFromToString.cpp
@@ -1,6 +1,5 @@
 #include <QtTest>
 
-#include <video/videoHandlerYUV.h>
 #include <video/yuvPixelFormat.h>
 
 class videoHandlerYUVFormatFromToString : public QObject
@@ -54,8 +53,6 @@ QList<YUV_Internals::yuvPixelFormat> getAllFormats()
 
 void videoHandlerYUVFormatFromToString::testFormatFromToString()
 {
-  videoHandlerYUV handler;
-
   for (auto fmt : getAllFormats())
   {
     QVERIFY(fmt.isValid());
@@ -82,8 +79,6 @@ void videoHandlerYUVFormatFromToString::testFormatFromToString()
       QFAIL(QString("Comparison of parameters failed. Endianess wrong. Names: %1").arg(name).toLocal8Bit().data());
     }
   }
-
-  handler.setYUVPixelFormat(YUV_Internals::yuvPixelFormat());
 }
 
 QTEST_MAIN(videoHandlerYUVFormatFromToString)

--- a/YUViewUnitTest/video/videoHandlerYUV/videoHandlerYUVFormatFromToString.cpp
+++ b/YUViewUnitTest/video/videoHandlerYUV/videoHandlerYUVFormatFromToString.cpp
@@ -1,0 +1,91 @@
+#include <QtTest>
+
+#include <video/videoHandlerYUV.h>
+#include <video/yuvPixelFormat.h>
+
+class videoHandlerYUVFormatFromToString : public QObject
+{
+  Q_OBJECT
+
+public:
+  videoHandlerYUVFormatFromToString() {};
+  ~videoHandlerYUVFormatFromToString() {};
+
+private slots:
+  void testFormatFromToString();
+};
+
+QList<YUV_Internals::yuvPixelFormat> getAllFormats()
+{
+  QList<YUV_Internals::yuvPixelFormat> allFormats;
+
+  for (auto subsampling : YUV_Internals::subsamplingList)
+  {
+    for (auto bitsPerSample : YUV_Internals::bitDepthList)
+    {
+      QList<bool> endianList = (bitsPerSample > 8) ? (QList<bool>() << false << true) : (QList<bool>() << false);
+
+      // Planar
+      for (auto planeOrder : YUV_Internals::planeOrderList)
+      {
+        for (auto bigEndian : endianList)
+        {
+          auto pixelFormat = YUV_Internals::yuvPixelFormat(subsampling, bitsPerSample, planeOrder, bigEndian);
+          allFormats.append(pixelFormat);
+        }
+      }
+      // Packet
+      for (auto packingOrder : YUV_Internals::getSupportedPackingFormats(subsampling))
+      {
+        for (auto bytePacking : {false, true})
+        {
+          for (auto bigEndian : endianList)
+          {
+            auto pixelFormat = YUV_Internals::yuvPixelFormat(subsampling, bitsPerSample, packingOrder, bytePacking, bigEndian);
+            allFormats.append(pixelFormat);
+          }
+        }
+      }
+    }
+  }
+
+  return allFormats;
+}
+
+void videoHandlerYUVFormatFromToString::testFormatFromToString()
+{
+  videoHandlerYUV handler;
+
+  for (auto fmt : getAllFormats())
+  {
+    QVERIFY(fmt.isValid());
+    auto name = fmt.getName();
+    auto fmtNew = YUV_Internals::yuvPixelFormat(name);
+    if (fmt != fmtNew)
+    {
+      QFAIL(QString("Comparison failed. Names: %1").arg(name).toLocal8Bit().data());
+    }
+    if (fmt.subsampling != fmtNew.subsampling ||
+        fmt.bitsPerSample != fmtNew.bitsPerSample ||
+        fmt.planar != fmtNew.planar ||
+        fmt.chromaOffset[0] != fmtNew.chromaOffset[0] ||
+        fmt.chromaOffset[1] != fmtNew.chromaOffset[1] ||
+        fmt.planeOrder != fmtNew.planeOrder ||
+        fmt.uvInterleaved != fmtNew.uvInterleaved ||
+        fmt.packingOrder != fmtNew.packingOrder ||
+        fmt.bytePacking != fmtNew.bytePacking)
+    {
+      QFAIL(QString("Comparison of parameters failed. Names: %1").arg(name).toLocal8Bit().data());
+    }
+    if (fmt.bitsPerSample > 8 && fmt.bigEndian != fmtNew.bigEndian)
+    {
+      QFAIL(QString("Comparison of parameters failed. Endianess wrong. Names: %1").arg(name).toLocal8Bit().data());
+    }
+  }
+
+  handler.setYUVPixelFormat(YUV_Internals::yuvPixelFormat());
+}
+
+QTEST_MAIN(videoHandlerYUVFormatFromToString)
+
+#include "videoHandlerYUVFormatFromToString.moc"

--- a/YUViewUnitTest/video/yuvPixelFormatTest.cpp
+++ b/YUViewUnitTest/video/yuvPixelFormatTest.cpp
@@ -2,13 +2,13 @@
 
 #include <video/yuvPixelFormat.h>
 
-class videoHandlerYUVFormatFromToString : public QObject
+class yuvPixelFormatTest : public QObject
 {
   Q_OBJECT
 
 public:
-  videoHandlerYUVFormatFromToString() {};
-  ~videoHandlerYUVFormatFromToString() {};
+  yuvPixelFormatTest() {};
+  ~yuvPixelFormatTest() {};
 
 private slots:
   void testFormatFromToString();
@@ -51,12 +51,16 @@ QList<YUV_Internals::yuvPixelFormat> getAllFormats()
   return allFormats;
 }
 
-void videoHandlerYUVFormatFromToString::testFormatFromToString()
+void yuvPixelFormatTest::testFormatFromToString()
 {
   for (auto fmt : getAllFormats())
   {
     QVERIFY(fmt.isValid());
     auto name = fmt.getName();
+    if (name.isEmpty())
+    {
+      QFAIL("Name empty");
+    }
     auto fmtNew = YUV_Internals::yuvPixelFormat(name);
     if (fmt != fmtNew)
     {
@@ -81,6 +85,6 @@ void videoHandlerYUVFormatFromToString::testFormatFromToString()
   }
 }
 
-QTEST_MAIN(videoHandlerYUVFormatFromToString)
+QTEST_MAIN(yuvPixelFormatTest)
 
-#include "videoHandlerYUVFormatFromToString.moc"
+#include "yuvPixelFormatTest.moc"

--- a/YUViewUnitTest/video/yuvPixelFormatTest.pro
+++ b/YUViewUnitTest/video/yuvPixelFormatTest.pro
@@ -4,7 +4,7 @@ CONFIG += qt console warn_on no_testcase_installs depend_includepath testcase
 CONFIG -= debug_and_release
 CONFIG -= app_bundled
 
-TARGET = videoHandlerYUVFormatFromToString
+TARGET = yuvPixelFormatTest
 
 QT += testlib
 QT -= gui
@@ -12,4 +12,4 @@ QT -= gui
 INCLUDEPATH += $$top_srcdir/YUViewLib/src
 LIBS += -L$$top_builddir/YUViewLib -lYUViewLib
 
-SOURCES += videoHandlerYUVFormatFromToString.cpp
+SOURCES += yuvPixelFormatTest.cpp


### PR DESCRIPTION
Work:
 - Added a smart item format memory that remembers if a user manually changes something about the format (width/height/YUV or RGB format) of a file. If a file is opened this memory is checked.
 - Some reformatting / moving code to seperate files
 - Added a test for the yuv/rgb format to/from string functionality (and found some bugs while doing this)