### PR TITLE
Use alpha images also on linux

### DIFF
--- a/YUViewLib/src/common/functionsGui.h
+++ b/YUViewLib/src/common/functionsGui.h
@@ -67,7 +67,7 @@ QString pixelFormatToString(QImage::Format f);
 // The platform-specific screen-compatible image format. Using a QImage of this format
 // is fast when drawing on a widget.
 // This function is thread-safe.
-inline QImage::Format platformImageFormat()
+inline QImage::Format platformImageFormat(bool needAlpha)
 {
   // see https://code.woboq.org/qt5/qtbase/src/gui/image/qpixmap_raster.cpp.html#97
   // see https://code.woboq.org/data/symbol.html?root=../qt5/&ref=_ZN21QRasterPlatformPixmap18systemOpaqueFormatEv
@@ -75,7 +75,7 @@ inline QImage::Format platformImageFormat()
     // https://code.woboq.org/qt5/qtbase/src/plugins/platforms/cocoa/qcocoaintegration.mm.html#117
     // https://code.woboq.org/data/symbol.html?root=../qt5/&ref=_ZN12QCocoaScreen14updateGeometryEv
     // Qt Docs: The image is stored using a 32-bit RGB format (0xffRRGGBB).
-    return QImage::Format_RGB32;
+    return needAlpha ? QImage::Format_ARGB32 : QImage::Format_RGB32;
   if (is_Q_OS_WIN)
     // https://code.woboq.org/qt5/qtbase/src/plugins/platforms/windows/qwindowsscreen.cpp.html#59
     // https://code.woboq.org/data/symbol.html?root=../qt5/&ref=_ZN18QWindowsScreenDataC1Ev
@@ -86,6 +86,8 @@ inline QImage::Format platformImageFormat()
     // premultiplied ARGB32 than with plain ARGB32.
     return QImage::Format_ARGB32_Premultiplied;
   // Fall back on Linux and other platforms.
+  if (needAlpha)
+    return QImage::Format_ARGB32;
   return pixmapImageFormat();
 }
 

--- a/YUViewLib/src/video/YUVPixelFormat.cpp
+++ b/YUViewLib/src/video/YUVPixelFormat.cpp
@@ -584,6 +584,22 @@ bool YUVPixelFormat::isPlanar() const
   return this->planar;
 }
 
+bool YUVPixelFormat::hasAlpha() const
+{
+  if (this->predefinedPixelFormat)
+  {
+    if (*this->predefinedPixelFormat == PredefinedPixelFormat::V210)
+      return false;
+    return false;
+  }
+
+  if (this->planar)
+    return this->planeOrder == PlaneOrder::YUVA || this->planeOrder == PlaneOrder::YVUA;
+  else
+    return this->packingOrder == PackingOrder::AYUV || this->packingOrder == PackingOrder::YUVA ||
+           this->packingOrder == PackingOrder::VUYA;
+}
+
 Offset YUVPixelFormat::getChromaOffset() const
 {
   if (this->predefinedPixelFormat)

--- a/YUViewLib/src/video/YUVPixelFormat.h
+++ b/YUViewLib/src/video/YUVPixelFormat.h
@@ -211,6 +211,7 @@ public:
   unsigned getBitsPerSample() const;
   bool     isBigEndian() const;
   bool     isPlanar() const;
+  bool     hasAlpha() const;
 
   Offset getChromaOffset() const;
 

--- a/YUViewLib/src/video/frameHandler.cpp
+++ b/YUViewLib/src/video/frameHandler.cpp
@@ -374,7 +374,7 @@ QImage frameHandler::calculateDifference(frameHandler *item2,
   auto width  = std::min(frameSize.width, item2->frameSize.width);
   auto height = std::min(frameSize.height, item2->frameSize.height);
 
-  QImage diffImg(width, height, functionsGui::platformImageFormat());
+  QImage diffImg(width, height, functionsGui::platformImageFormat(false));
 
   // Also calculate the MSE while we're at it (R,G,B)
   int64_t mseAdd[3] = {0, 0, 0};

--- a/YUViewLib/src/video/videoCache.cpp
+++ b/YUViewLib/src/video/videoCache.cpp
@@ -519,7 +519,7 @@ void videoCache::updateCacheQueue()
       if (i < range.first || i > range.second)
         item->removeFrameFromCache(i);
 
-    int64_t cachingFrameSize = item->getCachingFrameSize();
+    auto cachingFrameSize = item->getCachingFrameSize();
     cacheLevel += item->getNumberCachedFrames() * cachingFrameSize;
   }
   if (cacheLevel > cacheLevelMax)

--- a/YUViewLib/src/video/videoHandler.cpp
+++ b/YUViewLib/src/video/videoHandler.cpp
@@ -285,10 +285,11 @@ void videoHandler::cacheFrame(int frameIdx, bool testMode)
     DEBUG_VIDEO("videoHandler::cacheFrame loading frame %i for caching failed", frameIdx);
 }
 
