### PR TITLE
Log at least 100 bytes of unknown AVPackets

### DIFF
--- a/YUViewLib/src/ffmpeg/FFMpegLibrariesHandling.h
+++ b/YUViewLib/src/ffmpeg/FFMpegLibrariesHandling.h
@@ -448,7 +448,7 @@ enum class PacketType
   AUDIO,
   SUBTITLE_DVB,
   SUBTITLE_608,
-  SUBTITLE_OTHER
+  OTHER
 };
 
 // A wrapper around the different versions of the AVPacket versions.

--- a/YUViewLib/src/filesource/fileSourceFFmpegFile.cpp
+++ b/YUViewLib/src/filesource/fileSourceFFmpegFile.cpp
@@ -546,7 +546,7 @@ bool fileSourceFFmpegFile::goToNextPacket(bool videoPacketsOnly)
     else if (streamIndices.subtitle.eia608.contains(pkt.get_stream_index()))
       pkt.setPacketType(PacketType::SUBTITLE_608);
     else
-      pkt.setPacketType(PacketType::SUBTITLE_OTHER);
+      pkt.setPacketType(PacketType::OTHER);
   }
   while (ret == 0 && videoPacketsOnly && pkt.getPacketType() != PacketType::VIDEO);
   

--- a/YUViewLib/src/filesource/fileSourceFFmpegFile.cpp
+++ b/YUViewLib/src/filesource/fileSourceFFmpegFile.cpp
@@ -545,6 +545,8 @@ bool fileSourceFFmpegFile::goToNextPacket(bool videoPacketsOnly)
       pkt.setPacketType(PacketType::SUBTITLE_DVB);
     else if (streamIndices.subtitle.eia608.contains(pkt.get_stream_index()))
       pkt.setPacketType(PacketType::SUBTITLE_608);
+    else
+      pkt.setPacketType(PacketType::SUBTITLE_OTHER);
   }
   while (ret == 0 && videoPacketsOnly && pkt.getPacketType() != PacketType::VIDEO);
   

--- a/YUViewLib/src/parser/parserAVFormat.cpp
+++ b/YUViewLib/src/parser/parserAVFormat.cpp
@@ -498,6 +498,15 @@ bool parserAVFormat::parseAVPacket(unsigned int packetID, AVPacketWrapper &packe
   }
   else
   {
+    TreeItem *rawDataRoot = new TreeItem("Data", itemTree);
+    const auto nrBytesToLog = std::min(avpacketData.length(), 100);
+    for (int i = 0; i < nrBytesToLog; i++)
+    {
+      int val = (unsigned char)avpacketData.at(i);
+      QString code = QString("%1 (0x%2)").arg(val, 8, 2, QChar('0')).arg(val, 2, 16, QChar('0'));
+      new TreeItem(QString("Byte %1").arg(i), val, "b(8)", code, rawDataRoot);
+    }
+
     BitrateItemModel::bitrateEntry entry;
     entry.pts = packet.get_pts();
     entry.dts = packet.get_dts();


### PR DESCRIPTION
For AVPackets of unknown streams just log max of 100 bytes from the packet.