### PR TITLE
Fix for bitrate plot in AV1 and packet view

### DIFF
--- a/YUViewLib/src/parser/AV1/AV1OBU.cpp
+++ b/YUViewLib/src/parser/AV1/AV1OBU.cpp
@@ -76,8 +76,9 @@ std::pair<size_t, std::string> ParserAV1OBU::parseAndAddOBU(int                 
     if (obu.header.obu_type == ObuType::OBU_TEMPORAL_DELIMITER)
     {
       decValues.SeenFrameHeader = false;
+      obuTypeName = "Temporal Delimiter";
     }
-    if (obu.header.obu_type == ObuType::OBU_SEQUENCE_HEADER)
+    else if (obu.header.obu_type == ObuType::OBU_SEQUENCE_HEADER)
     {
       auto new_sequence_header = std::make_shared<sequence_header_obu>();
       new_sequence_header->parse(reader);
@@ -104,6 +105,7 @@ std::pair<size_t, std::string> ParserAV1OBU::parseAndAddOBU(int                 
   catch (const std::exception &e)
   {
     errorText = " ERROR " + std::string(e.what());
+    obuTypeName = "Error";
   }
 
   if (obuRoot)

--- a/YUViewLib/src/parser/common/BitratePlotModel.cpp
+++ b/YUViewLib/src/parser/common/BitratePlotModel.cpp
@@ -110,7 +110,7 @@ BitratePlotModel::getPointInfo(unsigned streamIndex, unsigned plotIndex, unsigne
       unsigned(this->dataPerStream[streamIndex].size()) <= pointIndex)
     return {};
 
-  auto &     entry         = this->dataPerStream[streamIndex][pointIndex];
+  auto       entry         = this->dataPerStream[streamIndex][pointIndex];
   const auto isAveragePlot = (plotIndex == 1);
 
   if (isAveragePlot)


### PR DESCRIPTION
Issue: #434 
 - Plot avpackets for everything that can not be plotted in more detail by a parser
 - Improve packet view of AV1 in list