-unsigned int videoHandler::getCachingFrameSize() const
+unsigned videoHandler::getCachingFrameSize() const
 {
-  auto bytes = functionsGui::bytesPerPixel(functionsGui::platformImageFormat());
-  return frameSize.width * frameSize.height * bytes;
+  const auto hasAlpha = false;
+  auto       bytes    = functionsGui::bytesPerPixel(functionsGui::platformImageFormat(hasAlpha));
+  return this->frameSize.width * this->frameSize.height * bytes;
 }
 
 QList<int> videoHandler::getCachedFrames() const

--- a/YUViewLib/src/video/videoHandler.h
+++ b/YUViewLib/src/video/videoHandler.h
@@ -55,14 +55,14 @@ public:
 
   // --- Caching ----
   // These methods are all thread-safe and can be invoked from any thread.
-  int          getNrFramesCached() const;
-  void         cacheFrame(int frameIndex, bool testMode);
-  unsigned int getCachingFrameSize() const; // How much bytes will be used when caching one frame?
-  QList<int>   getCachedFrames() const;
-  int          getNumberCachedFrames() const;
-  bool         isInCache(int idx) const;
-  virtual void removeFrameFromCache(int frameIndex);
-  virtual void removeAllFrameFromCache();
+  int              getNrFramesCached() const;
+  void             cacheFrame(int frameIndex, bool testMode);
+  virtual unsigned getCachingFrameSize() const;
+  QList<int>       getCachedFrames() const;
+  int              getNumberCachedFrames() const;
+  bool             isInCache(int idx) const;
+  virtual void     removeFrameFromCache(int frameIndex);
+  virtual void     removeAllFrameFromCache();
 
   // Get the number of bytes for one frame (RGB or YUV) with the current format (if this video
   // handler uses raw data)

--- a/YUViewLib/src/video/videoHandlerDifference.cpp
+++ b/YUViewLib/src/video/videoHandlerDifference.cpp
@@ -335,7 +335,7 @@ ItemLoadingState videoHandlerDifference::needsLoadingRawValues(int frameIndex)
   if (auto video = dynamic_cast<videoHandler *>(inputVideo[0].data()))
     if (video->needsLoadingRawValues(frameIndex) == ItemLoadingState::LoadingNeeded)
       return ItemLoadingState::LoadingNeeded;
-  
+
   if (auto video = dynamic_cast<videoHandler *>(inputVideo[1].data()))
     if (video->needsLoadingRawValues(frameIndex) == ItemLoadingState::LoadingNeeded)
       return ItemLoadingState::LoadingNeeded;

--- a/YUViewLib/src/video/videoHandlerDifference.h
+++ b/YUViewLib/src/video/videoHandlerDifference.h
@@ -45,11 +45,11 @@ class videoHandlerDifference : public videoHandler
   Q_OBJECT
 
 public:
+  explicit videoHandlerDifference();
+
   // Draw the frame with the given frame index and zoom factor. If onLoadShowLasFrame is set, show
   // the last frame if the frame with the current frame index is loaded in the background.
   void drawDifferenceFrame(QPainter *painter, int frameIdx, double zoomFactor, bool drawRawValues);
