### PR TITLE
Fixed autosaving of playlist not working on linux

### DIFF
--- a/YUViewLib/src/common/EnumMapper.h
+++ b/YUViewLib/src/common/EnumMapper.h
@@ -36,6 +36,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 /* This class implement mapping of "enum class" values to and from names (string).
  */

--- a/YUViewLib/src/playlistitem/playlistItemCompressedVideo.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemCompressedVideo.cpp
@@ -395,7 +395,8 @@ playlistItemCompressedVideo::newPlaylistItemCompressedVideo(const YUViewDomEleme
                                                             const QString &playlistFilePath)
 {
   // Parse the DOM element. It should have all values of a playlistItemRawCodedVideo
-  auto absolutePath  = root.findChildValue("absolutePath");
+  QUrl absoluteUrl = root.findChildValue("absolutePath");
+  auto absolutePath = absoluteUrl.toLocalFile();
   auto relativePath  = root.findChildValue("relativePath");
   int  displaySignal = root.findChildValue("displayComponent").toInt();
 

--- a/YUViewLib/src/playlistitem/playlistItemCompressedVideo.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemCompressedVideo.cpp
@@ -360,19 +360,14 @@ void playlistItemCompressedVideo::savePlaylist(QDomElement &root, const QDir &pl
 {
   auto filename = this->properties().name;
 
-  // Determine the relative path to the HEVC file. We save both in the playlist.
-  QUrl fileURL(filename);
-  fileURL.setScheme("file");
-  QString relativePath = playlistDir.relativeFilePath(filename);
-
   YUViewDomElement d = root.ownerDocument().createElement("playlistItemCompressedVideo");
 
   // Append the properties of the playlistItem
   playlistItem::appendPropertiesToPlaylist(d);
 
   // Append all the properties of the HEVC file (the path to the file. Relative and absolute)
-  d.appendProperiteChild("absolutePath", fileURL.toString());
-  d.appendProperiteChild("relativePath", relativePath);
+  d.appendProperiteChild("absolutePath", playlistDir.absoluteFilePath(filename));
+  d.appendProperiteChild("relativePath", playlistDir.relativeFilePath(filename));
   d.appendProperiteChild("displayComponent",
                          QString::number(loadingDecoder ? loadingDecoder->getDecodeSignal() : -1));
 
@@ -395,8 +390,7 @@ playlistItemCompressedVideo::newPlaylistItemCompressedVideo(const YUViewDomEleme
                                                             const QString &playlistFilePath)
 {
   // Parse the DOM element. It should have all values of a playlistItemRawCodedVideo
-  QUrl absoluteUrl = root.findChildValue("absolutePath");
-  auto absolutePath = absoluteUrl.toLocalFile();
+  auto absolutePath  = root.findChildValue("absolutePath");
   auto relativePath  = root.findChildValue("relativePath");
   int  displaySignal = root.findChildValue("displayComponent").toInt();
 

--- a/YUViewLib/src/playlistitem/playlistItemImageFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemImageFile.cpp
@@ -109,7 +109,8 @@ playlistItemImageFile::newplaylistItemImageFile(const YUViewDomElement &root,
                                                 const QString &         playlistFilePath)
 {
   // Parse the DOM element. It should have all values of a playlistItemImageFile
-  QString absolutePath = root.findChildValue("absolutePath");
+  QUrl absoluteUrl = root.findChildValue("absolutePath");
+  auto absolutePath = absoluteUrl.toLocalFile();
   QString relativePath = root.findChildValue("relativePath");
 
   // check if file with absolute path exists, otherwise check relative path

--- a/YUViewLib/src/playlistitem/playlistItemImageFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemImageFile.cpp
@@ -35,7 +35,6 @@
 #include <QImageReader>
 #include <QPainter>
 #include <QSettings>
-#include <QUrl>
 
 #include "common/functionsGui.h"
 #include "filesource/FileSource.h"
@@ -85,19 +84,14 @@ void playlistItemImageFile::savePlaylist(QDomElement &root, const QDir &playlist
 {
   const auto filename = this->properties().name;
 
-  // Determine the relative path to the raw file. We save both in the playlist.
-  QUrl fileURL(filename);
-  fileURL.setScheme("file");
-  QString relativePath = playlistDir.relativeFilePath(filename);
-
   YUViewDomElement d = root.ownerDocument().createElement("playlistItemImageFile");
 
   // Append the properties of the playlistItem
   playlistItem::appendPropertiesToPlaylist(d);
 
   // Append all the properties of the raw file (the path to the file. Relative and absolute)
-  d.appendProperiteChild("absolutePath", fileURL.toString());
-  d.appendProperiteChild("relativePath", relativePath);
+  d.appendProperiteChild("absolutePath", playlistDir.absoluteFilePath(filename));
+  d.appendProperiteChild("relativePath", playlistDir.relativeFilePath(filename));
 
   root.appendChild(d);
 }
@@ -109,12 +103,11 @@ playlistItemImageFile::newplaylistItemImageFile(const YUViewDomElement &root,
                                                 const QString &         playlistFilePath)
 {
   // Parse the DOM element. It should have all values of a playlistItemImageFile
-  QUrl absoluteUrl = root.findChildValue("absolutePath");
-  auto absolutePath = absoluteUrl.toLocalFile();
-  QString relativePath = root.findChildValue("relativePath");
+  auto absolutePath = root.findChildValue("absolutePath");
+  auto relativePath = root.findChildValue("relativePath");
 
   // check if file with absolute path exists, otherwise check relative path
-  QString filePath =
+  auto filePath =
       FileSource::getAbsPathFromAbsAndRel(playlistFilePath, absolutePath, relativePath);
   if (filePath.isEmpty())
     return nullptr;

--- a/YUViewLib/src/playlistitem/playlistItemImageFileSequence.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemImageFileSequence.cpp
@@ -34,7 +34,6 @@
 
 #include <QImageReader>
 #include <QSettings>
-#include <QUrl>
 
 #include "common/functionsGui.h"
 #include "filesource/FileSource.h"
@@ -199,14 +198,9 @@ void playlistItemImageFileSequence::savePlaylist(QDomElement &root, const QDir &
   // Put a list of all input files into the playlist
   for (int i = 0; i < imageFiles.length(); i++)
   {
-    // Determine the relative path to the file. We save both in the playlist.
-    QUrl fileURL(imageFiles[i]);
-    fileURL.setScheme("file");
-    QString relativePath = playlistDir.relativeFilePath(imageFiles[i]);
-
     // Append the relative and absolute path to the file
-    d.appendProperiteChild(QString("file%1_absolutePath").arg(i), fileURL.toString());
-    d.appendProperiteChild(QString("file%1_relativePath").arg(i), relativePath);
+    d.appendProperiteChild(QString("file%1_absolutePath").arg(i), playlistDir.absoluteFilePath(imageFiles[i]));
+    d.appendProperiteChild(QString("file%1_relativePath").arg(i), playlistDir.relativeFilePath(imageFiles[i]));
   }
 
   root.appendChild(d);

--- a/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
@@ -469,7 +469,8 @@ playlistItemRawFile *playlistItemRawFile::newplaylistItemRawFile(const YUViewDom
                                                                  const QString &playlistFilePath)
 {
   // Parse the DOM element. It should have all values of a playlistItemRawFile
-  auto absolutePath = root.findChildValue("absolutePath");
+  QUrl absoluteUrl = root.findChildValue("absolutePath");
+  auto absolutePath = absoluteUrl.toLocalFile();
   auto relativePath = root.findChildValue("relativePath");
   auto type         = root.findChildValue("type");
 

--- a/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
@@ -33,7 +33,6 @@
 #include "playlistItemRawFile.h"
 
 #include <QPainter>
-#include <QUrl>
 #include <QVBoxLayout>
 
 #include "common/functions.h"
@@ -443,10 +442,7 @@ void playlistItemRawFile::createPropertiesWidget()
 
 void playlistItemRawFile::savePlaylist(QDomElement &root, const QDir &playlistDir) const
 {
-  // Determine the relative path to the raw file. We save both in the playlist.
-  QUrl fileURL(dataSource.getAbsoluteFilePath());
-  fileURL.setScheme("file");
-  auto relativePath = playlistDir.relativeFilePath(dataSource.getAbsoluteFilePath());
+  auto filename = dataSource.getAbsoluteFilePath();
 
   auto d = YUViewDomElement(root.ownerDocument().createElement("playlistItemRawFile"));
 
@@ -454,8 +450,8 @@ void playlistItemRawFile::savePlaylist(QDomElement &root, const QDir &playlistDi
   playlistItem::appendPropertiesToPlaylist(d);
 
   // Append all the properties of the raw file (the path to the file. Relative and absolute)
-  d.appendProperiteChild("absolutePath", fileURL.toString());
-  d.appendProperiteChild("relativePath", relativePath);
+  d.appendProperiteChild("absolutePath", playlistDir.absoluteFilePath(filename));
+  d.appendProperiteChild("relativePath", playlistDir.relativeFilePath(filename));
   d.appendProperiteChild(std::string("type"), (rawFormat == raw_YUV) ? "YUV" : "RGB");
 
   this->video->savePlaylist(d);
@@ -469,8 +465,7 @@ playlistItemRawFile *playlistItemRawFile::newplaylistItemRawFile(const YUViewDom
                                                                  const QString &playlistFilePath)
 {
   // Parse the DOM element. It should have all values of a playlistItemRawFile
-  QUrl absoluteUrl = root.findChildValue("absolutePath");
-  auto absolutePath = absoluteUrl.toLocalFile();
+  auto absolutePath = root.findChildValue("absolutePath");
   auto relativePath = root.findChildValue("relativePath");
   auto type         = root.findChildValue("type");
 
@@ -481,7 +476,7 @@ playlistItemRawFile *playlistItemRawFile::newplaylistItemRawFile(const YUViewDom
 
   // We can still not be sure that the file really exists, but we gave our best to try to find it.
   auto newFile = new playlistItemRawFile(filePath, {}, {}, type);
-  
+
   newFile->video->loadPlaylist(root);
   playlistItem::loadPropertiesFromPlaylist(root, newFile);
 

--- a/YUViewLib/src/playlistitem/playlistItemStatisticsFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemStatisticsFile.cpp
@@ -34,7 +34,6 @@
 
 #include <QDebug>
 #include <QTime>
-#include <QUrl>
 #include <QtConcurrent>
 #include <cassert>
 #include <iostream>
@@ -104,9 +103,8 @@ playlistItemStatisticsFile *playlistItemStatisticsFile::newplaylistItemStatistic
     const YUViewDomElement &root, const QString &playlistFilePath, OpenMode openMode)
 {
   // Parse the DOM element. It should have all values of a playlistItemStatisticsFile
-  QUrl absoluteUrl = root.findChildValue("absolutePath");
-  auto absolutePath = absoluteUrl.toLocalFile();
-  auto relativePath = root.findChildValue("relativePath");
+  auto absolutePath  = root.findChildValue("absolutePath");
+  auto relativePath  = root.findChildValue("relativePath");
 
   // check if file with absolute path exists, otherwise check relative path
   auto filePath = FileSource::getAbsPathFromAbsAndRel(playlistFilePath, absolutePath, relativePath);
@@ -153,11 +151,7 @@ void playlistItemStatisticsFile::drawItem(QPainter *painter, int frameIdx, doubl
 
 void playlistItemStatisticsFile::savePlaylist(QDomElement &root, const QDir &playlistDir) const
 {
-  // Determine the relative path to the YUV file-> We save both in the playlist.
-  auto absolutePath = QFileInfo(this->prop.name).absoluteFilePath();
-  QUrl fileURL(absolutePath);
-  fileURL.setScheme("file");
-  auto relativePath = playlistDir.relativeFilePath(absolutePath);
+  auto filename = this->properties().name;
 
   YUViewDomElement d = root.ownerDocument().createElement("playlistItemStatisticsFile");
 
@@ -165,8 +159,8 @@ void playlistItemStatisticsFile::savePlaylist(QDomElement &root, const QDir &pla
   playlistItem::appendPropertiesToPlaylist(d);
 
   // Append all the properties of the YUV file (the path to the file-> Relative and absolute)
-  d.appendProperiteChild("absolutePath", fileURL.toString());
-  d.appendProperiteChild("relativePath", relativePath);
+  d.appendProperiteChild("absolutePath", playlistDir.absoluteFilePath(filename));
+  d.appendProperiteChild("relativePath", playlistDir.relativeFilePath(filename));
 
   // Save the status of the statistics (which are shown, transparency ...)
   this->statisticsData.savePlaylist(d);

--- a/YUViewLib/src/playlistitem/playlistItemStatisticsFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemStatisticsFile.cpp
@@ -104,7 +104,8 @@ playlistItemStatisticsFile *playlistItemStatisticsFile::newplaylistItemStatistic
     const YUViewDomElement &root, const QString &playlistFilePath, OpenMode openMode)
 {
   // Parse the DOM element. It should have all values of a playlistItemStatisticsFile
-  auto absolutePath = root.findChildValue("absolutePath");
+  QUrl absoluteUrl = root.findChildValue("absolutePath");
+  auto absolutePath = absoluteUrl.toLocalFile();
   auto relativePath = root.findChildValue("relativePath");
 
   // check if file with absolute path exists, otherwise check relative path

--- a/YUViewLib/src/ui/widgets/PlaylistTreeWidget.cpp
+++ b/YUViewLib/src/ui/widgets/PlaylistTreeWidget.cpp
@@ -217,10 +217,10 @@ void PlaylistTreeWidget::dropEvent(QDropEvent *event)
   if (event->mimeData()->hasUrls())
   {
     QStringList       fileList;
-    const QList<QUrl> urls = event->mimeData()->urls();
+    const auto urls = event->mimeData()->urls();
     for (auto &url : urls)
     {
-      QString fileName = url.toLocalFile();
+      auto fileName = url.toLocalFile();
       fileList.append(fileName);
     }
     event->acceptProposedAction();
@@ -233,7 +233,7 @@ void PlaylistTreeWidget::dropEvent(QDropEvent *event)
   else
   {
     // get the list of the items that are about to be dragged
-    QList<QTreeWidgetItem *> dragItems = selectedItems();
+    auto dragItems = selectedItems();
 
     // Actually move all the items
     QTreeWidget::dropEvent(event);


### PR DESCRIPTION
I actually never used the autosave feature so far. but now that i'm looking into #353  I realized it doesn't work for me at all in the current version. The reason is that on Linux absolute paths are saved as "file:///xxx" for path "/xxx". QUrl does this. When reading QString was used and no conversion to the latter (required) representation occurred. Fixed by letting QUrl do the conversion. Strangely it only affects the autosave feature. Playlists stored to files worked before. It was still able to find the files using the relative paths. 
Why do we actually need QUrl for storing paths in the first place? I guess YUView can also load web links?
The change needs to be tested again on Windows and Mac, which I can't do. I suspect the bug was also present on Mac before. 