### PR TITLE
Handle Qt version 5.15.0

### DIFF
--- a/YUViewLib/src/statistics/statisticHandler.cpp
+++ b/YUViewLib/src/statistics/statisticHandler.cpp
@@ -34,6 +34,10 @@
 
 #include <cmath>
 #include <QPainter>
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    #include <QPainterPath>
+#endif
 #include <QtMath>
 
 #include "common/functions.h"

--- a/YUViewLib/src/ui/views/splitViewWidget.cpp
+++ b/YUViewLib/src/ui/views/splitViewWidget.cpp
@@ -37,6 +37,10 @@
 #include <QDockWidget>
 #include <QInputDialog>
 #include <QMessageBox>
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    #include <QPainterPath>
+#endif
 #include <QPainter>
 #include <QSettings>
 #include <QTextDocument>


### PR DESCRIPTION
To compile under Qt version 5.15.0, `#include <QPainterPath>` needs to be added in two source files. 
As I'm not sure if this conflicts with older Qt version (I only have Ubuntu 18.04's 5.9.5 here and it won't compile under that version), I've added a Qt version check around the import. 

Not sure what your plans are for supporting different Qt versions but as most people may go ahead and download the newest one, it might be nice to support that.