### PR TITLE
Fix for null pointer SPS

### DIFF
--- a/YUViewLib/src/parser/parserAnnexBAVC.cpp
+++ b/YUViewLib/src/parser/parserAnnexBAVC.cpp
@@ -430,8 +430,8 @@ parserAnnexB::ParseResult parserAnnexBAVC::parseAndAddNALUnit(int nalID, QByteAr
       entry.keyframe = this->currentAUAllSlicesIntra;
       entry.frameType = parserBase::convertSliceTypeMapToString(this->currentAUSliceTypes);
       parseResult.bitrateEntry = entry;
-
-      this->hrd.addAU(this->sizeCurrentAU * 8, curFramePOC, this->active_SPS_list[0], this->lastBufferingPeriodSEI, this->lastPicTimingSEI, this->getHRDPlotModel());
+      if (this->active_SPS_list.size() > 0)
+        this->hrd.addAU(this->sizeCurrentAU * 8, curFramePOC, this->active_SPS_list[0], this->lastBufferingPeriodSEI, this->lastPicTimingSEI, this->getHRDPlotModel());
     }
     this->sizeCurrentAU = 0;
     this->counterAU++;


### PR DESCRIPTION
This small fix helps for parsing captured dirty transport streams which might contain NALUs with AUs before an SPS is found.  The access of the null pointer `this->active_SPS_list[0]` causes a segfault or other nasty stuff. The fix results in successful parsing for such type of streams:
<img width="1066" alt="Bildschirmfoto 2020-12-04 um 13 16 59" src="https://user-images.githubusercontent.com/11407722/101164762-d59dfe80-3635-11eb-94ad-e2a3db2422ba.png">

