### PR TITLE
Draft: Qt6 & VVC

### DIFF
--- a/YUViewLib/src/decoder/decoderBase.h
+++ b/YUViewLib/src/decoder/decoderBase.h
@@ -32,6 +32,8 @@
 
 #pragma once
 
+#include <dlfcn.h>
+
 #include <common/EnumMapper.h>
 #include <filesource/FileSourceAnnexBFile.h>
 #include <statistics/StatisticsData.h>
@@ -196,6 +198,8 @@ protected:
 
   QLibrary library;
   QString  libraryPath {};
+
+  void *dynamicLibrary;
 };
 
 } // namespace decoder

--- a/YUViewLib/src/decoder/decoderDav1d.cpp
+++ b/YUViewLib/src/decoder/decoderDav1d.cpp
@@ -48,7 +48,7 @@ using namespace YUView;
 using namespace YUV_Internals;
 
 // Debug the decoder (0:off 1:interactive deocder only 2:caching decoder only 3:both)
-#define DECODERDAV1D_DEBUG_OUTPUT 0
+#define DECODERDAV1D_DEBUG_OUTPUT 3
 #if DECODERDAV1D_DEBUG_OUTPUT && !NDEBUG
 #include <QDebug>
 #if DECODERDAV1D_DEBUG_OUTPUT == 1

--- a/YUViewLib/src/decoder/decoderFFmpeg.cpp
+++ b/YUViewLib/src/decoder/decoderFFmpeg.cpp
@@ -34,7 +34,7 @@
 
 #include "common/functions.h"
 
-#define DECODERFFMPEG_DEBUG_OUTPUT 0
+#define DECODERFFMPEG_DEBUG_OUTPUT 1
 #if DECODERFFMPEG_DEBUG_OUTPUT && !NDEBUG
 #include <QDebug>
 #define DEBUG_FFMPEG(f) qDebug() << f

--- a/YUViewLib/src/decoder/decoderHM.cpp
+++ b/YUViewLib/src/decoder/decoderHM.cpp
@@ -41,7 +41,7 @@
 #include "common/typedef.h"
 
 // Debug the decoder ( 0:off 1:interactive deocder only 2:caching decoder only 3:both)
-#define DECODERHM_DEBUG_OUTPUT 0
+#define DECODERHM_DEBUG_OUTPUT 3
 #if DECODERHM_DEBUG_OUTPUT && !NDEBUG
 #include <QDebug>
 #if DECODERHM_DEBUG_OUTPUT == 1

--- a/YUViewLib/src/decoder/decoderLibde265.cpp
+++ b/YUViewLib/src/decoder/decoderLibde265.cpp
@@ -43,7 +43,7 @@
 using namespace YUView;
 
 // Debug the decoder ( 0:off 1:interactive deocder only 2:caching decoder only 3:both)
-#define DECODERLIBD265_DEBUG_OUTPUT 0
+#define DECODERLIBD265_DEBUG_OUTPUT 3
 #if DECODERLIBD265_DEBUG_OUTPUT && !NDEBUG
 #include <QDebug>
 #if DECODERLIBD265_DEBUG_OUTPUT == 1
@@ -425,7 +425,7 @@ bool decoderLibde265::pushData(QByteArray &data)
     DEBUG_LIBDE265("decoderLibde265::pushData push data %d bytes%s%s",
                    data.size(),
                    err != DE265_OK ? " - err " : "",
-                   err != DE265_OK ? de265_get_error_text(err) : "");
+                   err != DE265_OK ? this->lib.de265_get_error_text(err) : "");
     if (err != DE265_OK)
       return setErrorB("Error pushing data to decoder (de265_push_NAL): " +
                        QString(this->lib.de265_get_error_text(err)));

--- a/YUViewLib/src/decoder/decoderVTM.cpp
+++ b/YUViewLib/src/decoder/decoderVTM.cpp
@@ -41,7 +41,7 @@
 #include "common/typedef.h"
 
 // Debug the decoder ( 0:off 1:interactive deocder only 2:caching decoder only 3:both)
-#define DECODERVTM_DEBUG_OUTPUT 0
+#define DECODERVTM_DEBUG_OUTPUT 3
 #if DECODERVTM_DEBUG_OUTPUT && !NDEBUG
 #include <QDebug>
 #if DECODERVTM_DEBUG_OUTPUT == 1

