### PR TITLE
Bugfix/hevc parsing

### DIFF
--- a/YUViewLib/src/parser/AVFormat/HVCC.cpp
+++ b/YUViewLib/src/parser/AVFormat/HVCC.cpp
@@ -65,7 +65,7 @@ void HVCCNalArray::parse(unsigned              arrayID,
 
   // The next 3 bytes contain info about the array
   this->array_completeness = reader.readFlag("array_completeness");
-  reader.readFlag("reserved_flag_false", Options().withCheckEqualTo(0));
+  reader.readFlag("reserved_flag_false", Options().withCheckEqualTo(0, CheckLevel::Warning));
   this->nal_unit_type = reader.readBits("nal_unit_type", 6);
   this->numNalus      = reader.readBits("numNalus", 16);
 
@@ -86,6 +86,7 @@ void HVCC::parse(ByteVector &              data,
   reader.disableEmulationPrevention();
 
   // The first 22 bytes are the hvcC header
+  // ISO/IEC 14496-15, 8.3.3.1.2
   this->configurationVersion =
       reader.readBits("configurationVersion", 8, Options().withCheckEqualTo(1));
   this->general_profile_space = reader.readBits("general_profile_space", 2);

--- a/YUViewLib/src/parser/HEVC/AnnexBHEVC.cpp
+++ b/YUViewLib/src/parser/HEVC/AnnexBHEVC.cpp
@@ -496,7 +496,7 @@ AnnexBHEVC::parseAndAddNALUnit(int                                           nal
       parseResult.nalTypeName = "Slice(POC " + std::to_string(poc) + ")";
 
       DEBUG_HEVC("AnnexBHEVC::parseAndAddNALUnit Slice POC "
-                 << POC << " - pocCounterOffset " << this->pocCounterOffset << " maxPOCCount "
+                 << poc << " - pocCounterOffset " << this->pocCounterOffset << " maxPOCCount "
                  << this->maxPOCCount << (nalHEVC->header.isIRAP() ? " - IRAP" : "")
                  << (newSlice->sliceSegmentHeader.NoRaslOutputFlag ? "" : " - RASL"));
     }

--- a/YUViewLib/src/parser/HEVC/video_parameter_set_rbsp.cpp
+++ b/YUViewLib/src/parser/HEVC/video_parameter_set_rbsp.cpp
@@ -93,7 +93,9 @@ void video_parameter_set_rbsp::parse(SubByteReaderLogging &reader)
     {
       this->hrd_layer_set_idx.push_back(reader.readUEV(formatArray("hrd_layer_set_idx", i)));
 
-      if (i > 0)
+      if (i == 0)
+        this->cprms_present_flag.push_back(1);
+      else
         this->cprms_present_flag.push_back(reader.readFlag(formatArray("cprms_present_flag", i)));
 
       // hrd_parameters...

--- a/YUViewLib/src/parser/common/SubByteReaderLogging.cpp
+++ b/YUViewLib/src/parser/common/SubByteReaderLogging.cpp
@@ -77,7 +77,7 @@ void checkAndLog(std::shared_ptr<TreeItem> item,
     item->createChildItem(
         symbolName, value, formatCoding(formatName, code.size()), code, meaning, isError);
   }
-  if (!checkResult)
+  if (!checkResult && checkResult.checkLevel == CheckLevel::Error)
     throw std::logic_error(checkResult.errorMessage);
 }
 

--- a/YUViewLib/src/parser/common/SubByteReaderLoggingOptions.h
+++ b/YUViewLib/src/parser/common/SubByteReaderLoggingOptions.h
@@ -43,22 +43,31 @@ namespace parser::reader
 
 using MeaningMap = std::map<int, std::string>;
 
+enum class CheckLevel
+{
+  Error,  // Parsing can not continue
+  Warning // Warn, but continue parsing
+};
+
 struct CheckResult
 {
   explicit    operator bool() const { return this->errorMessage.empty(); }
   std::string errorMessage;
+  CheckLevel  checkLevel{CheckLevel::Error};
 };
 
 class Check
 {
 public:
   Check() = default;
-  Check(std::string errorIfFail) : errorIfFail(errorIfFail){};
+  Check(std::string errorIfFail, CheckLevel checkLevel)
+      : errorIfFail(errorIfFail), checkLevel(checkLevel){};
   virtual ~Check() = default;
 
   virtual CheckResult checkValue(int64_t value) const = 0;
 
   std::string errorIfFail;
+  CheckLevel  checkLevel{CheckLevel::Error};
 };
 
 struct Options
@@ -69,14 +78,23 @@ struct Options
   [[nodiscard]] Options &&withMeaningMap(const MeaningMap &meaningMap);
   [[nodiscard]] Options &&withMeaningVector(const std::vector<std::string> &meaningVector);
   [[nodiscard]] Options &&
-                          withMeaningFunction(const std::function<std::string(int64_t)> &meaningFunction);
-  [[nodiscard]] Options &&withCheckEqualTo(int64_t value, const std::string &errorIfFail = {});
-  [[nodiscard]] Options &&
-  withCheckGreater(int64_t value, bool inclusive = true, const std::string &errorIfFail = {});
-  [[nodiscard]] Options &&
-  withCheckSmaller(int64_t value, bool inclusive = true, const std::string &errorIfFail = {});
-  [[nodiscard]] Options &&
-                          withCheckRange(Range<int64_t> range, bool inclusive = true, const std::string &errorIfFail = {});
+  withMeaningFunction(const std::function<std::string(int64_t)> &meaningFunction);
+  [[nodiscard]] Options &&withCheckEqualTo(int64_t            value,
+                                           const std::string &errorIfFail = {},
+                                           const CheckLevel   checkLevel  = CheckLevel::Error);
+  [[nodiscard]] Options &&withCheckEqualTo(int64_t value, const CheckLevel checkLevel);
+  [[nodiscard]] Options &&withCheckGreater(int64_t            value,
+                                           bool               inclusive   = true,
+                                           const std::string &errorIfFail = {},
+                                           const CheckLevel   checkLevel  = CheckLevel::Error);
+  [[nodiscard]] Options &&withCheckSmaller(int64_t            value,
+                                           bool               inclusive   = true,
+                                           const std::string &errorIfFail = {},
+                                           const CheckLevel   checkLevel  = CheckLevel::Error);
+  [[nodiscard]] Options &&withCheckRange(Range<int64_t>     range,
+                                         bool               inclusive   = true,
+                                         const std::string &errorIfFail = {},
+                                         const CheckLevel   checkLevel  = CheckLevel::Error);
   [[nodiscard]] Options &&withLoggingDisabled();
 
   std::string                         meaningString;


### PR DESCRIPTION
Issue: https://github.com/IENT/YUView/issues/485

Fixed an HEVC parsing bug. Also added the option to parse symbols and not fail but continue and mark the flag as wrong.