### PR TITLE
Fix hanging of bitstream parsing

### DIFF
--- a/YUViewLib/src/parser/AVC/SEI/buffering_period.cpp
+++ b/YUViewLib/src/parser/AVC/SEI/buffering_period.cpp
@@ -49,14 +49,20 @@ SEIParsingResult buffering_period::parse(reader::SubByteReaderLogging &         
 {
   (void)associatedSPS;
 
-  if (!reparse)
-    this->subLevel = SubByteReaderLoggingSubLevel(reader, "buffering_period()");
+  std::unique_ptr<SubByteReaderLoggingSubLevel> subLevel;
+  if (reparse)
+    reader.stashAndReplaceCurrentTreeItem(this->reparseTreeItem);
+  else
+    subLevel.reset(new SubByteReaderLoggingSubLevel(reader, "buffering_period()"));
 
   if (!reparse)
   {
     this->seq_parameter_set_id = reader.readUEV("seq_parameter_set_id");
     if (spsMap.count(this->seq_parameter_set_id) == 0)
+    {
+      this->reparseTreeItem = reader.getCurrentItemTree();
       return SEIParsingResult::WAIT_FOR_PARAMETER_SETS;
+    }
   }
   else
   {
@@ -93,6 +99,7 @@ SEIParsingResult buffering_period::parse(reader::SubByteReaderLogging &         
     }
   }
 
+  reader.popTreeItem();
   return SEIParsingResult::OK;
 }
 

--- a/YUViewLib/src/parser/AVC/SEI/buffering_period.h
+++ b/YUViewLib/src/parser/AVC/SEI/buffering_period.h
@@ -52,7 +52,8 @@ public:
   vector<unsigned> initial_cpb_removal_delay;
   vector<unsigned> initial_cpb_removal_delay_offset;
 
-  reader::SubByteReaderLoggingSubLevel subLevel;
+private:
+  TreeItem *reparseTreeItem{};
 };
 
 } // namespace parser::avc

--- a/YUViewLib/src/parser/AVC/SEI/pic_timing.cpp
+++ b/YUViewLib/src/parser/AVC/SEI/pic_timing.cpp
@@ -46,9 +46,6 @@ SEIParsingResult pic_timing::parse(SubByteReaderLogging &                  reade
 {
   (void)spsMap;
 
-  if (!reparse)
-    this->subLevel = SubByteReaderLoggingSubLevel(reader, "pic_timing()");
-
   if (!associatedSPS)
   {
     if (reparse)
@@ -56,6 +53,8 @@ SEIParsingResult pic_timing::parse(SubByteReaderLogging &                  reade
     else
       return SEIParsingResult::WAIT_FOR_PARAMETER_SETS;
   }
+
+  auto subLevel = SubByteReaderLoggingSubLevel(reader, "pic_timing()");
 
   // ... is dependent on the content of the sequence parameter set that is active for the primary
   // coded picture associated with the picture timing SEI message.

--- a/YUViewLib/src/parser/AVC/SEI/pic_timing.h
+++ b/YUViewLib/src/parser/AVC/SEI/pic_timing.h
@@ -69,9 +69,6 @@ public:
   bool     minutes_flag[3]{};
   bool     hours_flag[3]{};
   unsigned time_offset[3]{};
-
-private:
-  reader::SubByteReaderLoggingSubLevel subLevel;
 };
 
 } // namespace parser::avc

--- a/YUViewLib/src/parser/HEVC/SEI/active_parameter_sets.h
+++ b/YUViewLib/src/parser/HEVC/SEI/active_parameter_sets.h
@@ -57,7 +57,7 @@ public:
   vector<unsigned> layer_sps_idx;
 
 private:
-  reader::SubByteReaderLoggingSubLevel subLevel;
+  TreeItem *reparseTreeItem{};
 };
 
 } // namespace parser::hevc

--- a/YUViewLib/src/parser/HEVC/SEI/buffering_period.h
+++ b/YUViewLib/src/parser/HEVC/SEI/buffering_period.h
@@ -69,7 +69,7 @@ public:
   bool use_alt_cpb_params_flag{};
 
 private:
-  reader::SubByteReaderLoggingSubLevel subLevel;
+  TreeItem *reparseTreeItem{};
 };
 
 } // namespace parser::hevc

--- a/YUViewLib/src/parser/HEVC/SEI/pic_timing.cpp
+++ b/YUViewLib/src/parser/HEVC/SEI/pic_timing.cpp
@@ -50,9 +50,6 @@ SEIParsingResult pic_timing::parse(SubByteReaderLogging &                  reade
   (void)spsMap;
 
   if (!reparse)
-    this->subLevel = SubByteReaderLoggingSubLevel(reader, "pic_timing()");
-
-  if (!reparse)
   {
     if (!associatedSPS)
       return SEIParsingResult::WAIT_FOR_PARAMETER_SETS;
@@ -68,6 +65,8 @@ SEIParsingResult pic_timing::parse(SubByteReaderLogging &                  reade
   }
   auto vps = vpsMap.at(associatedSPS->sps_video_parameter_set_id);
   auto sps = associatedSPS;
+
+  auto subLevel = SubByteReaderLoggingSubLevel(reader, "pic_timing()");
 
   if (sps->vuiParameters.frame_field_info_present_flag)
   {

--- a/YUViewLib/src/parser/HEVC/SEI/pic_timing.h
+++ b/YUViewLib/src/parser/HEVC/SEI/pic_timing.h
@@ -63,7 +63,7 @@ public:
   vector<unsigned> du_cpb_removal_delay_increment_minus1;
 
 private:
-  reader::SubByteReaderLoggingSubLevel subLevel;
+  TreeItem *reparseTreeItem{};
 };
 
 } // namespace parser::hevc

--- a/YUViewLib/src/parser/common/SubByteReaderLogging.cpp
+++ b/YUViewLib/src/parser/common/SubByteReaderLogging.cpp
@@ -186,8 +186,9 @@ void SubByteReaderLogging::removeLogSubLevel()
   this->currentTreeLevel = this->itemHierarchy.top();
 }
 
