### PR TITLE
bugfix/build failure Qt6 in modern clang

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -7,34 +7,54 @@ on:
       - created
 
 jobs:
-  build-unix-native:
+  # build-unix-native:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       include: 
+  #         - os: ubuntu-18.04
+  #           INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
+  #           QMAKE_COMMAND: qmake
+  #         - os: ubuntu-20.04
+  #           INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
+  #           QMAKE_COMMAND: qmake
+  #         - os: ubuntu-22.04
+  #           INSTALL_LIBS: qt6-base-dev
+  #           QMAKE_COMMAND: qmake6
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - run: git fetch --prune --unshallow
+  #   - name: Install Linux packages
+  #     run: |
+  #       sudo apt-get update
+  #       sudo apt-get install ${{matrix.INSTALL_LIBS}}
+  #   - name: Build
+  #     run: |
+  #       cd $GITHUB_WORKSPACE
+  #       mkdir build
+  #       cd build
+  #       ${{matrix.QMAKE_COMMAND}} CONFIG+=UNITTESTS ..
+  #       make -j 2
+  #       make check
+  build-mac-native:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include: 
-          #- os: ubuntu-18.04
-          #   INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
-          #   QMAKE_COMMAND: qmake
-          #- os: ubuntu-20.04
-          #   INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
-          #   QMAKE_COMMAND: qmake
-          - os: ubuntu-22.04
-            INSTALL_LIBS: qt6-base-dev
-            QMAKE_COMMAND: qmake6
+          - os: macos-12
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow
-    - name: Install Linux packages
+    - name: Install packages
       run: |
-        sudo apt-get update
-        sudo apt-get install ${{matrix.INSTALL_LIBS}}
+        brew install qt
     - name: Build
       run: |
         cd $GITHUB_WORKSPACE
         mkdir build
         cd build
-        ${{matrix.QMAKE_COMMAND}} CONFIG+=UNITTESTS ..
-        make -j 2
+        qmake CONFIG+=UNITTESTS ..
+        make -j $(sysctl -n hw.logicalcpu)
         make check
   # build-unix:
   #   runs-on: ${{ matrix.os }}

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -13,11 +13,11 @@ jobs:
       matrix:
         include: 
           #- os: ubuntu-18.04
-             INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
-             QMAKE_COMMAND: qmake
+          #   INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
+          #   QMAKE_COMMAND: qmake
           #- os: ubuntu-20.04
-             INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
-             QMAKE_COMMAND: qmake
+          #   INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
+          #   QMAKE_COMMAND: qmake
           - os: ubuntu-22.04
             INSTALL_LIBS: qt6-base-dev
             QMAKE_COMMAND: qmake6

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -12,8 +12,9 @@ jobs:
     strategy:
       matrix:
         include: 
-          - os: ubuntu-18.04
-          - os: ubuntu-20.04
+          #- os: ubuntu-18.04
+          #- os: ubuntu-20.04
+          - os: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow
@@ -29,229 +30,229 @@ jobs:
         qmake CONFIG+=UNITTESTS ..
         make -j 2
         make check
