### PR TITLE
Fix compilation error with g++ 10

### DIFF
--- a/YUViewLib/src/common/EnumMapper.h
+++ b/YUViewLib/src/common/EnumMapper.h
@@ -36,6 +36,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 /* This class implement mapping of "enum class" values to and from names (string).
  */


### PR DESCRIPTION
Building on linux with g++ 10 fails with the following error:

```
In file included from src/video/YUVPixelFormat.h:35,
                 from src/video/videoHandlerYUV.h:35,
                 from src/video/videoHandlerYUV.cpp:33:
src/common/EnumMapper.h: In member function ‘std::string EnumMapper<T>::getName(T) const’:
src/common/EnumMapper.h:72:16: error: ‘logic_error’ is not a member of ‘std’
   72 |     throw std::logic_error(
      |                ^~~~~~~~~~~
```

Add the missing include for `std::logic_error`.