-uint64_t
-SubByteReaderLogging::readBits(const std::string &symbolName, size_t numBits, const Options &options)
+uint64_t SubByteReaderLogging::readBits(const std::string &symbolName,
+                                        size_t             numBits,
+                                        const Options &    options)
 {
   try
   {
@@ -322,6 +323,18 @@ void SubByteReaderLogging::logArbitrary(const std::string &symbolName,
   new TreeItem(this->currentTreeLevel, symbolName, value, coding, code, meaning);
 }
 
+void SubByteReaderLogging::stashAndReplaceCurrentTreeItem(TreeItem *newItem)
+{
+  this->stashedTreeItem  = this->currentTreeLevel;
+  this->currentTreeLevel = newItem;
+}
+
+void SubByteReaderLogging::popTreeItem()
+{
+  this->currentTreeLevel = this->stashedTreeItem;
+  this->stashedTreeItem  = nullptr;
+}
+
 void SubByteReaderLogging::logExceptionAndThrowError(const std::exception &ex,
                                                      const std::string &   when)
 {
@@ -332,6 +345,19 @@ void SubByteReaderLogging::logExceptionAndThrowError(const std::exception &ex,
     item->setError();
   }
   throw std::logic_error("Error reading " + when);
+}
+
+SubByteReaderLoggingSubLevel::SubByteReaderLoggingSubLevel(SubByteReaderLogging &reader,
+                                                           std::string           name)
+{
+  reader.addLogSubLevel(name);
+  this->r = &reader;
+}
+
+SubByteReaderLoggingSubLevel::~SubByteReaderLoggingSubLevel()
+{
+  if (this->r != nullptr)
+    this->r->removeLogSubLevel();
 }
 
 } // namespace parser::reader

--- a/YUViewLib/src/parser/common/SubByteReaderLogging.h
+++ b/YUViewLib/src/parser/common/SubByteReaderLogging.h
@@ -36,8 +36,8 @@
 #include <optional>
 #include <stack>
 
-#include "SubByteReaderLoggingOptions.h"
 #include "SubByteReader.h"
+#include "SubByteReaderLoggingOptions.h"
 #include "TreeItem.h"
 #include "common/typedef.h"
 
@@ -54,9 +54,7 @@ class SubByteReaderLogging : public SubByteReader
 {
 public:
   SubByteReaderLogging() = default;
-  SubByteReaderLogging(SubByteReader &reader,
-                       TreeItem *        item,
-                       std::string       new_sub_item_name = "");
+  SubByteReaderLogging(SubByteReader &reader, TreeItem *item, std::string new_sub_item_name = "");
   SubByteReaderLogging(const ByteVector &inArr,
                        TreeItem *        item,
                        std::string       new_sub_item_name = "",
@@ -85,6 +83,9 @@ public:
                     const std::string &code    = {},
                     const std::string &meaning = {});
 
+  void stashAndReplaceCurrentTreeItem(TreeItem *newItem);
+  void popTreeItem();
+
   [[nodiscard]] TreeItem *getCurrentItemTree() { return currentTreeLevel; }
 
 private:
@@ -95,7 +96,8 @@ private:
   void logExceptionAndThrowError [[noreturn]] (const std::exception &ex, const std::string &when);
 
   std::stack<TreeItem *> itemHierarchy;
-  TreeItem *             currentTreeLevel{nullptr};
+  TreeItem *             currentTreeLevel{};
+  TreeItem *             stashedTreeItem{};
 };
 
 // A simple wrapper for SubByteReaderLogging->addLogSubLevel /
@@ -104,19 +106,11 @@ class SubByteReaderLoggingSubLevel
 {
 public:
   SubByteReaderLoggingSubLevel() = default;
-  SubByteReaderLoggingSubLevel(SubByteReaderLogging &reader, std::string name)
-  {
-    reader.addLogSubLevel(name);
-    this->r = &reader;
-  }
-  ~SubByteReaderLoggingSubLevel()
-  {
-    if (this->r != nullptr)
-      this->r->removeLogSubLevel();
-  }
+  SubByteReaderLoggingSubLevel(SubByteReaderLogging &reader, std::string name);
+  ~SubByteReaderLoggingSubLevel();
 
 private:
-  SubByteReaderLogging *r{nullptr};
+  SubByteReaderLogging *r{};
 };
 
 } // namespace parser::reader


### PR DESCRIPTION
Removed saving of SubByteReaderLoggingSubLevel instances. This does not work because the associated reader may have been destroyed before the instance.