### PR TITLE
Fix compilation error when debug log enabled

### DIFF
--- a/YUViewLib/src/video/FrameHandler.cpp
+++ b/YUViewLib/src/video/FrameHandler.cpp
@@ -155,7 +155,7 @@ void FrameHandler::setFrameSize(Size newSize)
   if (newSize != this->frameSize)
   {
     // Set the new size
-    DEBUG_FRAME("FrameHandler::setFrameSize %dx%d", newSize.width(), newSize.height());
+    DEBUG_FRAME("FrameHandler::setFrameSize %dx%d", newSize.width, newSize.height);
     this->frameSize = newSize;
   }
 }
@@ -218,7 +218,7 @@ void FrameHandler::slotVideoControlChanged()
   // Update the controls and get the new selected size
   auto newSize = getNewSizeFromControls();
   DEBUG_FRAME(
-      "FrameHandler::slotVideoControlChanged new size %dx%d", newSize.width(), newSize.height());
+      "FrameHandler::slotVideoControlChanged new size %dx%d", newSize.width, newSize.height);
 
   if (newSize != frameSize && newSize.isValid())
   {


### PR DESCRIPTION
Fixes `error: expression cannot be used as a function` when attempting to compile with debug log enabled via `FRAMEHANDLER_DEBUG_LOADING` define.