### PR TITLE
Fix YUV file format guessing for NV12

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Version (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Version [e.g. 2.2.1, commit gb283bgrj]
+ - If you compiled YUView yourself then which Qt version did you use?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen. How do you think this may work in the user interface? Maybe you could even provide a sketch. 
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.

--- a/YUViewLib/src/video/PixelFormatYUVGuess.cpp
+++ b/YUViewLib/src/video/PixelFormatYUVGuess.cpp
@@ -242,13 +242,6 @@ PixelFormatYUV guessFormatFromSizeAndName(const Size       size,
   // The name of the folder that the file is in
   auto dirName = fileInfo.absoluteDir().dirName().toLower().toStdString();
 
-  if (fileInfo.suffix().toLower() == "nv21")
-  {
-    // This should be a 8 bit planar yuv 4:2:0 file with interleaved UV components and YVU order
-    auto fmt = PixelFormatYUV(Subsampling::YUV_420, 8, PlaneOrder::YVU, false, {}, true);
-    if (checkFormat(fmt, size, fileSize))
-      return fmt;
-  }
   if (fileInfo.suffix().toLower() == "v210")
   {
     auto fmt = PixelFormatYUV(PredefinedPixelFormat::V210);
@@ -282,6 +275,24 @@ PixelFormatYUV guessFormatFromSizeAndName(const Size       size,
         return fmt;
       fmt = testFormatFromSizeAndNamePacked(name, size, bitDepth, subsampling, fileSize);
       if (fmt.isValid())
+        return fmt;
+    }
+
+    // Check if the filename contains NV12
+    if (name.find("nv12") != std::string::npos)
+    {
+      // This should be a 8 bit semi-planar yuv 4:2:0 file with interleaved UV components and YYYYUV order
+      auto fmt = PixelFormatYUV(Subsampling::YUV_420, 8, PlaneOrder::YUV, false, {}, true);
+      if (checkFormat(fmt, size, fileSize))
+        return fmt;
+    }
+
+    // Check if the filename contains NV21
+    if (name.find("nv21") != std::string::npos)
+    {
+      // This should be a 8 bit semi-planar yuv 4:2:0 file with interleaved UV components and YYYYVU order
+      auto fmt = PixelFormatYUV(Subsampling::YUV_420, 8, PlaneOrder::YVU, false, {}, true);
+      if (checkFormat(fmt, size, fileSize))
         return fmt;
     }
 

--- a/YUViewLib/src/video/PixelFormatYUVGuess.cpp
+++ b/YUViewLib/src/video/PixelFormatYUVGuess.cpp
@@ -296,6 +296,24 @@ PixelFormatYUV guessFormatFromSizeAndName(const Size       size,
         return fmt;
     }
 
+    // Check if the filename contains NV24
+    if (name.find("nv24") != std::string::npos)
+    {
+      // This should be a 8 bit semi-planar yuv 4:4:4 file with interleaved UV components and YYYYUVUV order
+      auto fmt = PixelFormatYUV(Subsampling::YUV_444, 8, PlaneOrder::YUV, false, {}, true);
+      if (checkFormat(fmt, size, fileSize))
+        return fmt;
+    }
+
+    // Check if the filename contains NV42
+    if (name.find("nv42") != std::string::npos)
+    {
+      // This should be a 8 bit semi-planar yuv 4:4:4 file with interleaved UV components and YYYYVUVU order
+      auto fmt = PixelFormatYUV(Subsampling::YUV_444, 8, PlaneOrder::YVU, false, {}, true);
+      if (checkFormat(fmt, size, fileSize))
+        return fmt;
+    }
+
     // One more FFMpeg format description that does not match the pattern above is: "ayuv64le"
     if (name.find("ayuv64le") != std::string::npos)
     {

--- a/deployment/deploy.nsi
+++ b/deployment/deploy.nsi
@@ -2,7 +2,7 @@
 
 ; HM NIS Edit Wizard helper defines
 !define PRODUCT_NAME "YUView"
-!define PRODUCT_VERSION "2.12"
+!define PRODUCT_VERSION "2.12.1"
 !define PRODUCT_PUBLISHER "Institut für Nachrichtentechnik"
 !define PRODUCT_WEB_SITE "http://www.ient.rwth-aachen.de"
 !define PRODUCT_DIR_REGKEY "Software\Microsoft\Windows\CurrentVersion\App Paths\YUView.exe"

--- a/deployment/wix/YUView.wxs
+++ b/deployment/wix/YUView.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="YUView" Language="1033" Version="2.12" Manufacturer="IENT RWTH Aachen University" UpgradeCode="07fd1dd5-9b1e-453d-974b-4ff7919a49c7">
+  <Product Id="*" Name="YUView" Language="1033" Version="2.12.1" Manufacturer="IENT RWTH Aachen University" UpgradeCode="07fd1dd5-9b1e-453d-974b-4ff7919a49c7">
     <Package InstallerVersion="301" Compressed="yes" Platform="x64" InstallScope="perMachine" />
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />

--- a/packaging/linux/de.rwth_aachen.ient.YUView.appdata.xml
+++ b/packaging/linux/de.rwth_aachen.ient.YUView.appdata.xml
@@ -41,6 +41,6 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
-    <release version="2.12" date="2019-01-12"></release>
+    <release version="2.12.1" date="2019-01-12"></release>
   </releases>
 </component>

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: yuview
-version: 2.12
+version: 2.12.1
 summary: YUView
 description: YUView - The free cross platform YUV viewer and video analysis tool
 


### PR DESCRIPTION
This patch adds NV12 support and guesses the YUV format from the filename instead of the extension (suffix).

Tested with:
./YUView Session_800x630_NV12.yuv
./YUView Session_1084x660_NV12.yuv