### PR TITLE
Fix for cpb size limit on HRD plot

### DIFF
--- a/YUViewLib/src/parser/common/HRDPlotModel.cpp
+++ b/YUViewLib/src/parser/common/HRDPlotModel.cpp
@@ -196,6 +196,9 @@ void HRDPlotModel::setCPBBufferSize(int size)
   {
     QMutexLocker locker(&this->dataMutex);
     this->cpb_buffer_size = size;
+    // this should be our initial guess for the yMax range
+    if (size>0)
+        this->bufferLevelLimits.max = size;
     this->eventSubsampler.postEvent();
   }
 }


### PR DESCRIPTION
Another tiny fix. If you have a large cpb size, the upper limit is not visible :) 