-
-  explicit videoHandlerDifference();
 
   void loadFrameDifference(int frameIndex, bool loadToDoubleBuffer = false);
 

--- a/YUViewLib/src/video/videoHandlerRGB.cpp
+++ b/YUViewLib/src/video/videoHandlerRGB.cpp
@@ -714,11 +714,10 @@ void videoHandlerRGB::convertSourceToRGBA32Bit(const QByteArray &sourceBuffer,
         dst[0] = val;
         dst[1] = val;
         dst[2] = val;
-        if (hasAlpha)
-          dst[3] = 255;
+        dst[3] = 255;
 
         src += offsetToNextValue;
-        dst += hasAlpha ? 4 : 3;
+        dst += 4;
       }
     }
     else if (srcPixelFormat.bitsPerValue == 8)
@@ -743,11 +742,10 @@ void videoHandlerRGB::convertSourceToRGBA32Bit(const QByteArray &sourceBuffer,
         dst[0] = val;
         dst[1] = val;
         dst[2] = val;
-        if (hasAlpha)
-          dst[3] = 255;
+        dst[3] = 255;
 
         src += offsetToNextValue;
-        dst += hasAlpha ? 4 : 3;
+        dst += 4;
       }
     }
     else
@@ -841,9 +839,9 @@ void videoHandlerRGB::convertSourceToRGBA32Bit(const QByteArray &sourceBuffer,
         dst[0] = valB;
         dst[1] = valG;
         dst[2] = valR;
-        if (hasAlpha)
-          dst[3] = valA;
-        dst += hasAlpha ? 4 : 3;
+        dst[3] = valA;  
+        
+        dst += 4;
       }
     }
     else if (srcPixelFormat.bitsPerValue == 8)
@@ -921,9 +919,9 @@ void videoHandlerRGB::convertSourceToRGBA32Bit(const QByteArray &sourceBuffer,
         dst[0] = valB;
         dst[1] = valG;
         dst[2] = valR;
-        if (hasAlpha)
-          dst[3] = valA;
-        dst += hasAlpha ? 4 : 3;
+        dst[3] = valA;
+        
+        dst += 4;
       }
     }
     else

--- a/YUViewLib/src/video/videoHandlerRGB.h
+++ b/YUViewLib/src/video/videoHandlerRGB.h
@@ -65,6 +65,8 @@ public:
     return (frameHandler::isFormatValid() && srcPixelFormat.isValid());
   }
 
+  unsigned getCachingFrameSize() const override;
+
   // Return the RGB values for the given pixel
   virtual QStringPairList getPixelValues(const QPoint &pixelPos,
                                          int           frameIdx,
@@ -203,7 +205,7 @@ private:
   // Convert one frame from the current pixel format to RGB888
   void       convertSourceToRGBA32Bit(const QByteArray &sourceBuffer,
                                       unsigned char *   targetBuffer,
-                                      bool              convertSourceToRGBA32Bit);
+                                      QImage::Format    imageFormat);
   QByteArray tmpBufferRawRGBDataCaching;
 
   // When a caching job is running in the background it will lock this mutex, so that

--- a/YUViewLib/src/video/videoHandlerYUV.h
+++ b/YUViewLib/src/video/videoHandlerYUV.h
@@ -55,6 +55,8 @@ public:
   videoHandlerYUV();
   ~videoHandlerYUV();
 
+  unsigned getCachingFrameSize() const override;
+
   // The format is valid if the frame width/height/pixel format are set
   virtual bool isFormatValid() const override
   {


### PR DESCRIPTION
Issue: https://github.com/IENT/YUView/issues/404

New way to get the "best" platform image format:
 - If no alpha component is needed, we get the same formats as before.
 - If alpha is needed, we get a format with alpha. This may not be the fastest to render on some platforms but in that case we want to have alpha. 

Test on:

- [x] Windows
- [x] Linux
- [x] Mac