--- a/YUViewLib/src/ui/settingsDialog.cpp
+++ b/YUViewLib/src/ui/settingsDialog.cpp
@@ -138,18 +138,18 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent)
   ui.lineEditDecoderPath->setText(settings.value("SearchPath", "").toString());
 
   for (const auto &decoder : decoder::DecodersHEVC)
-    ui.comboBoxDefaultHEVC->addItem(
+    ui.comboBoxDefaultDecoder->addItem(
         QString::fromStdString(decoder::DecoderEngineMapper.getName(decoder)));
   for (const auto &decoder : decoder::DecodersVVC)
-    ui.comboBoxDefaultVVC->addItem(
+    ui.comboBoxDefaultDecoder->addItem(
         QString::fromStdString(decoder::DecoderEngineMapper.getName(decoder)));
   for (const auto &decoder : decoder::DecodersAV1)
-    ui.comboBoxDefaultAV1->addItem(
+    ui.comboBoxDefaultDecoder->addItem(
         QString::fromStdString(decoder::DecoderEngineMapper.getName(decoder)));
 
-  ui.comboBoxDefaultHEVC->setCurrentText(settings.value("DefaultDecoderHEVC", 0).toString());
-  ui.comboBoxDefaultVVC->setCurrentText(settings.value("DefaultDecoderVVC", 0).toString());
-  ui.comboBoxDefaultAV1->setCurrentText(settings.value("DefaultDecoderAV1", 0).toString());
+  ui.comboBoxDefaultDecoder->setCurrentText(settings.value("DefaultDecoderHEVC", 0).toString());
+  ui.comboBoxDefaultDecoder->setCurrentText(settings.value("DefaultDecoderVVC", 0).toString());
+  ui.comboBoxDefaultDecoder->setCurrentText(settings.value("DefaultDecoderAV1", 0).toString());
 
   ui.lineEditLibde265File->setText(settings.value("libde265File", "").toString());
   ui.lineEditLibHMFile->setText(settings.value("libHMFile", "").toString());
@@ -468,9 +468,9 @@ void SettingsDialog::on_pushButtonSave_clicked()
   // "Decoders" tab
   settings.beginGroup("Decoders");
   settings.setValue("SearchPath", ui.lineEditDecoderPath->text());
-  settings.setValue("DefaultDecoderHEVC", ui.comboBoxDefaultHEVC->currentText());
-  settings.setValue("DefaultDecoderVVC", ui.comboBoxDefaultVVC->currentText());
-  settings.setValue("DefaultDecoderAV1", ui.comboBoxDefaultAV1->currentText());
+  settings.setValue("DefaultDecoderHEVC", ui.comboBoxDefaultDecoder->currentText());
+  settings.setValue("DefaultDecoderVVC", ui.comboBoxDefaultDecoder->currentText());
+  settings.setValue("DefaultDecoderAV1", ui.comboBoxDefaultDecoder->currentText());
   // Raw coded video files
   settings.setValue("libde265File", ui.lineEditLibde265File->text());
   settings.setValue("libHMFile", ui.lineEditLibHMFile->text());

--- a/YUViewLib/src/video/videoHandlerRGB.cpp
+++ b/YUViewLib/src/video/videoHandlerRGB.cpp
@@ -265,13 +265,13 @@ QLayout *videoHandlerRGB::createVideoHandlerControls(bool isSizeFixed)
   ui.GScaleSpinBox->setMaximum(1000);
   ui.BScaleSpinBox->setValue(componentScale[2]);
   ui.BScaleSpinBox->setMaximum(1000);
-  ui.AScaleSpinBox->setValue(componentScale[3]);
-  ui.AScaleSpinBox->setMaximum(1000);
+  // ui.AScaleSpinBox->setValue(componentScale[3]);
+  // ui.AScaleSpinBox->setMaximum(1000);
 
   ui.RInvertCheckBox->setChecked(this->componentInvert[0]);
   ui.GInvertCheckBox->setChecked(this->componentInvert[1]);
   ui.BInvertCheckBox->setChecked(this->componentInvert[2]);
-  ui.AInvertCheckBox->setChecked(this->componentInvert[3]);
+  // ui.AInvertCheckBox->setChecked(this->componentInvert[3]);
 
   ui.limitedRangeCheckBox->setChecked(this->limitedRange);
 
@@ -283,7 +283,8 @@ QLayout *videoHandlerRGB::createVideoHandlerControls(bool isSizeFixed)
           QOverload<int>::of(&QComboBox::currentIndexChanged),
           this,
           &videoHandlerRGB::slotDisplayOptionsChanged);
-  for (auto spinBox : {ui.RScaleSpinBox, ui.GScaleSpinBox, ui.BScaleSpinBox, ui.AScaleSpinBox})
+  // for (auto spinBox : {ui.RScaleSpinBox, ui.GScaleSpinBox, ui.BScaleSpinBox, ui.AScaleSpinBox})
+  for (auto spinBox : {ui.RScaleSpinBox, ui.GScaleSpinBox, ui.BScaleSpinBox})
     connect(spinBox,
             QOverload<int>::of(&QSpinBox::valueChanged),
             this,
@@ -291,7 +292,7 @@ QLayout *videoHandlerRGB::createVideoHandlerControls(bool isSizeFixed)
   for (auto checkBox : {ui.RInvertCheckBox,
                         ui.GInvertCheckBox,
                         ui.BInvertCheckBox,
-                        ui.AInvertCheckBox,
+                        // ui.AInvertCheckBox,
                         ui.limitedRangeCheckBox})
     connect(checkBox, &QCheckBox::stateChanged, this, &videoHandlerRGB::slotDisplayOptionsChanged);
 
@@ -317,11 +318,11 @@ void videoHandlerRGB::slotDisplayOptionsChanged()
   componentScale[0]  = ui.RScaleSpinBox->value();
   componentScale[1]  = ui.GScaleSpinBox->value();
   componentScale[2]  = ui.BScaleSpinBox->value();
-  componentScale[3]  = ui.AScaleSpinBox->value();
+  // componentScale[3]  = ui.AScaleSpinBox->value();
   componentInvert[0] = ui.RInvertCheckBox->isChecked();
   componentInvert[1] = ui.GInvertCheckBox->isChecked();
   componentInvert[2] = ui.BInvertCheckBox->isChecked();
-  componentInvert[3] = ui.AInvertCheckBox->isChecked();
+  // componentInvert[3] = ui.AInvertCheckBox->isChecked();
   limitedRange       = ui.limitedRangeCheckBox->isChecked();
 
   // Set the current frame in the buffer to be invalid and clear the cache.
@@ -343,11 +344,11 @@ void videoHandlerRGB::updateControlsForNewPixelFormat()
   ui.RScaleSpinBox->setEnabled(valid);
   ui.GScaleSpinBox->setEnabled(valid);
   ui.BScaleSpinBox->setEnabled(valid);
-  ui.AScaleSpinBox->setEnabled(validAndAlpha);
+  // ui.AScaleSpinBox->setEnabled(validAndAlpha);
   ui.RInvertCheckBox->setEnabled(valid);
   ui.GInvertCheckBox->setEnabled(valid);
   ui.BInvertCheckBox->setEnabled(valid);
-  ui.AInvertCheckBox->setEnabled(validAndAlpha);
+  // ui.AInvertCheckBox->setEnabled(validAndAlpha);
 
   QSignalBlocker block(ui.colorComponentsComboBox);
   ui.colorComponentsComboBox->setEnabled(valid);

--- a/YUViewLib/ui/settingsDialog.ui
+++ b/YUViewLib/ui/settingsDialog.ui
@@ -970,7 +970,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QComboBox" name="comboBoxDefaultHEVC">
+           <widget class="QComboBox" name="comboBoxDefaultDecoder">
             <property name="toolTip">
              <string>Default HEVC decoder to use.</string>
             </property>


### PR DESCRIPTION
@ChristianFeldmann please have a look at these changes. At first I wanted to get Qt6 version, then I realized dynamic linking with recent VVdeC was not working. At least on Fedora Linux.

![Snímka obrazovky z 2021-07-25 12-55-44](https://user-images.githubusercontent.com/3098510/126896761-a5c9de02-123a-4e60-bfac-57f70c3ae4a0.png)
