### PR TITLE
Fix to make qmake generate a plist.info file

### DIFF
--- a/YUViewApp/YUViewApp.pro
+++ b/YUViewApp/YUViewApp.pro
@@ -53,10 +53,7 @@ contains(QT_ARCH, x86_32|i386) {
 }
 
 macx {
-    QMAKE_MAC_SDK = macosx
-
     ICON = images/YUView.icns
-    QMAKE_INFO_PLIST = Info.plist
     SVNN = $$system("git describe --tags")
 }
 

--- a/YUViewLib/YUViewLib.pro
+++ b/YUViewLib/YUViewLib.pro
@@ -29,10 +29,6 @@ isEmpty(SVNN) {
     SVNN = 0
 }
 
-macx {
-    QMAKE_MAC_SDK = macosx
-    QMAKE_INFO_PLIST = Info.plist
-}
 win32-g++ {
     QMAKE_FLAGS_RELEASE += -O3 -Ofast -msse4.1 -mssse3 -msse3 -msse2 -msse -mfpmath=sse
     QMAKE_CXXFLAGS_RELEASE += -O3 -Ofast -msse4.1 -mssse3 -msse3 -msse2 -msse -mfpmath=sse


### PR DESCRIPTION
This fixes the issue that graphics looked bad on older MacOS versions. 
Issue: https://github.com/IENT/YUView/issues/194