### PR TITLE
Disable parsing limit by default.

### DIFF
--- a/YUViewLib/src/parser/parserBase.h
+++ b/YUViewLib/src/parser/parserBase.h
@@ -97,5 +97,5 @@ protected:
   // If this variable is set (from an external thread), the parsing process should cancel immediately
   bool cancelBackgroundParser {false};
   int  progressPercentValue   {0};
-  bool parsingLimitEnabled    {true};
+  bool parsingLimitEnabled    {false};
 };


### PR DESCRIPTION
Bugfix for parsing of longer raw AnnexB files. The parsing limit was enabled by accident and only the first 500 frames were shown.