### PR TITLE
Add VUYA support

### DIFF
--- a/YUViewLib/src/video/videoHandlerYUV.cpp
+++ b/YUViewLib/src/video/videoHandlerYUV.cpp
@@ -2231,9 +2231,9 @@ bool videoHandlerYUV::convertYUVPackedToPlanar(const QByteArray &sourceBuffer, Q
   else if (format.subsampling == Subsampling::YUV_444)
   {
     // What are the offsets withing the 3 or 4 bytes per sample?
-    const int oY = (packing == PackingOrder::AYUV) ? 1 : 0;
-    const int oU = (packing == PackingOrder::YUV || packing == PackingOrder::YUVA) ? 1 : 2;
-    const int oV = (packing == PackingOrder::YVU) ? 1 : (packing == PackingOrder::AYUV) ? 3 : 2;
+    const int oY = (packing == PackingOrder::AYUV) ? 1 : (packing == PackingOrder::VUYA) ? 2 : 0;
+    const int oU = (packing == PackingOrder::YUV || packing == PackingOrder::YUVA || packing == PackingOrder::VUYA) ? 1 : 2;
+    const int oV = (packing == PackingOrder::YVU) ? 1 : (packing == PackingOrder::AYUV) ? 3 : (packing == PackingOrder::VUYA) ? 0 : 2;
 
     // How many samples to the next sample?
     const int offsetNext = (packing == PackingOrder::YUV || packing == PackingOrder::YVU ? 3 : 4);
@@ -2587,9 +2587,9 @@ videoHandlerYUV::yuv_t videoHandlerYUV::getPixelValue(const QPoint &pixelPos) co
     {
       // The samples are packed in 4:4:4.
       // What are the offsets withing the 3 or 4 bytes per sample?
-      const int oY = (packing == PackingOrder::AYUV) ? 1 : 0;
-      const int oU = (packing == PackingOrder::YUV || packing == PackingOrder::YUVA) ? 1 : 2;
-      const int oV = (packing == PackingOrder::YVU) ? 1 : (packing == PackingOrder::AYUV) ? 3 : 2;
+      const int oY = (packing == PackingOrder::AYUV) ? 1 : (packing == PackingOrder::VUYA) ? 2 : 0;
+      const int oU = (packing == PackingOrder::YUV || packing == PackingOrder::YUVA || packing == PackingOrder::VUYA) ? 1 : 2;
+      const int oV = (packing == PackingOrder::YVU) ? 1 : (packing == PackingOrder::AYUV) ? 3 : (packing == PackingOrder::VUYA) ? 0 : 2;
 
       // How many bytes to the next sample?
       const int offsetNext = (packing == PackingOrder::YUV || packing == PackingOrder::YVU ? 3 : 4) * (format.bitsPerSample > 8 ? 2 : 1);

--- a/YUViewLib/src/video/yuvPixelFormat.cpp
+++ b/YUViewLib/src/video/yuvPixelFormat.cpp
@@ -79,7 +79,7 @@ QList<PackingOrder> getSupportedPackingFormats(Subsampling subsampling)
   if (subsampling == Subsampling::YUV_422)
     return QList<PackingOrder>() << PackingOrder::UYVY << PackingOrder::VYUY << PackingOrder::YUYV << PackingOrder::YVYU;
   if (subsampling == Subsampling::YUV_444)
-    return QList<PackingOrder>() << PackingOrder::YUV << PackingOrder::YVU << PackingOrder::AYUV << PackingOrder::YUVA;
+    return QList<PackingOrder>() << PackingOrder::YUV << PackingOrder::YVU << PackingOrder::AYUV << PackingOrder::YUVA << PackingOrder::VUYA;
 
   return QList<PackingOrder>();
 }
@@ -224,7 +224,7 @@ bool yuvPixelFormat::isValid() const
   if (!planar)
   {
     // Check the packing mode
-    if ((packingOrder == PackingOrder::YUV || packingOrder == PackingOrder::YVU || packingOrder == PackingOrder::AYUV || packingOrder == PackingOrder::YUVA) && subsampling != Subsampling::YUV_444)
+    if ((packingOrder == PackingOrder::YUV || packingOrder == PackingOrder::YVU || packingOrder == PackingOrder::AYUV || packingOrder == PackingOrder::YUVA || packingOrder == PackingOrder::VUYA) && subsampling != Subsampling::YUV_444)
       return false;
     if ((packingOrder == PackingOrder::UYVY || packingOrder == PackingOrder::VYUY || packingOrder == PackingOrder::YUYV || packingOrder == PackingOrder::YVYU) && subsampling != Subsampling::YUV_422)
       return false;
@@ -368,7 +368,7 @@ int64_t yuvPixelFormat::bytesPerFrame(const QSize &frameSize) const
     if (planar && (planeOrder == PlaneOrder::YUVA || planeOrder == PlaneOrder::YVUA))
       // There is an additional alpha plane. The alpha plane is not subsampled
       bytes += frameSize.width() * frameSize.height() * bytesPerSample; // Alpha plane
-    if (!planar && subsampling == Subsampling::YUV_444 && (packingOrder == PackingOrder::AYUV || packingOrder == PackingOrder::YUVA))
+    if (!planar && subsampling == Subsampling::YUV_444 && (packingOrder == PackingOrder::AYUV || packingOrder == PackingOrder::YUVA || packingOrder == PackingOrder::VUYA))
       // There is an additional alpha plane. The alpha plane is not subsampled
       bytes += frameSize.width() * frameSize.height() * bytesPerSample; // Alpha plane
   }
@@ -385,7 +385,7 @@ int64_t yuvPixelFormat::bytesPerFrame(const QSize &frameSize) const
     if (subsampling == Subsampling::YUV_444)
     {
       int bitsPerPixel = bitsPerSample * 3;
-      if (packingOrder == PackingOrder::AYUV || packingOrder == PackingOrder::YUVA)
+      if (packingOrder == PackingOrder::AYUV || packingOrder == PackingOrder::YUVA || packingOrder == PackingOrder::VUYA)
         bitsPerPixel += bitsPerSample;
       return ((bitsPerPixel + 7) / 8) * frameSize.width() * frameSize.height();
     }

--- a/YUViewLib/src/video/yuvPixelFormat.h
+++ b/YUViewLib/src/video/yuvPixelFormat.h
@@ -88,6 +88,7 @@ enum class PackingOrder
   YVU,      // 444
   AYUV,     // 444
   YUVA,     // 444
+  VUYA,     // 444
   UYVY,     // 422
   VYUY,     // 422
   YUYV,     // 422
@@ -98,8 +99,8 @@ enum class PackingOrder
   //VYYUYY    // 420
   UNKNOWN
 };
-const auto packingOrderList = QList<PackingOrder>() << PackingOrder::YUV << PackingOrder::YVU << PackingOrder::AYUV << PackingOrder::YUVA << PackingOrder::UYVY << PackingOrder::VYUY << PackingOrder::YUYV << PackingOrder::YVYU;
-const auto packingOrderNameList = QStringList() << "YUV" << "YVU" << "AYUV" << "YUVA" << "UYVY" << "VYUY" << "YUYV" << "YVYU";
+const auto packingOrderList = QList<PackingOrder>() << PackingOrder::YUV << PackingOrder::YVU << PackingOrder::AYUV << PackingOrder::YUVA << PackingOrder::VUYA << PackingOrder::UYVY << PackingOrder::VYUY << PackingOrder::YUYV << PackingOrder::YVYU;
+const auto packingOrderNameList = QStringList() << "YUV" << "YVU" << "AYUV" << "YUVA" << "VUYA" << "UYVY" << "VYUY" << "YUYV" << "YVYU";
 QString getPackingFormatString(PackingOrder packing);
 
 enum class Subsampling


### PR DESCRIPTION
VUYA is the packed byte order for microsoft AYUV

https://docs.microsoft.com/en-us/windows/win32/medfound/recommended-8-bit-yuv-formats-for-video-rendering#ayuv