-  build-unix:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include: 
-          - os: ubuntu-18.04
-            QT_FILE: qtBase_5.15.1_bionic.zip
-            LIBDE265_REMOTE: libde265.so
-            LIBDE265_LOCAL: libde265-internals.so
-            ARTIFACT_NAME: YUView.AppImage
-          - os: macos-10.15
-            QT_FILE: qtBase_5.15.1_mac.zip
-            LIBDE265_REMOTE: libde265.dylib
-            LIBDE265_LOCAL: libde265-internals.dylib
-            ARTIFACT_NAME: YUView-Mac.zip
-          - os: macos-11.0
-            QT_FILE: qtBase_5.15.1_mac.zip
-            LIBDE265_REMOTE: libde265.dylib
-            LIBDE265_LOCAL: libde265-internals.dylib
-            ARTIFACT_NAME: YUView-Mac-BigSur.zip
-    steps:
-    - uses: actions/checkout@v2
-    - run: git fetch --prune --unshallow
-    - name: Install Qt base
-      run: |
-        cd ../../
-        mkdir -p YUViewQt/YUViewQt
-        cd YUViewQt/YUViewQt
-        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtBase-5.15.1/${{matrix.QT_FILE}} -o Qt.zip
-        unzip -qa Qt.zip
-        echo "$GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin" >> $GITHUB_PATH
-      shell: bash
-    - name: Install MacDeployQT
-      run: |
-        cd $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt
-        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtDeployTools-5.15.1/qtTools_5.15.1_mac.zip -o deployQt.zip
-        unzip -qa deployQt.zip
-      shell: bash
-      if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
-    - name: Install Macdeploy Qt
-      run: |
-        cp $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qttools/bin/macdeployqt $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin/macdeployqt
-        strip $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin/macdeployqt
-      if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
-    - name: Install Linuxdeployqt
-      run: |
-        curl -L https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage -o linuxdeployqt-6-x86_64.AppImage
-        chmod a+x linuxdeployqt-6-x86_64.AppImage
-      if: matrix.os == 'ubuntu-18.04'
-    - name: Install Linux packages
-      run: |
-        sudo apt-get update
-        sudo apt-get install libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libatspi2.0-dev
-      if: matrix.os == 'ubuntu-16.04' || matrix.os == 'ubuntu-18.04'
-    - name: Install libde265
-      run: |
-        curl -L https://github.com/ChristianFeldmann/libde265/releases/download/v1.1/${{matrix.LIBDE265_REMOTE}} -o ${{matrix.LIBDE265_LOCAL}}
-        curl -L https://raw.githubusercontent.com/ChristianFeldmann/libde265/master/COPYING -o libde265License.txt
-      shell: bash
-    - name: Build Linux/Mac
-      run: |
-        cd $GITHUB_WORKSPACE
-        export PATH=$GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin:$PATH
-        mkdir build
-        cd build
-        qmake CONFIG+=UNITTESTS ..
-        make -j 2
-        make check
-    - name: Build App (Mac)
-      run: |
-        macdeployqt build/YUViewApp/YUView.app -always-overwrite -verbose=2
-        cp ${{matrix.LIBDE265_LOCAL}} build/YUViewApp/YUView.app/Contents/MacOS/.
-        cd build/YUViewApp
-        # Zip
-        zip -r ${{matrix.ARTIFACT_NAME}} YUView.app/
-        mkdir $GITHUB_WORKSPACE/artifacts
-        cp ${{matrix.ARTIFACT_NAME}} $GITHUB_WORKSPACE/artifacts/
-      if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
-    - name: Build Appimage (Linux)
-      run: |
-        cd build
-        make INSTALL_ROOT=appdir install
-        $GITHUB_WORKSPACE/linuxdeployqt-6-x86_64.AppImage YUViewApp/appdir/usr/local/share/applications/de.rwth_aachen.ient.YUView.desktop -appimage -bundle-non-qt-libs -verbose=2
-        mv YUView-*.AppImage YUView.AppImage
-        mkdir $GITHUB_WORKSPACE/artifacts
-        cp YUView.AppImage $GITHUB_WORKSPACE/artifacts/
-        cd $GITHUB_WORKSPACE
-        ls -l
-        cd $GITHUB_WORKSPACE/artifacts
-        ls -l
-      if: matrix.os == 'ubuntu-18.04'
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{matrix.ARTIFACT_NAME}}
-        path: artifacts
-    - name: Upload Release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: artifacts/${{matrix.ARTIFACT_NAME}}
-        asset_name: ${{matrix.ARTIFACT_NAME}}
-        asset_content_type: application/zip
-      if: github.event_name == 'release'
-  build-windows:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include: 
-          - os: windows-2019
-            auto_update: true
-            ARTIFACT_NAME: YUView-Win.zip
-          - os: windows-2019
-            auto_update: false
-            ARTIFACT_NAME: YUView-Win-noautoupdate.zip
-    steps:
-    - uses: actions/checkout@v2
-    - run: git fetch --prune --unshallow
-    - name: Install Qt base
-      run: |
-        cd ../../
-        mkdir -p YUViewQt/YUViewQt
-        cd YUViewQt/YUViewQt
-        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtBase-5.15.1/qtBase_5.15.1_win.zip -o Qt.zip
-        7z x  Qt.zip
-        echo "${{ github.workspace }}\..\..\YUViewQt\YUViewQt\Qt\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-    - name: Install Qt deploy tools
-      run: |
-        cd ../../YUViewQt/YUViewQt
-        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtDeployTools-5.15.1/qtTools_5.15.1_win.zip -o deployQt.zip
-        7z x deployQt.zip
-    - name: Install libde265
-      run: |
-        curl -L https://github.com/ChristianFeldmann/libde265/releases/download/v1.1/libde265.dll -o libde265.dll
-        curl -L https://raw.githubusercontent.com/ChristianFeldmann/libde265/master/COPYING -o libde265License.txt
-    - name: Install jom
-      run: |
-        Get-Location
-        curl -L https://github.com/ChristianFeldmann/jom/releases/download/v1.1.3-build/jom.exe -o jom.exe
-        cp jom.exe ../../YUViewQt/YUViewQt/Qt/bin/
-    - name: Install openSSL
-      run: |
-        mkdir openSSL
-        cd openSSL
-        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/openSSL1.1.1g/openSSL_1_1_1g_win.zip -o openSSL.zip
-        7z x openSSL.zip
-        cd ..
-    - name: Activate auto update
-      run: sed -i -- "s/#define UPDATE_FEATURE_ENABLE 0/#define UPDATE_FEATURE_ENABLE 1/g" YUViewLib/src/common/Typedef.h
-      shell: bash
-      if: matrix.auto_update == true
-    - name: Set up Visual Studio shell
-      uses: egor-tensin/vs-shell@v2
-    - name: Build
-      run: |
-        mkdir build
-        cd build
-        d:\a\YUViewQt\YUViewQt\Qt\bin\qmake CONFIG+=UNITTESTS ..
-        jom
-    - name: Run tests
-      run: |
-        cd build
-        nmake check
-        cd ..
-    - name: WindeployQT
-      run: |
-        mkdir deploy
-        cd deploy
-        cp ../build/YUViewApp/YUView.exe .
-        d:\a\YUViewQt\YUViewQt\Qttools\bin\windeployqt.exe --release --no-compiler-runtime YUView.exe
-        cp ../openSSL/*.dll .
-        mkdir decoder
-        cp ..\libde265.dll decoder
-        cp ..\libde265License.txt decoder
-        cp ../LICENSE.GPL3 .
-        cd ..
-        python deployment/versioning.py -d deploy -o deploy/versioninfo.txt
-        mkdir artifacts
-        7z a artifacts/YUView-Win.zip ./deploy/*
-    - name: Wix Windows
-      run: |
-        cd ${{ github.workspace }}/deployment/wix
-        cp 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\v142\MergeModules\Microsoft_VC142_CRT_x64.msm' .
-        & "${{ env.WIX }}\bin\heat.exe" dir ../../deploy -gg -dr APPLICATIONFOLDER -srd -sreg -cg YUViewComponents -out harvestedDirectory.wxs
-        & "${{ env.WIX }}\bin\candle.exe" -dConfiguration=Release -dOutDir=bin/Release/ '-dTargetExt=.msi' '-dTargetFileName=YUViewSetup.msi' -dTargetName=YUViewSetup -out obj/Release/ -arch x64 -ext "${{ env.WIX }}\bin\WixUIExtension.dll" YUView.wxs
-        & "${{ env.WIX }}\bin\candle.exe" -dConfiguration=Release -dOutDir=bin/Release/ '-dTargetExt=.msi' '-dTargetFileName=YUViewSetup.msi' -dTargetName=YUViewSetup -out obj/Release/ -arch x64 harvestedDirectory.wxs
-        & "${{ env.WIX }}\bin\Light.exe" -b ../../deploy -out bin/Release/YUViewSetup.msi -pdbout bin/Release/YUViewSetup.wixpdb -cultures:null -ext "${{ env.WIX }}\bin\WixUIExtension.dll" -contentsfile obj/Release/YUViewSetup.wixproj.BindContentsFileListnull.txt -outputsfile obj/Release/YUViewSetup.wixproj.BindOutputsFileListnull.txt -builtoutputsfile obj/Release/YUViewSetup.wixproj.BindBuiltOutputsFileListnull.txt obj/Release/YUView.wixobj obj/Release/harvestedDirectory.wixobj
-        cd ${{ github.workspace }}
-        cp deployment/wix/bin/Release/YUViewSetup.msi ./
-      if: matrix.auto_update == true
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{matrix.ARTIFACT_NAME}}
-        path: artifacts
-    - name: Upload Windows installer Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: YUViewSetup.msi
-        path: ./YUViewSetup.msi
-      if: matrix.auto_update == true
-    - name: Upload Windows zip to Release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: artifacts/YUView-Win.zip
-        asset_name: ${{matrix.ARTIFACT_NAME}}
-        asset_content_type: application/zip
-      if: github.event_name == 'release'
-    - name: Upload Windows installer to Release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: YUViewSetup.msi
-        asset_name: YUViewSetup.msi
-        asset_content_type: application/zip
-      if: github.event_name == 'release' && matrix.auto_update == true
+  # build-unix:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       include: 
+  #         - os: ubuntu-18.04
+  #           QT_FILE: qtBase_5.15.1_bionic.zip
+  #           LIBDE265_REMOTE: libde265.so
+  #           LIBDE265_LOCAL: libde265-internals.so
+  #           ARTIFACT_NAME: YUView.AppImage
+  #         - os: macos-10.15
+  #           QT_FILE: qtBase_5.15.1_mac.zip
+  #           LIBDE265_REMOTE: libde265.dylib
+  #           LIBDE265_LOCAL: libde265-internals.dylib
+  #           ARTIFACT_NAME: YUView-Mac.zip
+  #         - os: macos-11.0
+  #           QT_FILE: qtBase_5.15.1_mac.zip
+  #           LIBDE265_REMOTE: libde265.dylib
+  #           LIBDE265_LOCAL: libde265-internals.dylib
+  #           ARTIFACT_NAME: YUView-Mac-BigSur.zip
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - run: git fetch --prune --unshallow
+  #   - name: Install Qt base
+  #     run: |
+  #       cd ../../
+  #       mkdir -p YUViewQt/YUViewQt
+  #       cd YUViewQt/YUViewQt
+  #       curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtBase-5.15.1/${{matrix.QT_FILE}} -o Qt.zip
+  #       unzip -qa Qt.zip
+  #       echo "$GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin" >> $GITHUB_PATH
+  #     shell: bash
+  #   - name: Install MacDeployQT
+  #     run: |
+  #       cd $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt
+  #       curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtDeployTools-5.15.1/qtTools_5.15.1_mac.zip -o deployQt.zip
+  #       unzip -qa deployQt.zip
+  #     shell: bash
+  #     if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
+  #   - name: Install Macdeploy Qt
+  #     run: |
+  #       cp $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qttools/bin/macdeployqt $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin/macdeployqt
+  #       strip $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin/macdeployqt
+  #     if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
+  #   - name: Install Linuxdeployqt
+  #     run: |
+  #       curl -L https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage -o linuxdeployqt-6-x86_64.AppImage
+  #       chmod a+x linuxdeployqt-6-x86_64.AppImage
+  #     if: matrix.os == 'ubuntu-18.04'
+  #   - name: Install Linux packages
+  #     run: |
+  #       sudo apt-get update
+  #       sudo apt-get install libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libatspi2.0-dev
+  #     if: matrix.os == 'ubuntu-16.04' || matrix.os == 'ubuntu-18.04'
+  #   - name: Install libde265
+  #     run: |
+  #       curl -L https://github.com/ChristianFeldmann/libde265/releases/download/v1.1/${{matrix.LIBDE265_REMOTE}} -o ${{matrix.LIBDE265_LOCAL}}
+  #       curl -L https://raw.githubusercontent.com/ChristianFeldmann/libde265/master/COPYING -o libde265License.txt
+  #     shell: bash
+  #   - name: Build Linux/Mac
+  #     run: |
+  #       cd $GITHUB_WORKSPACE
+  #       export PATH=$GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin:$PATH
+  #       mkdir build
+  #       cd build
+  #       qmake CONFIG+=UNITTESTS ..
+  #       make -j 2
+  #       make check
+  #   - name: Build App (Mac)
+  #     run: |
+  #       macdeployqt build/YUViewApp/YUView.app -always-overwrite -verbose=2
+  #       cp ${{matrix.LIBDE265_LOCAL}} build/YUViewApp/YUView.app/Contents/MacOS/.
+  #       cd build/YUViewApp
+  #       # Zip
+  #       zip -r ${{matrix.ARTIFACT_NAME}} YUView.app/
+  #       mkdir $GITHUB_WORKSPACE/artifacts
+  #       cp ${{matrix.ARTIFACT_NAME}} $GITHUB_WORKSPACE/artifacts/
+  #     if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
+  #   - name: Build Appimage (Linux)
+  #     run: |
+  #       cd build
+  #       make INSTALL_ROOT=appdir install
+  #       $GITHUB_WORKSPACE/linuxdeployqt-6-x86_64.AppImage YUViewApp/appdir/usr/local/share/applications/de.rwth_aachen.ient.YUView.desktop -appimage -bundle-non-qt-libs -verbose=2
+  #       mv YUView-*.AppImage YUView.AppImage
+  #       mkdir $GITHUB_WORKSPACE/artifacts
+  #       cp YUView.AppImage $GITHUB_WORKSPACE/artifacts/
+  #       cd $GITHUB_WORKSPACE
+  #       ls -l
+  #       cd $GITHUB_WORKSPACE/artifacts
+  #       ls -l
+  #     if: matrix.os == 'ubuntu-18.04'
+  #   - name: Upload Artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{matrix.ARTIFACT_NAME}}
+  #       path: artifacts
+  #   - name: Upload Release
+  #     uses: actions/upload-release-asset@v1.0.1
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     with:
+  #       upload_url: ${{ github.event.release.upload_url }}
+  #       asset_path: artifacts/${{matrix.ARTIFACT_NAME}}
+  #       asset_name: ${{matrix.ARTIFACT_NAME}}
+  #       asset_content_type: application/zip
+  #     if: github.event_name == 'release'
+  # build-windows:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       include: 
+  #         - os: windows-2019
+  #           auto_update: true
+  #           ARTIFACT_NAME: YUView-Win.zip
+  #         - os: windows-2019
+  #           auto_update: false
+  #           ARTIFACT_NAME: YUView-Win-noautoupdate.zip
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - run: git fetch --prune --unshallow
+  #   - name: Install Qt base
+  #     run: |
+  #       cd ../../
+  #       mkdir -p YUViewQt/YUViewQt
+  #       cd YUViewQt/YUViewQt
+  #       curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtBase-5.15.1/qtBase_5.15.1_win.zip -o Qt.zip
+  #       7z x  Qt.zip
+  #       echo "${{ github.workspace }}\..\..\YUViewQt\YUViewQt\Qt\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+  #   - name: Install Qt deploy tools
+  #     run: |
+  #       cd ../../YUViewQt/YUViewQt
+  #       curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtDeployTools-5.15.1/qtTools_5.15.1_win.zip -o deployQt.zip
+  #       7z x deployQt.zip
+  #   - name: Install libde265
+  #     run: |
+  #       curl -L https://github.com/ChristianFeldmann/libde265/releases/download/v1.1/libde265.dll -o libde265.dll
+  #       curl -L https://raw.githubusercontent.com/ChristianFeldmann/libde265/master/COPYING -o libde265License.txt
+  #   - name: Install jom
+  #     run: |
+  #       Get-Location
+  #       curl -L https://github.com/ChristianFeldmann/jom/releases/download/v1.1.3-build/jom.exe -o jom.exe
+  #       cp jom.exe ../../YUViewQt/YUViewQt/Qt/bin/
+  #   - name: Install openSSL
+  #     run: |
+  #       mkdir openSSL
+  #       cd openSSL
+  #       curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/openSSL1.1.1g/openSSL_1_1_1g_win.zip -o openSSL.zip
+  #       7z x openSSL.zip
+  #       cd ..
+  #   - name: Activate auto update
+  #     run: sed -i -- "s/#define UPDATE_FEATURE_ENABLE 0/#define UPDATE_FEATURE_ENABLE 1/g" YUViewLib/src/common/Typedef.h
+  #     shell: bash
+  #     if: matrix.auto_update == true
+  #   - name: Set up Visual Studio shell
+  #     uses: egor-tensin/vs-shell@v2
+  #   - name: Build
+  #     run: |
+  #       mkdir build
+  #       cd build
+  #       d:\a\YUViewQt\YUViewQt\Qt\bin\qmake CONFIG+=UNITTESTS ..
+  #       jom
+  #   - name: Run tests
+  #     run: |
+  #       cd build
+  #       nmake check
+  #       cd ..
+  #   - name: WindeployQT
+  #     run: |
+  #       mkdir deploy
+  #       cd deploy
+  #       cp ../build/YUViewApp/YUView.exe .
+  #       d:\a\YUViewQt\YUViewQt\Qttools\bin\windeployqt.exe --release --no-compiler-runtime YUView.exe
+  #       cp ../openSSL/*.dll .
+  #       mkdir decoder
+  #       cp ..\libde265.dll decoder
+  #       cp ..\libde265License.txt decoder
+  #       cp ../LICENSE.GPL3 .
+  #       cd ..
+  #       python deployment/versioning.py -d deploy -o deploy/versioninfo.txt
+  #       mkdir artifacts
+  #       7z a artifacts/YUView-Win.zip ./deploy/*
+  #   - name: Wix Windows
+  #     run: |
+  #       cd ${{ github.workspace }}/deployment/wix
+  #       cp 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\v142\MergeModules\Microsoft_VC142_CRT_x64.msm' .
+  #       & "${{ env.WIX }}\bin\heat.exe" dir ../../deploy -gg -dr APPLICATIONFOLDER -srd -sreg -cg YUViewComponents -out harvestedDirectory.wxs
+  #       & "${{ env.WIX }}\bin\candle.exe" -dConfiguration=Release -dOutDir=bin/Release/ '-dTargetExt=.msi' '-dTargetFileName=YUViewSetup.msi' -dTargetName=YUViewSetup -out obj/Release/ -arch x64 -ext "${{ env.WIX }}\bin\WixUIExtension.dll" YUView.wxs
+  #       & "${{ env.WIX }}\bin\candle.exe" -dConfiguration=Release -dOutDir=bin/Release/ '-dTargetExt=.msi' '-dTargetFileName=YUViewSetup.msi' -dTargetName=YUViewSetup -out obj/Release/ -arch x64 harvestedDirectory.wxs
+  #       & "${{ env.WIX }}\bin\Light.exe" -b ../../deploy -out bin/Release/YUViewSetup.msi -pdbout bin/Release/YUViewSetup.wixpdb -cultures:null -ext "${{ env.WIX }}\bin\WixUIExtension.dll" -contentsfile obj/Release/YUViewSetup.wixproj.BindContentsFileListnull.txt -outputsfile obj/Release/YUViewSetup.wixproj.BindOutputsFileListnull.txt -builtoutputsfile obj/Release/YUViewSetup.wixproj.BindBuiltOutputsFileListnull.txt obj/Release/YUView.wixobj obj/Release/harvestedDirectory.wixobj
+  #       cd ${{ github.workspace }}
+  #       cp deployment/wix/bin/Release/YUViewSetup.msi ./
+  #     if: matrix.auto_update == true
+  #   - name: Upload Artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{matrix.ARTIFACT_NAME}}
+  #       path: artifacts
+  #   - name: Upload Windows installer Artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: YUViewSetup.msi
+  #       path: ./YUViewSetup.msi
+  #     if: matrix.auto_update == true
+  #   - name: Upload Windows zip to Release
+  #     uses: actions/upload-release-asset@v1.0.1
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     with:
+  #       upload_url: ${{ github.event.release.upload_url }}
+  #       asset_path: artifacts/YUView-Win.zip
+  #       asset_name: ${{matrix.ARTIFACT_NAME}}
+  #       asset_content_type: application/zip
+  #     if: github.event_name == 'release'
+  #   - name: Upload Windows installer to Release
+  #     uses: actions/upload-release-asset@v1.0.1
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     with:
+  #       upload_url: ${{ github.event.release.upload_url }}
+  #       asset_path: YUViewSetup.msi
+  #       asset_name: YUViewSetup.msi
+  #       asset_content_type: application/zip
+  #     if: github.event_name == 'release' && matrix.auto_update == true
     
   # How to upload files to the release:
   # https://github.com/Blacksmoke16/oq/pull/47/files#diff-082c28d748ad2e3eecc5508d740d9417R9-R29

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -13,21 +13,27 @@ jobs:
       matrix:
         include: 
           #- os: ubuntu-18.04
+             INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
+             QMAKE_COMMAND: qmake
           #- os: ubuntu-20.04
+             INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
+             QMAKE_COMMAND: qmake
           - os: ubuntu-22.04
+            INSTALL_LIBS: qt6-base-dev
+            QMAKE_COMMAND: qmake6
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow
     - name: Install Linux packages
       run: |
         sudo apt-get update
-        sudo apt-get install libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
+        sudo apt-get install ${{matrix.INSTALL_LIBS}}
     - name: Build
       run: |
         cd $GITHUB_WORKSPACE
         mkdir build
         cd build
-        qmake CONFIG+=UNITTESTS ..
+        ${{matrix.QMAKE_COMMAND}} CONFIG+=UNITTESTS ..
         make -j 2
         make check
   # build-unix:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -125,7 +125,7 @@ jobs:
         mkdir build
         cd build
         qmake CONFIG+=UNITTESTS ..
-        make -j ${{matrix.CPU_COUNT_COMMAND}}
+        make -j $(${{matrix.CPU_COUNT_COMMAND}})
         make check
     - name: Build App (Mac)
       run: |

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -22,7 +22,7 @@ jobs:
   #           INSTALL_LIBS: qt6-base-dev
   #           QMAKE_COMMAND: qmake6
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v3
   #   - run: git fetch --prune --unshallow
   #   - name: Install Linux packages
   #     run: |
@@ -34,7 +34,7 @@ jobs:
   #       mkdir build
   #       cd build
   #       ${{matrix.QMAKE_COMMAND}} CONFIG+=UNITTESTS ..
-  #       make -j 2
+  #       make -j$(nproc)
   #       make check
   build-mac-native:
     runs-on: ${{ matrix.os }}
@@ -43,7 +43,7 @@ jobs:
         include: 
           - os: macos-12
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: git fetch --prune --unshallow
     - name: Install packages
       run: |
@@ -53,7 +53,7 @@ jobs:
         cd $GITHUB_WORKSPACE
         mkdir build
         cd build
-        qmake CONFIG+=UNITTESTS ..
+        qmake6 CONFIG+=UNITTESTS ..
         make -j $(sysctl -n hw.logicalcpu)
         make check
   # build-unix:
@@ -77,7 +77,7 @@ jobs:
   #           LIBDE265_LOCAL: libde265-internals.dylib
   #           ARTIFACT_NAME: YUView-Mac-BigSur.zip
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v3
   #   - run: git fetch --prune --unshallow
   #   - name: Install Qt base
   #     run: |
@@ -174,7 +174,7 @@ jobs:
   #           auto_update: false
   #           ARTIFACT_NAME: YUView-Win-noautoupdate.zip
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v3
   #   - run: git fetch --prune --unshallow
   #   - name: Install Qt base
   #     run: |

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -7,35 +7,35 @@ on:
       - created
 
 jobs:
-  # build-unix-native:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       include: 
-  #         - os: ubuntu-18.04
-  #           INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
-  #           QMAKE_COMMAND: qmake
-  #         - os: ubuntu-20.04
-  #           INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
-  #           QMAKE_COMMAND: qmake
-  #         - os: ubuntu-22.04
-  #           INSTALL_LIBS: qt6-base-dev
-  #           QMAKE_COMMAND: qmake6
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - run: git fetch --prune --unshallow
-  #   - name: Install Linux packages
-  #     run: |
-  #       sudo apt-get update
-  #       sudo apt-get install ${{matrix.INSTALL_LIBS}}
-  #   - name: Build
-  #     run: |
-  #       cd $GITHUB_WORKSPACE
-  #       mkdir build
-  #       cd build
-  #       ${{matrix.QMAKE_COMMAND}} CONFIG+=UNITTESTS ..
-  #       make -j$(nproc)
-  #       make check
+  build-unix-native:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include: 
+          - os: ubuntu-18.04
+            INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
+            QMAKE_COMMAND: qmake
+          - os: ubuntu-20.04
+            INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
+            QMAKE_COMMAND: qmake
+          - os: ubuntu-22.04
+            INSTALL_LIBS: qt6-base-dev
+            QMAKE_COMMAND: qmake6
+    steps:
+    - uses: actions/checkout@v3
+    - run: git fetch --prune --unshallow
+    - name: Install Linux packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install ${{matrix.INSTALL_LIBS}}
+    - name: Build
+      run: |
+        cd $GITHUB_WORKSPACE
+        mkdir build
+        cd build
+        ${{matrix.QMAKE_COMMAND}} CONFIG+=UNITTESTS ..
+        make -j$(nproc)
+        make check
   build-mac-native:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -56,229 +56,232 @@ jobs:
         qmake6 CONFIG+=UNITTESTS ..
         make -j $(sysctl -n hw.logicalcpu)
         make check
-  # build-unix:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       include: 
-  #         - os: ubuntu-18.04
-  #           QT_FILE: qtBase_5.15.1_bionic.zip
-  #           LIBDE265_REMOTE: libde265.so
-  #           LIBDE265_LOCAL: libde265-internals.so
-  #           ARTIFACT_NAME: YUView.AppImage
-  #         - os: macos-10.15
-  #           QT_FILE: qtBase_5.15.1_mac.zip
-  #           LIBDE265_REMOTE: libde265.dylib
-  #           LIBDE265_LOCAL: libde265-internals.dylib
-  #           ARTIFACT_NAME: YUView-Mac.zip
-  #         - os: macos-11.0
-  #           QT_FILE: qtBase_5.15.1_mac.zip
-  #           LIBDE265_REMOTE: libde265.dylib
-  #           LIBDE265_LOCAL: libde265-internals.dylib
-  #           ARTIFACT_NAME: YUView-Mac-BigSur.zip
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - run: git fetch --prune --unshallow
-  #   - name: Install Qt base
-  #     run: |
-  #       cd ../../
-  #       mkdir -p YUViewQt/YUViewQt
-  #       cd YUViewQt/YUViewQt
-  #       curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtBase-5.15.1/${{matrix.QT_FILE}} -o Qt.zip
-  #       unzip -qa Qt.zip
-  #       echo "$GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin" >> $GITHUB_PATH
-  #     shell: bash
-  #   - name: Install MacDeployQT
-  #     run: |
-  #       cd $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt
-  #       curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtDeployTools-5.15.1/qtTools_5.15.1_mac.zip -o deployQt.zip
-  #       unzip -qa deployQt.zip
-  #     shell: bash
-  #     if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
-  #   - name: Install Macdeploy Qt
-  #     run: |
-  #       cp $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qttools/bin/macdeployqt $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin/macdeployqt
-  #       strip $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin/macdeployqt
-  #     if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
-  #   - name: Install Linuxdeployqt
-  #     run: |
-  #       curl -L https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage -o linuxdeployqt-6-x86_64.AppImage
-  #       chmod a+x linuxdeployqt-6-x86_64.AppImage
-  #     if: matrix.os == 'ubuntu-18.04'
-  #   - name: Install Linux packages
-  #     run: |
-  #       sudo apt-get update
-  #       sudo apt-get install libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libatspi2.0-dev
-  #     if: matrix.os == 'ubuntu-16.04' || matrix.os == 'ubuntu-18.04'
-  #   - name: Install libde265
-  #     run: |
-  #       curl -L https://github.com/ChristianFeldmann/libde265/releases/download/v1.1/${{matrix.LIBDE265_REMOTE}} -o ${{matrix.LIBDE265_LOCAL}}
-  #       curl -L https://raw.githubusercontent.com/ChristianFeldmann/libde265/master/COPYING -o libde265License.txt
-  #     shell: bash
-  #   - name: Build Linux/Mac
-  #     run: |
-  #       cd $GITHUB_WORKSPACE
-  #       export PATH=$GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin:$PATH
-  #       mkdir build
-  #       cd build
-  #       qmake CONFIG+=UNITTESTS ..
-  #       make -j 2
-  #       make check
-  #   - name: Build App (Mac)
-  #     run: |
-  #       macdeployqt build/YUViewApp/YUView.app -always-overwrite -verbose=2
-  #       cp ${{matrix.LIBDE265_LOCAL}} build/YUViewApp/YUView.app/Contents/MacOS/.
-  #       cd build/YUViewApp
-  #       # Zip
-  #       zip -r ${{matrix.ARTIFACT_NAME}} YUView.app/
-  #       mkdir $GITHUB_WORKSPACE/artifacts
-  #       cp ${{matrix.ARTIFACT_NAME}} $GITHUB_WORKSPACE/artifacts/
-  #     if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
-  #   - name: Build Appimage (Linux)
-  #     run: |
-  #       cd build
-  #       make INSTALL_ROOT=appdir install
-  #       $GITHUB_WORKSPACE/linuxdeployqt-6-x86_64.AppImage YUViewApp/appdir/usr/local/share/applications/de.rwth_aachen.ient.YUView.desktop -appimage -bundle-non-qt-libs -verbose=2
-  #       mv YUView-*.AppImage YUView.AppImage
-  #       mkdir $GITHUB_WORKSPACE/artifacts
-  #       cp YUView.AppImage $GITHUB_WORKSPACE/artifacts/
-  #       cd $GITHUB_WORKSPACE
-  #       ls -l
-  #       cd $GITHUB_WORKSPACE/artifacts
-  #       ls -l
-  #     if: matrix.os == 'ubuntu-18.04'
-  #   - name: Upload Artifact
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       name: ${{matrix.ARTIFACT_NAME}}
-  #       path: artifacts
-  #   - name: Upload Release
-  #     uses: actions/upload-release-asset@v1.0.1
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     with:
-  #       upload_url: ${{ github.event.release.upload_url }}
-  #       asset_path: artifacts/${{matrix.ARTIFACT_NAME}}
-  #       asset_name: ${{matrix.ARTIFACT_NAME}}
-  #       asset_content_type: application/zip
-  #     if: github.event_name == 'release'
-  # build-windows:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       include: 
-  #         - os: windows-2019
-  #           auto_update: true
-  #           ARTIFACT_NAME: YUView-Win.zip
-  #         - os: windows-2019
-  #           auto_update: false
-  #           ARTIFACT_NAME: YUView-Win-noautoupdate.zip
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - run: git fetch --prune --unshallow
-  #   - name: Install Qt base
-  #     run: |
-  #       cd ../../
-  #       mkdir -p YUViewQt/YUViewQt
-  #       cd YUViewQt/YUViewQt
-  #       curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtBase-5.15.1/qtBase_5.15.1_win.zip -o Qt.zip
-  #       7z x  Qt.zip
-  #       echo "${{ github.workspace }}\..\..\YUViewQt\YUViewQt\Qt\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-  #   - name: Install Qt deploy tools
-  #     run: |
-  #       cd ../../YUViewQt/YUViewQt
-  #       curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtDeployTools-5.15.1/qtTools_5.15.1_win.zip -o deployQt.zip
-  #       7z x deployQt.zip
-  #   - name: Install libde265
-  #     run: |
-  #       curl -L https://github.com/ChristianFeldmann/libde265/releases/download/v1.1/libde265.dll -o libde265.dll
-  #       curl -L https://raw.githubusercontent.com/ChristianFeldmann/libde265/master/COPYING -o libde265License.txt
-  #   - name: Install jom
-  #     run: |
-  #       Get-Location
-  #       curl -L https://github.com/ChristianFeldmann/jom/releases/download/v1.1.3-build/jom.exe -o jom.exe
-  #       cp jom.exe ../../YUViewQt/YUViewQt/Qt/bin/
-  #   - name: Install openSSL
-  #     run: |
-  #       mkdir openSSL
-  #       cd openSSL
-  #       curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/openSSL1.1.1g/openSSL_1_1_1g_win.zip -o openSSL.zip
-  #       7z x openSSL.zip
-  #       cd ..
-  #   - name: Activate auto update
-  #     run: sed -i -- "s/#define UPDATE_FEATURE_ENABLE 0/#define UPDATE_FEATURE_ENABLE 1/g" YUViewLib/src/common/Typedef.h
-  #     shell: bash
-  #     if: matrix.auto_update == true
-  #   - name: Set up Visual Studio shell
-  #     uses: egor-tensin/vs-shell@v2
-  #   - name: Build
-  #     run: |
-  #       mkdir build
-  #       cd build
-  #       d:\a\YUViewQt\YUViewQt\Qt\bin\qmake CONFIG+=UNITTESTS ..
-  #       jom
-  #   - name: Run tests
-  #     run: |
-  #       cd build
-  #       nmake check
-  #       cd ..
-  #   - name: WindeployQT
-  #     run: |
-  #       mkdir deploy
-  #       cd deploy
-  #       cp ../build/YUViewApp/YUView.exe .
-  #       d:\a\YUViewQt\YUViewQt\Qttools\bin\windeployqt.exe --release --no-compiler-runtime YUView.exe
-  #       cp ../openSSL/*.dll .
-  #       mkdir decoder
-  #       cp ..\libde265.dll decoder
-  #       cp ..\libde265License.txt decoder
-  #       cp ../LICENSE.GPL3 .
-  #       cd ..
-  #       python deployment/versioning.py -d deploy -o deploy/versioninfo.txt
-  #       mkdir artifacts
-  #       7z a artifacts/YUView-Win.zip ./deploy/*
-  #   - name: Wix Windows
-  #     run: |
-  #       cd ${{ github.workspace }}/deployment/wix
-  #       cp 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\v142\MergeModules\Microsoft_VC142_CRT_x64.msm' .
-  #       & "${{ env.WIX }}\bin\heat.exe" dir ../../deploy -gg -dr APPLICATIONFOLDER -srd -sreg -cg YUViewComponents -out harvestedDirectory.wxs
-  #       & "${{ env.WIX }}\bin\candle.exe" -dConfiguration=Release -dOutDir=bin/Release/ '-dTargetExt=.msi' '-dTargetFileName=YUViewSetup.msi' -dTargetName=YUViewSetup -out obj/Release/ -arch x64 -ext "${{ env.WIX }}\bin\WixUIExtension.dll" YUView.wxs
-  #       & "${{ env.WIX }}\bin\candle.exe" -dConfiguration=Release -dOutDir=bin/Release/ '-dTargetExt=.msi' '-dTargetFileName=YUViewSetup.msi' -dTargetName=YUViewSetup -out obj/Release/ -arch x64 harvestedDirectory.wxs
-  #       & "${{ env.WIX }}\bin\Light.exe" -b ../../deploy -out bin/Release/YUViewSetup.msi -pdbout bin/Release/YUViewSetup.wixpdb -cultures:null -ext "${{ env.WIX }}\bin\WixUIExtension.dll" -contentsfile obj/Release/YUViewSetup.wixproj.BindContentsFileListnull.txt -outputsfile obj/Release/YUViewSetup.wixproj.BindOutputsFileListnull.txt -builtoutputsfile obj/Release/YUViewSetup.wixproj.BindBuiltOutputsFileListnull.txt obj/Release/YUView.wixobj obj/Release/harvestedDirectory.wixobj
-  #       cd ${{ github.workspace }}
-  #       cp deployment/wix/bin/Release/YUViewSetup.msi ./
-  #     if: matrix.auto_update == true
-  #   - name: Upload Artifact
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       name: ${{matrix.ARTIFACT_NAME}}
-  #       path: artifacts
-  #   - name: Upload Windows installer Artifact
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       name: YUViewSetup.msi
-  #       path: ./YUViewSetup.msi
-  #     if: matrix.auto_update == true
-  #   - name: Upload Windows zip to Release
-  #     uses: actions/upload-release-asset@v1.0.1
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     with:
-  #       upload_url: ${{ github.event.release.upload_url }}
-  #       asset_path: artifacts/YUView-Win.zip
-  #       asset_name: ${{matrix.ARTIFACT_NAME}}
-  #       asset_content_type: application/zip
-  #     if: github.event_name == 'release'
-  #   - name: Upload Windows installer to Release
-  #     uses: actions/upload-release-asset@v1.0.1
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     with:
-  #       upload_url: ${{ github.event.release.upload_url }}
-  #       asset_path: YUViewSetup.msi
-  #       asset_name: YUViewSetup.msi
-  #       asset_content_type: application/zip
-  #     if: github.event_name == 'release' && matrix.auto_update == true
+  build-unix:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include: 
+          - os: ubuntu-18.04
+            QT_FILE: qtBase_5.15.1_bionic.zip
+            LIBDE265_REMOTE: libde265.so
+            LIBDE265_LOCAL: libde265-internals.so
+            ARTIFACT_NAME: YUView.AppImage
+            CPU_COUNT_COMMAND: nproc
+          - os: macos-10.15
+            QT_FILE: qtBase_5.15.1_mac.zip
+            LIBDE265_REMOTE: libde265.dylib
+            LIBDE265_LOCAL: libde265-internals.dylib
+            ARTIFACT_NAME: YUView-Mac.zip
+            CPU_COUNT_COMMAND: sysctl -n hw.logicalcpu
+          - os: macos-11.0
+            QT_FILE: qtBase_5.15.1_mac.zip
+            LIBDE265_REMOTE: libde265.dylib
+            LIBDE265_LOCAL: libde265-internals.dylib
+            ARTIFACT_NAME: YUView-Mac-BigSur.zip
+            CPU_COUNT_COMMAND: sysctl -n hw.logicalcpu
+    steps:
+    - uses: actions/checkout@v3
+    - run: git fetch --prune --unshallow
+    - name: Install Qt base
+      run: |
+        cd ../../
+        mkdir -p YUViewQt/YUViewQt
+        cd YUViewQt/YUViewQt
+        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtBase-5.15.1/${{matrix.QT_FILE}} -o Qt.zip
+        unzip -qa Qt.zip
+        echo "$GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin" >> $GITHUB_PATH
+      shell: bash
+    - name: Install MacDeployQT
+      run: |
+        cd $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt
+        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtDeployTools-5.15.1/qtTools_5.15.1_mac.zip -o deployQt.zip
+        unzip -qa deployQt.zip
+      shell: bash
+      if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
+    - name: Install Macdeploy Qt
+      run: |
+        cp $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qttools/bin/macdeployqt $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin/macdeployqt
+        strip $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin/macdeployqt
+      if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
+    - name: Install Linuxdeployqt
+      run: |
+        curl -L https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage -o linuxdeployqt-6-x86_64.AppImage
+        chmod a+x linuxdeployqt-6-x86_64.AppImage
+      if: matrix.os == 'ubuntu-18.04'
+    - name: Install Linux packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libatspi2.0-dev
+      if: matrix.os == 'ubuntu-16.04' || matrix.os == 'ubuntu-18.04'
+    - name: Install libde265
+      run: |
+        curl -L https://github.com/ChristianFeldmann/libde265/releases/download/v1.1/${{matrix.LIBDE265_REMOTE}} -o ${{matrix.LIBDE265_LOCAL}}
+        curl -L https://raw.githubusercontent.com/ChristianFeldmann/libde265/master/COPYING -o libde265License.txt
+      shell: bash
+    - name: Build Linux/Mac
+      run: |
+        cd $GITHUB_WORKSPACE
+        export PATH=$GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin:$PATH
+        mkdir build
+        cd build
+        qmake CONFIG+=UNITTESTS ..
+        make -j ${{matrix.CPU_COUNT_COMMAND}}
+        make check
+    - name: Build App (Mac)
+      run: |
+        macdeployqt build/YUViewApp/YUView.app -always-overwrite -verbose=2
+        cp ${{matrix.LIBDE265_LOCAL}} build/YUViewApp/YUView.app/Contents/MacOS/.
+        cd build/YUViewApp
+        # Zip
+        zip -r ${{matrix.ARTIFACT_NAME}} YUView.app/
+        mkdir $GITHUB_WORKSPACE/artifacts
+        cp ${{matrix.ARTIFACT_NAME}} $GITHUB_WORKSPACE/artifacts/
+      if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
+    - name: Build Appimage (Linux)
+      run: |
+        cd build
+        make INSTALL_ROOT=appdir install
+        $GITHUB_WORKSPACE/linuxdeployqt-6-x86_64.AppImage YUViewApp/appdir/usr/local/share/applications/de.rwth_aachen.ient.YUView.desktop -appimage -bundle-non-qt-libs -verbose=2
+        mv YUView-*.AppImage YUView.AppImage
+        mkdir $GITHUB_WORKSPACE/artifacts
+        cp YUView.AppImage $GITHUB_WORKSPACE/artifacts/
+        cd $GITHUB_WORKSPACE
+        ls -l
+        cd $GITHUB_WORKSPACE/artifacts
+        ls -l
+      if: matrix.os == 'ubuntu-18.04'
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{matrix.ARTIFACT_NAME}}
+        path: artifacts
+    - name: Upload Release
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: artifacts/${{matrix.ARTIFACT_NAME}}
+        asset_name: ${{matrix.ARTIFACT_NAME}}
+        asset_content_type: application/zip
+      if: github.event_name == 'release'
+  build-windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include: 
+          - os: windows-2019
+            auto_update: true
+            ARTIFACT_NAME: YUView-Win.zip
+          - os: windows-2019
+            auto_update: false
+            ARTIFACT_NAME: YUView-Win-noautoupdate.zip
+    steps:
+    - uses: actions/checkout@v3
+    - run: git fetch --prune --unshallow
+    - name: Install Qt base
+      run: |
+        cd ../../
+        mkdir -p YUViewQt/YUViewQt
+        cd YUViewQt/YUViewQt
+        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtBase-5.15.1/qtBase_5.15.1_win.zip -o Qt.zip
+        7z x  Qt.zip
+        echo "${{ github.workspace }}\..\..\YUViewQt\YUViewQt\Qt\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    - name: Install Qt deploy tools
+      run: |
+        cd ../../YUViewQt/YUViewQt
+        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtDeployTools-5.15.1/qtTools_5.15.1_win.zip -o deployQt.zip
+        7z x deployQt.zip
+    - name: Install libde265
+      run: |
+        curl -L https://github.com/ChristianFeldmann/libde265/releases/download/v1.1/libde265.dll -o libde265.dll
+        curl -L https://raw.githubusercontent.com/ChristianFeldmann/libde265/master/COPYING -o libde265License.txt
+    - name: Install jom
+      run: |
+        Get-Location
+        curl -L https://github.com/ChristianFeldmann/jom/releases/download/v1.1.3-build/jom.exe -o jom.exe
+        cp jom.exe ../../YUViewQt/YUViewQt/Qt/bin/
+    - name: Install openSSL
+      run: |
+        mkdir openSSL
+        cd openSSL
+        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/openSSL1.1.1g/openSSL_1_1_1g_win.zip -o openSSL.zip
+        7z x openSSL.zip
+        cd ..
+    - name: Activate auto update
+      run: sed -i -- "s/#define UPDATE_FEATURE_ENABLE 0/#define UPDATE_FEATURE_ENABLE 1/g" YUViewLib/src/common/Typedef.h
+      shell: bash
+      if: matrix.auto_update == true
+    - name: Set up Visual Studio shell
+      uses: egor-tensin/vs-shell@v2
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        d:\a\YUViewQt\YUViewQt\Qt\bin\qmake CONFIG+=UNITTESTS ..
+        jom
+    - name: Run tests
+      run: |
+        cd build
+        nmake check
+        cd ..
+    - name: WindeployQT
+      run: |
+        mkdir deploy
+        cd deploy
+        cp ../build/YUViewApp/YUView.exe .
+        d:\a\YUViewQt\YUViewQt\Qttools\bin\windeployqt.exe --release --no-compiler-runtime YUView.exe
+        cp ../openSSL/*.dll .
+        mkdir decoder
+        cp ..\libde265.dll decoder
+        cp ..\libde265License.txt decoder
+        cp ../LICENSE.GPL3 .
+        cd ..
+        python deployment/versioning.py -d deploy -o deploy/versioninfo.txt
+        mkdir artifacts
+        7z a artifacts/YUView-Win.zip ./deploy/*
+    - name: Wix Windows
+      run: |
+        cd ${{ github.workspace }}/deployment/wix
+        cp 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\v142\MergeModules\Microsoft_VC142_CRT_x64.msm' .
+        & "${{ env.WIX }}\bin\heat.exe" dir ../../deploy -gg -dr APPLICATIONFOLDER -srd -sreg -cg YUViewComponents -out harvestedDirectory.wxs
+        & "${{ env.WIX }}\bin\candle.exe" -dConfiguration=Release -dOutDir=bin/Release/ '-dTargetExt=.msi' '-dTargetFileName=YUViewSetup.msi' -dTargetName=YUViewSetup -out obj/Release/ -arch x64 -ext "${{ env.WIX }}\bin\WixUIExtension.dll" YUView.wxs
+        & "${{ env.WIX }}\bin\candle.exe" -dConfiguration=Release -dOutDir=bin/Release/ '-dTargetExt=.msi' '-dTargetFileName=YUViewSetup.msi' -dTargetName=YUViewSetup -out obj/Release/ -arch x64 harvestedDirectory.wxs
+        & "${{ env.WIX }}\bin\Light.exe" -b ../../deploy -out bin/Release/YUViewSetup.msi -pdbout bin/Release/YUViewSetup.wixpdb -cultures:null -ext "${{ env.WIX }}\bin\WixUIExtension.dll" -contentsfile obj/Release/YUViewSetup.wixproj.BindContentsFileListnull.txt -outputsfile obj/Release/YUViewSetup.wixproj.BindOutputsFileListnull.txt -builtoutputsfile obj/Release/YUViewSetup.wixproj.BindBuiltOutputsFileListnull.txt obj/Release/YUView.wixobj obj/Release/harvestedDirectory.wixobj
+        cd ${{ github.workspace }}
+        cp deployment/wix/bin/Release/YUViewSetup.msi ./
+      if: matrix.auto_update == true
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{matrix.ARTIFACT_NAME}}
+        path: artifacts
+    - name: Upload Windows installer Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: YUViewSetup.msi
+        path: ./YUViewSetup.msi
+      if: matrix.auto_update == true
+    - name: Upload Windows zip to Release
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: artifacts/YUView-Win.zip
+        asset_name: ${{matrix.ARTIFACT_NAME}}
+        asset_content_type: application/zip
+      if: github.event_name == 'release'
+    - name: Upload Windows installer to Release
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: YUViewSetup.msi
+        asset_name: YUViewSetup.msi
+        asset_content_type: application/zip
+      if: github.event_name == 'release' && matrix.auto_update == true
     
   # How to upload files to the release:
   # https://github.com/Blacksmoke16/oq/pull/47/files#diff-082c28d748ad2e3eecc5508d740d9417R9-R29

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -44,11 +44,11 @@ jobs:
             LIBDE265_REMOTE: libde265.dylib
             LIBDE265_LOCAL: libde265-internals.dylib
             ARTIFACT_NAME: YUView-Mac.zip
-          # - os: macos-11.0
-          #   QT_FILE: qtBase_5.15.1_mac.zip
-          #   LIBDE265_REMOTE: libde265.dylib
-          #   LIBDE265_LOCAL: libde265-internals.dylib
-          #   ARTIFACT_NAME: YUView-Mac-BigSur.zip
+          - os: macos-11.0
+            QT_FILE: qtBase_5.15.1_mac.zip
+            LIBDE265_REMOTE: libde265.dylib
+            LIBDE265_LOCAL: libde265-internals.dylib
+            ARTIFACT_NAME: YUView-Mac-BigSur.zip
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow

--- a/YUViewLib/src/common/FunctionsGui.cpp
+++ b/YUViewLib/src/common/FunctionsGui.cpp
@@ -65,7 +65,7 @@ QIcon functionsGui::convertIcon(QString iconPath)
   // Get the active and inactive colors
   QStringList colors = functions::getThemeColors(themeName);
   QRgb        activeColor, inActiveColor;
-  if (colors.count() == 4)
+  if (colors.size() == 4)
   {
     QColor active(colors[1]);
     QColor inactive(colors[2]);
@@ -116,7 +116,7 @@ QPixmap functionsGui::convertPixmap(QString pixmapPath)
   // Get the active and inactive colors
   QStringList colors = functions::getThemeColors(themeName);
   QRgb        activeColor;
-  if (colors.count() == 4)
+  if (colors.size() == 4)
   {
     QColor active(colors[1]);
     activeColor = active.rgb();

--- a/YUViewLib/src/ffmpeg/AVCodecWrapper.h
+++ b/YUViewLib/src/ffmpeg/AVCodecWrapper.h
@@ -33,7 +33,8 @@
 #pragma once
 
 #include "FFMpegLibrariesTypes.h"
-#include <QList>
+
+#include <vector>
 
 namespace FFmpeg
 {

--- a/YUViewLib/src/playlistitem/playlistItemImageFileSequence.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemImageFileSequence.cpp
@@ -100,7 +100,7 @@ void playlistItemImageFileSequence::fillImageFileList(QStringList &  imageFiles,
   QString   base     = fi.baseName();
 
   int lastN = 0;
-  for (int i = base.count() - 1; i >= 0; i--)
+  for (auto i = base.size() - 1; i >= 0; i--)
   {
     // Get the char and see if it is a number
     if (base[i].isDigit())
@@ -117,7 +117,7 @@ void playlistItemImageFileSequence::fillImageFileList(QStringList &  imageFiles,
   }
 
   // The base name without the indexing number at the end
-  QString absBaseName = base.left(base.count() - lastN);
+  QString absBaseName = base.left(base.size() - lastN);
 
   // List all files in the directory and get all that have the same pattern.
   QDir                currentDir(fi.path());
@@ -171,7 +171,7 @@ InfoData playlistItemImageFileSequence::getInfo() const
   if (this->video->isFormatValid())
   {
     auto videoSize = this->video->getFrameSize();
-    auto  nrFrames  = this->imageFiles.size();
+    auto nrFrames  = this->imageFiles.size();
     info.items.append(InfoItem("Num Frames", QString::number(nrFrames)));
     info.items.append(InfoItem("Resolution",
                                QString("%1x%2").arg(videoSize.width).arg(videoSize.height),
@@ -305,7 +305,7 @@ void playlistItemImageFileSequence::setInternals(const QString &filePath)
   // Open frame 0 and set the size of it
   {
     QImage frame0 = QImage(imageFiles[0]);
-    auto s = frame0.size();
+    auto   s      = frame0.size();
     video->setFrameSize(Size(s.width(), s.height()));
   }
 
@@ -316,7 +316,7 @@ void playlistItemImageFileSequence::setInternals(const QString &filePath)
   QString   fileName = fi.fileName();
   QString   base     = fi.baseName();
 
-  for (int i = base.count() - 1; i >= 0; i--)
+  for (int i = base.size() - 1; i >= 0; i--)
   {
     // Get the char and see if it is a number
     if (base[i].isDigit())

--- a/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
@@ -347,8 +347,7 @@ bool playlistItemRawFile::parseY4MFile()
     while (rawData.at(offset) != ' ' && rawData.at(offset) != 10)
     {
       offset++;
-      if (offset >= rawData.count())
-        // End of bufer
+      if (offset >= rawData.size())
         break;
     }
 

--- a/YUViewLib/src/ui/Mainwindow.cpp
+++ b/YUViewLib/src/ui/Mainwindow.cpp
@@ -244,6 +244,7 @@ void MainWindow::createMenusAndActions()
                                 auto               reciever,
                                 auto               functionPointer,
                                 const QKeySequence shortcut = {}) {
+    (void)this; // QObject::connect uses this
     auto action = new QAction(name, menu);
     action->setShortcut(shortcut);
     QObject::connect(action, &QAction::triggered, reciever, functionPointer);

--- a/YUViewLib/src/ui/ViewStateHandler.h
+++ b/YUViewLib/src/ui/ViewStateHandler.h
@@ -34,6 +34,7 @@
 
 #include <QPoint>
 #include <QPointer>
+#include <QObject>
 
 class QDomElement;
 class QKeyEvent;

--- a/YUViewLib/src/ui/views/MoveAndZoomableView.cpp
+++ b/YUViewLib/src/ui/views/MoveAndZoomableView.cpp
@@ -73,15 +73,23 @@ void MoveAndZoomableView::addSlaveView(MoveAndZoomableView *view)
 
 void MoveAndZoomableView::addContextMenuActions(QMenu *menu)
 {
-  menu->addAction("Zoom to 1:1", this, &MoveAndZoomableView::resetView, Qt::CTRL | Qt::Key_0);
-  menu->addAction("Zoom to Fit", this, &MoveAndZoomableView::zoomToFit, Qt::CTRL | Qt::Key_9);
-  menu->addAction("Zoom in", this, &MoveAndZoomableView::zoomIn, Qt::CTRL | Qt::Key_Plus);
-  menu->addAction("Zoom out", this, &MoveAndZoomableView::zoomOut, Qt::CTRL | Qt::Key_Minus);
+  auto addActionToMenu =
+      [this, &menu](QString name, auto functionPointer, const QKeySequence shortcut = {}) {
+        auto action = new QAction(name, menu);
+        action->setShortcut(shortcut);
+        QObject::connect(action, &QAction::triggered, this, functionPointer);
+        menu->addAction(action);
+      };
+
+  addActionToMenu("Zoom to 1:1", &MoveAndZoomableView::resetView, Qt::CTRL | Qt::Key_0);
+  addActionToMenu("Zoom to Fit", &MoveAndZoomableView::zoomToFit, Qt::CTRL | Qt::Key_9);
+  addActionToMenu("Zoom in", &MoveAndZoomableView::zoomIn, Qt::CTRL | Qt::Key_Plus);
+  addActionToMenu("Zoom out", &MoveAndZoomableView::zoomOut, Qt::CTRL | Qt::Key_Minus);
   menu->addSeparator();
-  menu->addAction("Zoom to 50%", this, &MoveAndZoomableView::zoomTo50);
-  menu->addAction("Zoom to 100%", this, &MoveAndZoomableView::zoomTo100);
-  menu->addAction("Zoom to 200%", this, &MoveAndZoomableView::zoomTo200);
-  menu->addAction("Zoom to ...", this, &MoveAndZoomableView::zoomToCustom);
+  addActionToMenu("Zoom to 50%", &MoveAndZoomableView::zoomTo50);
+  addActionToMenu("Zoom to 100%", &MoveAndZoomableView::zoomTo100);
+  addActionToMenu("Zoom to 200%", &MoveAndZoomableView::zoomTo200);
+  addActionToMenu("Zoom to ...", &MoveAndZoomableView::zoomToCustom);
 }
 
 // Handle the key press event (if this widgets handles it). If not, return false.
@@ -259,7 +267,10 @@ void MoveAndZoomableView::keyPressEvent(QKeyEvent *event)
     QWidget::keyPressEvent(event);
 }
 
-void MoveAndZoomableView::resizeEvent(QResizeEvent *) { this->update(); }
+void MoveAndZoomableView::resizeEvent(QResizeEvent *)
+{
+  this->update();
+}
 
 void MoveAndZoomableView::updateMouseCursor()
 {
@@ -461,7 +472,7 @@ bool MoveAndZoomableView::event(QEvent *event)
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     isTouchScreenEvent = (device->type() == QInputDevice::DeviceType::TouchScreen);
 #else
-    isTouchScreenEvent      = (device->type() == QTouchDevice::TouchScreen);
+    isTouchScreenEvent = (device->type() == QTouchDevice::TouchScreen);
 #endif
   }
 

--- a/YUViewUnitTest/video/rgb/ConversionRGBTest/ConversionRGBTest.cpp
+++ b/YUViewUnitTest/video/rgb/ConversionRGBTest/ConversionRGBTest.cpp
@@ -323,11 +323,11 @@ void runTestForAllParameters(TestingFunction testingFunction)
   {
     for (const auto bitDepth : {8, 10, 12})
     {
-      for (const auto alphaMode : AlphaModeMapper.entries())
+      for (const auto &alphaMode : AlphaModeMapper.entries())
       {
-        for (const auto dataLayout : DataLayoutMapper.entries())
+        for (const auto &dataLayout : DataLayoutMapper.entries())
         {
-          for (const auto channelOrder : ChannelOrderMapper.entries())
+          for (const auto &channelOrder : ChannelOrderMapper.entries())
           {
             const PixelFormatRGB format(
                 bitDepth, dataLayout.value, channelOrder.value, alphaMode.value, endianness);
@@ -335,19 +335,19 @@ void runTestForAllParameters(TestingFunction testingFunction)
 
             for (const auto outputHasAlpha : {false, true})
             {
-              for (const auto componentScale : {ScalingPerComponent({1, 1, 1, 1}),
-                                                ScalingPerComponent({2, 1, 1, 1}),
-                                                ScalingPerComponent({1, 2, 1, 1}),
-                                                ScalingPerComponent({1, 1, 2, 1}),
-                                                ScalingPerComponent({1, 1, 1, 2}),
-                                                ScalingPerComponent({1, 8, 1, 1})})
+              for (const auto &componentScale : {ScalingPerComponent({1, 1, 1, 1}),
+                                                 ScalingPerComponent({2, 1, 1, 1}),
+                                                 ScalingPerComponent({1, 2, 1, 1}),
+                                                 ScalingPerComponent({1, 1, 2, 1}),
+                                                 ScalingPerComponent({1, 1, 1, 2}),
+                                                 ScalingPerComponent({1, 8, 1, 1})})
               {
-                for (const auto inversion : {InversionPerComponent({false, false, false, false}),
-                                             InversionPerComponent({true, false, false, false}),
-                                             InversionPerComponent({false, true, false, false}),
-                                             InversionPerComponent({false, false, true, false}),
-                                             InversionPerComponent({false, false, false, true}),
-                                             InversionPerComponent({true, true, true, true})})
+                for (const auto &inversion : {InversionPerComponent({false, false, false, false}),
+                                              InversionPerComponent({true, false, false, false}),
+                                              InversionPerComponent({false, true, false, false}),
+                                              InversionPerComponent({false, false, true, false}),
+                                              InversionPerComponent({false, false, false, true}),
+                                              InversionPerComponent({true, true, true, true})})
                 {
                   for (const auto limitedRange : {false, true})
                   {
@@ -399,11 +399,11 @@ void ConversionRGBTest::testGetPixelValue()
   {
     for (auto bitDepth : {8, 10, 12})
     {
-      for (const auto alphaMode : AlphaModeMapper.entries())
+      for (const auto &alphaMode : AlphaModeMapper.entries())
       {
-        for (const auto dataLayout : DataLayoutMapper.entries())
+        for (const auto &dataLayout : DataLayoutMapper.entries())
         {
-          for (const auto channelOrder : ChannelOrderMapper.entries())
+          for (const auto &channelOrder : ChannelOrderMapper.entries())
           {
             const PixelFormatRGB format(
                 bitDepth, dataLayout.value, channelOrder.value, alphaMode.value, endianness);


### PR DESCRIPTION
#516 
Work:
 - Add latest Ubuntu 22 as a runner on CI
 - Add macOS 12 with clang and Qt6 as a runner. This is where compilation failed
 - Fixed the failing compilation. Some headers were missing.
 - Fixed how the QActions were added. The previously used way is deprecated in Qt 6.3