### PR TITLE
Bugfix: YUV component and interpolation were connected incorrectly

### DIFF
--- a/YUViewLib/src/video/videoHandlerYUV.cpp
+++ b/YUViewLib/src/video/videoHandlerYUV.cpp
@@ -2903,9 +2903,9 @@ void videoHandlerYUV::slotYUVControlChanged()
       sender == ui.chromaInvertCheckBox)
   {
     this->conversionSettings.chromaInterpolation =
-        *ChromaInterpolationMapper.at(ui.colorComponentsComboBox->currentIndex());
+        *ChromaInterpolationMapper.at(ui.chromaInterpolationComboBox->currentIndex());
     this->conversionSettings.componentDisplayMode =
-        *ComponentDisplayModeMapper.at(ui.chromaInterpolationComboBox->currentIndex());
+        *ComponentDisplayModeMapper.at(ui.colorComponentsComboBox->currentIndex());
     this->conversionSettings.colorConversion =
         *ColorConversionMapper.at(ui.colorConversionComboBox->currentIndex());
 

--- a/YUViewLib/src/video/videoHandlerYUV.h
+++ b/YUViewLib/src/video/videoHandlerYUV.h
@@ -57,9 +57,9 @@ enum class ComponentDisplayMode
 
 const auto ComponentDisplayModeMapper =
     EnumMapper<ComponentDisplayMode>({{ComponentDisplayMode::DisplayAll, "Y'CbCr"},
-                                      {ComponentDisplayMode::DisplayAll, "Luma (Y) Only"},
-                                      {ComponentDisplayMode::DisplayAll, "Cb only"},
-                                      {ComponentDisplayMode::DisplayAll, "Cr only"}});
+                                      {ComponentDisplayMode::DisplayY, "Luma (Y) Only"},
+                                      {ComponentDisplayMode::DisplayCb, "Cb only"},
+                                      {ComponentDisplayMode::DisplayCr, "Cr only"}});
 
 struct ConversionSettings
 {


### PR DESCRIPTION
Issue: #435 
The combo boxes were connected incorrectly and the component enum was wrong.