### PR TITLE
Handle Qt version < 5.10

### DIFF
--- a/YUViewLib/src/filesource/fileSource.cpp
+++ b/YUViewLib/src/filesource/fileSource.cpp
@@ -36,6 +36,7 @@
 #include <QDir>
 #include <QRegExp>
 #include <QSettings>
+#include <QtGlobal>
 #ifdef Q_OS_WIN
 #include <windows.h>
 #endif
@@ -126,7 +127,11 @@ QList<infoItem> fileSource::getFileInfoList() const
   infoList.append(infoItem("File Path", fileInfo.absoluteFilePath()));
 
   // The file creation time
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+  QString createdtime = fileInfo.created().toString("yyyy-MM-dd hh:mm:ss");
+#else
   QString createdtime = fileInfo.birthTime().toString("yyyy-MM-dd hh:mm:ss");
+#endif
   infoList.append(infoItem("Time Created", createdtime));
 
   // The last modification time

--- a/YUViewLib/src/parser/common/ReaderHelper.cpp
+++ b/YUViewLib/src/parser/common/ReaderHelper.cpp
@@ -31,6 +31,7 @@
 */
 
 #include "ReaderHelper.h"
+#include <cassert>
 
 ReaderHelper::ReaderHelper(SubByteReader &reader, TreeItem *item, QString new_sub_item_name)
 {

--- a/YUViewLib/src/parser/common/SubByteReader.cpp
+++ b/YUViewLib/src/parser/common/SubByteReader.cpp
@@ -33,6 +33,7 @@
 #include "SubByteReader.h"
 
 #include <stdexcept>
+#include <cassert>
 
 unsigned int SubByteReader::readBits(int nrBits, QString &bitsRead)
 {

--- a/YUViewLib/src/video/videoHandlerRGB.cpp
+++ b/YUViewLib/src/video/videoHandlerRGB.cpp
@@ -33,7 +33,7 @@
 #include "videoHandlerRGB.h"
 
 #include <QPainter>
-
+#include <QtGlobal>
 #include "common/functions.h"
 #include "common/fileInfo.h"
 #include "videoHandlerRGBCustomFormatDialog.h"
@@ -476,7 +476,11 @@ void videoHandlerRGB::convertRGBToImage(const QByteArray &sourceBuffer, QImage &
   }
 
   // Check the image buffer size before we write to it
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+  assert(outputImage.byteCount() >= curFrameSize.width() * curFrameSize.height() * 4);
+#else
   assert(outputImage.sizeInBytes() >= curFrameSize.width() * curFrameSize.height() * 4);
+#endif
 
   convertSourceToRGBA32Bit(sourceBuffer, outputImage.bits());
 

--- a/YUViewLib/src/video/videoHandlerYUV.cpp
+++ b/YUViewLib/src/video/videoHandlerYUV.cpp
@@ -2467,7 +2467,11 @@ void videoHandlerYUV::convertYUVToImage(const QByteArray &sourceBuffer, QImage &
   }
 
   // Check the image buffer size before we write to it
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+  assert(outputImage.byteCount() >= curFrameSize.width() * curFrameSize.height() * 4);
+#else
   assert(outputImage.sizeInBytes() >= curFrameSize.width() * curFrameSize.height() * 4);
+#endif
   
   // Convert the source to RGB
   bool convOK = true;


### PR DESCRIPTION
Replace `QFileInfo.birthTime()` by `created()` and `QImage.sizeInBytes()` by `byteCount()` and add `#include <cassert>` where necessary to (re-)enable building under Qt 5.9.5 that is shipped with Ubuntu 18.04 LTS. 

Changes are wrapped in version checks so that they can be easily removed once support for legacy Qt is dropped.

Works for both 5.9.5 as well as 5.15 and as both new functions were introduced in 5.10, version checks are only necessary for below/above 5.10.

Related to issue https://github.com/IENT/YUView/issues/258