### PR TITLE
Fix for YRange of PlotModel always refering to first stream

### DIFF
--- a/YUViewLib/src/parser/common/BitratePlotModel.cpp
+++ b/YUViewLib/src/parser/common/BitratePlotModel.cpp
@@ -189,6 +189,10 @@ void BitratePlotModel::addBitratePoint(int streamIndex, BitrateEntry &entry)
   rangeBitratePerStream[streamIndex].min = qMin(rangeBitratePerStream[streamIndex].min, int(entry.bitrate));
   rangeBitratePerStream[streamIndex].max = qMax(rangeBitratePerStream[streamIndex].max, int(entry.bitrate));
 
+  // Store absolute minimum and maximum over all streams
+  yMaxStreamRange.min = qMin(yMaxStreamRange.min, double(rangeBitratePerStream[streamIndex].min));
+  yMaxStreamRange.max = qMax(yMaxStreamRange.max, double(rangeBitratePerStream[streamIndex].max));
+
   DEBUG_PLOT("BitrateItemModel::addBitratePoint streamIndex " << streamIndex << " pts " << entry.pts << " dts " << entry.dts << " rate " << entry.bitrate << " keyframe " << entry.keyframe);
 
   // Keep the list sorted

--- a/YUViewLib/src/parser/common/BitratePlotModel.h
+++ b/YUViewLib/src/parser/common/BitratePlotModel.h
@@ -51,7 +51,7 @@ public:
   QString getPointInfo(unsigned streamIndex, unsigned plotIndex, unsigned pointIndex) const override;
   std::optional<unsigned> getReasonabelRangeToShowOnXAxisPer100Pixels() const override;
   QString formatValue(Axis axis, double value) const override;
-  
+  Range<double> getYRange() const override {return yMaxStreamRange;}
   QString getItemInfoText(int index);
 
   struct BitrateEntry
@@ -84,4 +84,5 @@ private:
   Range<int> rangeDts;
   Range<int> rangePts;
   QMap<unsigned int, Range<int>> rangeBitratePerStream;
+  Range<double> yMaxStreamRange;
 };

--- a/YUViewLib/src/parser/common/HRDPlotModel.h
+++ b/YUViewLib/src/parser/common/HRDPlotModel.h
@@ -51,7 +51,7 @@ public:
   QString getPointInfo(unsigned streamIndex, unsigned plotIndex, unsigned pointIndex) const override;
   std::optional<unsigned> getReasonabelRangeToShowOnXAxisPer100Pixels() const override { return 1; }
   QString formatValue(Axis axis, double value) const override;
-  
+  Range<double> getYRange() const override {return getStreamParameter(0).yRange;}
   QString getItemInfoText(int index);
 
   struct HRDEntry

--- a/YUViewLib/src/ui/views/dummyPlotModel.h
+++ b/YUViewLib/src/ui/views/dummyPlotModel.h
@@ -106,6 +106,8 @@ public:
                    ).arg(streamIndex).arg(point.x).arg(point.y).arg("Inter");
   }
 
+  Range<double> getYRange() const override {getStreamParameter(0).yRange;}
+
 private:
   QList<int> barData;
   QList<Point> graphData;

--- a/YUViewLib/src/ui/views/plotModel.h
+++ b/YUViewLib/src/ui/views/plotModel.h
@@ -99,7 +99,7 @@ public:
   virtual QString getPointInfo(unsigned streamIndex, unsigned plotIndex, unsigned pointIndex) const = 0;
   virtual std::optional<unsigned> getReasonabelRangeToShowOnXAxisPer100Pixels() const = 0;
   virtual QString formatValue(Axis axis, double value) const = 0;
-
+  virtual Range<double> getYRange() const = 0;
   std::optional<unsigned> getPointIndex(unsigned streamIndex, unsigned plotIndex, QPointF point) const;
 
 protected:

--- a/YUViewLib/src/ui/views/plotViewWidget.cpp
+++ b/YUViewLib/src/ui/views/plotViewWidget.cpp
@@ -913,7 +913,7 @@ QPointF PlotViewWidget::convertPlotPosToPixelPos(const QPointF &plotPos, std::op
 
   Range<double> yRange = {0, 100};
   if (this->model)
-    yRange = this->model->getStreamParameter(0).yRange;
+    yRange = this->model->getYRange();
   const auto rangeY = double(yRange.max - yRange.min);
   
   const auto pixelPosX = this->propertiesAxis[0].line.p1().x() + (plotPos.x() * this->zoomToPixelsPerValueX) * (*zoomFactor) + this->moveOffset.x();
@@ -942,7 +942,7 @@ QPointF PlotViewWidget::convertPixelPosToPlotPos(const QPointF &pixelPos, std::o
 
   Range<double> yRange = {0, 100};
   if (this->model)
-    yRange = this->model->getStreamParameter(0).yRange;
+    yRange = this->model->getYRange();
   const auto rangeY = double(yRange.max - yRange.min);
   
   const auto valueX = ((pixelPos.x() - this->propertiesAxis[0].line.p1().x() - this->moveOffset.x()) / (*zoomFactor)) / this->zoomToPixelsPerValueX;


### PR DESCRIPTION
The yRange of the PlotViewWidget is always set to the yRange of the first stream, assuming it is the video stream. This does not have to be the case. We have some TS where the first stream with index 0 is the audio stream. I propose to record the absolute maximum yRange over all streams and return this value instead.