### PR TITLE
Retrieve extradata correctly from stream for new interface

### DIFF
--- a/YUViewLib/src/ffmpeg/AVCodecParametersWrapper.cpp
+++ b/YUViewLib/src/ffmpeg/AVCodecParametersWrapper.cpp
@@ -118,6 +118,12 @@ Ratio AVCodecParametersWrapper::getSampleAspectRatio()
   return Ratio({this->sample_aspect_ratio.num, this->sample_aspect_ratio.den});
 }
 
+QByteArray AVCodecParametersWrapper::getExtradata()
+{
+  this->update();
+  return this->extradata;
+}
+
 QStringPairList AVCodecParametersWrapper::getInfoText()
 {
   QStringPairList info;
@@ -229,8 +235,7 @@ QStringPairList AVCodecParametersWrapper::getInfoText()
 
 void AVCodecParametersWrapper::setClearValues()
 {
-  if (this->libVer.avformat.major == 57 || //
-      this->libVer.avformat.major == 58 || //
+  if (this->libVer.avformat.major == 57 || this->libVer.avformat.major == 58 ||
       this->libVer.avformat.major == 59)
   {
     auto p                   = reinterpret_cast<AVCodecParameters_57_58_59 *>(this->param);
@@ -266,8 +271,7 @@ void AVCodecParametersWrapper::setClearValues()
 
 void AVCodecParametersWrapper::setAVMediaType(AVMediaType type)
 {
-  if (this->libVer.avformat.major == 57 || //
-      this->libVer.avformat.major == 58 || //
+  if (this->libVer.avformat.major == 57 || this->libVer.avformat.major == 58 ||
       this->libVer.avformat.major == 59)
   {
     auto p           = reinterpret_cast<AVCodecParameters_57_58_59 *>(this->param);
@@ -278,8 +282,7 @@ void AVCodecParametersWrapper::setAVMediaType(AVMediaType type)
 
 void AVCodecParametersWrapper::setAVCodecID(AVCodecID id)
 {
-  if (this->libVer.avformat.major == 57 || //
-      this->libVer.avformat.major == 58 || //
+  if (this->libVer.avformat.major == 57 || this->libVer.avformat.major == 58 ||
       this->libVer.avformat.major == 59)
   {
     auto p         = reinterpret_cast<AVCodecParameters_57_58_59 *>(this->param);
@@ -290,23 +293,19 @@ void AVCodecParametersWrapper::setAVCodecID(AVCodecID id)
 
 void AVCodecParametersWrapper::setExtradata(QByteArray data)
 {
-  if (this->libVer.avformat.major == 57 || //
-      this->libVer.avformat.major == 58 || //
+  if (this->libVer.avformat.major == 57 || this->libVer.avformat.major == 58 ||
       this->libVer.avformat.major == 59)
   {
-    this->set_extradata  = data;
-    auto p               = reinterpret_cast<AVCodecParameters_57_58_59 *>(this->param);
-    p->extradata         = (uint8_t *)set_extradata.data();
-    p->extradata_size    = set_extradata.length();
-    this->extradata      = (uint8_t *)set_extradata.data();
-    this->extradata_size = set_extradata.length();
+    this->extradata   = data;
+    auto p            = reinterpret_cast<AVCodecParameters_57_58_59 *>(this->param);
+    p->extradata      = (uint8_t *)this->extradata.data();
+    p->extradata_size = this->extradata.length();
   }
 }
 
 void AVCodecParametersWrapper::setSize(Size size)
 {
-  if (this->libVer.avformat.major == 57 || //
-      this->libVer.avformat.major == 58 || //
+  if (this->libVer.avformat.major == 57 || this->libVer.avformat.major == 58 ||
       this->libVer.avformat.major == 59)
   {
     auto p       = reinterpret_cast<AVCodecParameters_57_58_59 *>(this->param);
@@ -319,8 +318,7 @@ void AVCodecParametersWrapper::setSize(Size size)
 
 void AVCodecParametersWrapper::setAVPixelFormat(AVPixelFormat format)
 {
-  if (this->libVer.avformat.major == 57 || //
-      this->libVer.avformat.major == 58 || //
+  if (this->libVer.avformat.major == 57 || this->libVer.avformat.major == 58 ||
       this->libVer.avformat.major == 59)
   {
     auto p       = reinterpret_cast<AVCodecParameters_57_58_59 *>(this->param);
@@ -331,8 +329,7 @@ void AVCodecParametersWrapper::setAVPixelFormat(AVPixelFormat format)
 
 void AVCodecParametersWrapper::setProfileLevel(int profile, int level)
 {
-  if (this->libVer.avformat.major == 57 || //
-      this->libVer.avformat.major == 58 || //
+  if (this->libVer.avformat.major == 57 || this->libVer.avformat.major == 58 ||
       this->libVer.avformat.major == 59)
   {
     auto p        = reinterpret_cast<AVCodecParameters_57_58_59 *>(this->param);
@@ -345,8 +342,7 @@ void AVCodecParametersWrapper::setProfileLevel(int profile, int level)
 
 void AVCodecParametersWrapper::setSampleAspectRatio(int num, int den)
 {
-  if (this->libVer.avformat.major == 57 || //
-      this->libVer.avformat.major == 58 || //
+  if (this->libVer.avformat.major == 57 || this->libVer.avformat.major == 58 ||
       this->libVer.avformat.major == 59)
   {
     auto       p = reinterpret_cast<AVCodecParameters_57_58_59 *>(param);
@@ -368,8 +364,7 @@ void AVCodecParametersWrapper::update()
     // This data structure does not exist in avformat major version 56.
     this->param = nullptr;
   }
-  else if (this->libVer.avformat.major == 57 || //
-           this->libVer.avformat.major == 58 || //
+  else if (this->libVer.avformat.major == 57 || this->libVer.avformat.major == 58 ||
            this->libVer.avformat.major == 59)
   {
     auto p = reinterpret_cast<AVCodecParameters_57_58_59 *>(this->param);
@@ -377,8 +372,7 @@ void AVCodecParametersWrapper::update()
     this->codec_type            = p->codec_type;
     this->codec_id              = p->codec_id;
     this->codec_tag             = p->codec_tag;
-    this->extradata             = p->extradata;
-    this->extradata_size        = p->extradata_size;
+    this->extradata             = QByteArray((const char *)p->extradata, p->extradata_size);
     this->format                = p->format;
     this->bit_rate              = p->bit_rate;
     this->bits_per_coded_sample = p->bits_per_coded_sample;

--- a/YUViewLib/src/ffmpeg/AVCodecParametersWrapper.h
+++ b/YUViewLib/src/ffmpeg/AVCodecParametersWrapper.h
@@ -42,7 +42,7 @@ class AVCodecParametersWrapper
 public:
   AVCodecParametersWrapper() = default;
   AVCodecParametersWrapper(AVCodecParameters *p, LibraryVersion v);
-  explicit        operator bool() const { return param != nullptr; }
+  explicit        operator bool() const { return this->param != nullptr; }
   QStringPairList getInfoText();
 
   AVMediaType   getCodecType();
@@ -52,6 +52,7 @@ public:
   AVColorSpace  getColorspace();
   AVPixelFormat getPixelFormat();
   Ratio         getSampleAspectRatio();
+  QByteArray    getExtradata();
 
   // Set a default set of (unknown) values
   void setClearValues();
@@ -64,7 +65,7 @@ public:
   void setProfileLevel(int profile, int level);
   void setSampleAspectRatio(int num, int den);
 
-  AVCodecParameters *getCodecParameters() { return param; }
+  AVCodecParameters *getCodecParameters() const { return this->param; }
 
 private:
   // Update all private values from the AVCodecParameters
@@ -74,8 +75,7 @@ private:
   AVMediaType                   codec_type{};
   AVCodecID                     codec_id{};
   uint32_t                      codec_tag{};
-  uint8_t *                     extradata{};
-  int                           extradata_size{};
+  QByteArray                    extradata{};
   int                           format{};
   int64_t                       bit_rate{};
   int                           bits_per_coded_sample{};
@@ -92,9 +92,6 @@ private:
   AVColorSpace                  color_space{};
   AVChromaLocation              chroma_location{};
   int                           video_delay{};
-
-  // When setting custom metadata, we keep a reference to it here.
-  QByteArray set_extradata{};
 
   AVCodecParameters *param{};
   LibraryVersion     libVer{};

--- a/YUViewLib/src/ffmpeg/AVStreamWrapper.cpp
+++ b/YUViewLib/src/ffmpeg/AVStreamWrapper.cpp
@@ -303,6 +303,14 @@ AVPixelFormat AVStreamWrapper::getPixelFormat()
   return this->codecpar.getPixelFormat();
 }
 
+QByteArray AVStreamWrapper::getExtradata()
+{
+  this->update();
+  if (this->libVer.avformat.major <= 56 || !this->codecpar)
+    return this->codec.getExtradata();
+  return this->codecpar.getExtradata();
+}
+
 int AVStreamWrapper::getIndex()
 {
   this->update();

--- a/YUViewLib/src/ffmpeg/AVStreamWrapper.h
+++ b/YUViewLib/src/ffmpeg/AVStreamWrapper.h
@@ -60,6 +60,7 @@ public:
   int                      getFrameHeight();
   AVColorSpace             getColorspace();
   AVPixelFormat            getPixelFormat();
+  QByteArray               getExtradata();
   int                      getIndex();
   AVCodecParametersWrapper getCodecpar();
 

--- a/YUViewLib/src/filesource/FileSourceFFmpegFile.cpp
+++ b/YUViewLib/src/filesource/FileSourceFFmpegFile.cpp
@@ -225,7 +225,10 @@ QList<QByteArray> FileSourceFFmpegFile::getParameterSets()
    * To access them from libav* APIs you need to look for extradata field in AVCodecContext of
    * AVStream which relate to needed video stream. Also extradata can have different format from
    * standard H.264 NALs so look in MP4-container specs for format description. */
-  const auto        extradata = this->getExtradata();
+  const auto extradata = this->getExtradata();
+  if (extradata.length() == 0)
+    return {};
+
   QList<QByteArray> retArray;
 
   // Since the FFmpeg developers don't want to make it too easy, the extradata is organized

--- a/YUViewLib/src/filesource/FileSourceFFmpegFile.cpp
+++ b/YUViewLib/src/filesource/FileSourceFFmpegFile.cpp
@@ -59,7 +59,7 @@ auto startCode = QByteArrayLiteral("\x00\x00\x01");
 
 FileSourceFFmpegFile::FileSourceFFmpegFile()
 {
-  connect(&fileWatcher,
+  connect(&this->fileWatcher,
           &QFileSystemWatcher::fileChanged,
           this,
           &FileSourceFFmpegFile::fileSystemWatcherFileChanged);
@@ -74,13 +74,13 @@ AVPacketWrapper FileSourceFFmpegFile::getNextPacket(bool getLastPackage, bool vi
   if (!this->goToNextPacket(videoPacket))
   {
     this->posInFile = -1;
-    return AVPacketWrapper();
+    return {};
   }
 
   return this->currentPacket;
 }
 
-QByteArray FileSourceFFmpegFile::getNextUnit(bool getLastDataAgain, int64_t *pts)
+QByteArray FileSourceFFmpegFile::getNextUnit(bool getLastDataAgain)
 {
   if (getLastDataAgain)
     return this->lastReturnArray;
@@ -105,8 +105,8 @@ QByteArray FileSourceFFmpegFile::getNextUnit(bool getLastDataAgain, int64_t *pts
   // by the payload
   if (this->packetDataFormat == PacketDataFormat::RawNAL)
   {
-    auto firstBytes = this->currentPacketData.mid(posInData, 4);
-    int  offset;
+    const auto firstBytes = this->currentPacketData.mid(posInData, 4);
+    int        offset;
     if (firstBytes.at(0) == (char)0 && firstBytes.at(1) == (char)0 && firstBytes.at(2) == (char)0 &&
         firstBytes.at(3) == (char)1)
       offset = 4;
@@ -121,7 +121,7 @@ QByteArray FileSourceFFmpegFile::getNextUnit(bool getLastDataAgain, int64_t *pts
     }
 
     // Look for the next start code (or the end of the file)
-    int nextStartCodePos = this->currentPacketData.indexOf(startCode, posInData + 3);
+    auto nextStartCodePos = this->currentPacketData.indexOf(startCode, posInData + 3);
 
     if (nextStartCodePos == -1)
     {
@@ -132,7 +132,7 @@ QByteArray FileSourceFFmpegFile::getNextUnit(bool getLastDataAgain, int64_t *pts
     }
     else
     {
-      int size        = nextStartCodePos - this->posInData - offset;
+      auto size       = nextStartCodePos - this->posInData - offset;
       lastReturnArray = this->currentPacketData.mid(this->posInData + offset, size);
       this->posInData += 3 + size;
     }
@@ -194,32 +194,25 @@ QByteArray FileSourceFFmpegFile::getNextUnit(bool getLastDataAgain, int64_t *pts
     {
       // The reader threw an exception
       this->currentPacketData.clear();
-      return QByteArray();
+      return {};
     }
   }
-
-  if (pts)
-    *pts = this->currentPacket.getPTS();
 
   return this->lastReturnArray;
 }
 
 QByteArray FileSourceFFmpegFile::getExtradata()
 {
-  // Get the video stream
-  if (!video_stream)
-    return QByteArray();
-  FFmpeg::AVCodecContextWrapper codec = video_stream.getCodec();
-  if (!codec)
-    return QByteArray();
-  return codec.getExtradata();
+  if (!this->video_stream)
+    return {};
+  return this->video_stream.getExtradata();
 }
 
 StringPairVec FileSourceFFmpegFile::getMetadata()
 {
-  if (!formatCtx)
+  if (!this->formatCtx)
     return {};
-  return ff.getDictionaryEntries(formatCtx.getMetadata(), "", 0);
+  return ff.getDictionaryEntries(this->formatCtx.getMetadata(), "", 0);
 }
 
 QList<QByteArray> FileSourceFFmpegFile::getParameterSets()
@@ -232,7 +225,7 @@ QList<QByteArray> FileSourceFFmpegFile::getParameterSets()
    * To access them from libav* APIs you need to look for extradata field in AVCodecContext of
    * AVStream which relate to needed video stream. Also extradata can have different format from
    * standard H.264 NALs so look in MP4-container specs for format description. */
-  auto              extradata = getExtradata();
+  const auto        extradata = this->getExtradata();
   QList<QByteArray> retArray;
 
   // Since the FFmpeg developers don't want to make it too easy, the extradata is organized
@@ -413,7 +406,7 @@ bool FileSourceFFmpegFile::scanBitstream(QWidget *mainWindow)
     return false;
 
   // Create the dialog (if the given pointer is not null)
-  auto maxPTS = getMaxTS();
+  auto maxPTS = this->getMaxTS();
   // Updating the dialog (setValue) is quite slow. Only do this if the percent value changes.
   int                             curPercentValue = 0;
   QScopedPointer<QProgressDialog> progress;
@@ -475,7 +468,6 @@ void FileSourceFFmpegFile::openFileAndFindVideoStream(QString fileName)
 
   this->formatCtx.getInputFormat();
 
-  // Iterate through all streams
   for (unsigned idx = 0; idx < this->formatCtx.getNbStreams(); idx++)
   {
     auto stream     = this->formatCtx.getStream(idx);
@@ -501,15 +493,14 @@ void FileSourceFFmpegFile::openFileAndFindVideoStream(QString fileName)
   if (!this->video_stream)
     return;
 
-  // Initialize an empty packet
   this->currentPacket = this->ff.allocatePaket();
 
   // Get the frame rate, picture size and color conversion mode
   auto avgFrameRate = this->video_stream.getAvgFrameRate();
   if (avgFrameRate.den == 0)
-    frameRate = -1.0;
+    this->frameRate = -1.0;
   else
-    frameRate = avgFrameRate.num / double(avgFrameRate.den);
+    this->frameRate = avgFrameRate.num / double(avgFrameRate.den);
 
   const auto ffmpegPixFormat =
       this->ff.getAvPixFmtDescriptionFromAvPixelFormat(this->video_stream.getPixelFormat());

--- a/YUViewLib/src/filesource/FileSourceFFmpegFile.h
+++ b/YUViewLib/src/filesource/FileSourceFFmpegFile.h
@@ -77,7 +77,7 @@ public:
    * functions.
    */
   // Get the next NAL unit (everything excluding the start code) or the next packet.
-  QByteArray getNextUnit(bool getLastDataAgain = false, int64_t *pts = nullptr);
+  QByteArray getNextUnit(bool getLastDataAgain = false);
   // Return the next packet (unless getLastPackage is set in which case we return the current
   // packet)
   FFmpeg::AVPacketWrapper getNextPacket(bool getLastPackage = false, bool videoPacket = true);


### PR DESCRIPTION
Issue: #480 
Get the extradata from the codecpar and not from the codes struct. That is deprecated.