### PR TITLE
CI: don't re-upload the flatpak bundle

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -30,11 +30,6 @@ jobs:
       with:
         bundle: "YUView.flatpak"
         manifest-path: "de.rwth_aachen.ient.YUView.yaml"
-    - name: Upload artifacts to GitHub
-      uses: actions/upload-artifact@v2
-      with:
-        name: YUView.flatpak
-        path: YUView.flatpak        
     - name: Upload Release
       uses: actions/upload-release-asset@v1.0.1
       env:


### PR DESCRIPTION
it's already done by the action if the build succeeds