### PR TITLE
Bitstream analysis tab switch crash fix

### DIFF
--- a/YUViewLib/src/ffmpeg/FFmpegVersionHandler.cpp
+++ b/YUViewLib/src/ffmpeg/FFmpegVersionHandler.cpp
@@ -310,6 +310,11 @@ FFmpegVersionHandler::FFmpegVersionHandler()
   this->lib.setLogList(&logList);
 }
 
+FFmpegVersionHandler::~FFmpegVersionHandler()
+{
+    this->lib.setLogList(nullptr);
+}
+
 void FFmpegVersionHandler::avLogCallback(void *, int level, const char *fmt, va_list vargs)
 {
   QString msg;

--- a/YUViewLib/src/ffmpeg/FFmpegVersionHandler.h
+++ b/YUViewLib/src/ffmpeg/FFmpegVersionHandler.h
@@ -53,6 +53,8 @@ class FFmpegVersionHandler
 public:
   FFmpegVersionHandler();
 
+  virtual ~FFmpegVersionHandler();
+
   // Try to load the ffmpeg libraries and get all the function pointers.
   void loadFFmpegLibraries();
   bool loadingSuccessfull() const;


### PR DESCRIPTION
When changing the tabbed view to the bitstream analysis/packet analysis tab the program would crash.
The cause was due to the object being pointed to no longer existed.

#514  

![crash](https://user-images.githubusercontent.com/125405191/218859097-f475b5a8-cc94-47f5-a838-53c16f020742.png)

