### PR TITLE
Fix yuvformat guessing

### DIFF
--- a/YUViewLib/src/video/PixelFormatYUVGuess.cpp
+++ b/YUViewLib/src/video/PixelFormatYUVGuess.cpp
@@ -242,13 +242,6 @@ PixelFormatYUV guessFormatFromSizeAndName(const Size       size,
   // The name of the folder that the file is in
   auto dirName = fileInfo.absoluteDir().dirName().toLower().toStdString();
 
-  if (fileInfo.suffix().toLower() == "nv21")
-  {
-    // This should be a 8 bit planar yuv 4:2:0 file with interleaved UV components and YVU order
-    auto fmt = PixelFormatYUV(Subsampling::YUV_420, 8, PlaneOrder::YVU, false, {}, true);
-    if (checkFormat(fmt, size, fileSize))
-      return fmt;
-  }
   if (fileInfo.suffix().toLower() == "v210")
   {
     auto fmt = PixelFormatYUV(PredefinedPixelFormat::V210);
@@ -282,6 +275,24 @@ PixelFormatYUV guessFormatFromSizeAndName(const Size       size,
         return fmt;
       fmt = testFormatFromSizeAndNamePacked(name, size, bitDepth, subsampling, fileSize);
       if (fmt.isValid())
+        return fmt;
+    }
+
+    // Check if the filename contains NV12
+    if (name.find("nv12") != std::string::npos)
+    {
+      // This should be a 8 bit semi-planar yuv 4:2:0 file with interleaved UV components and YYYYUV order
+      auto fmt = PixelFormatYUV(Subsampling::YUV_420, 8, PlaneOrder::YUV, false, {}, true);
+      if (checkFormat(fmt, size, fileSize))
+        return fmt;
+    }
+
+    // Check if the filename contains NV21
+    if (name.find("nv21") != std::string::npos)
+    {
+      // This should be a 8 bit semi-planar yuv 4:2:0 file with interleaved UV components and YYYYVU order
+      auto fmt = PixelFormatYUV(Subsampling::YUV_420, 8, PlaneOrder::YVU, false, {}, true);
+      if (checkFormat(fmt, size, fileSize))
         return fmt;
     }
 


### PR DESCRIPTION
This patch expands the guessing logic to support NV12 and to guess it from the filename instead of looking at the file suffix.

Tested with:
./YUView Session_800x630_NV12.yuv