### PR TITLE
Disable Chroma Dropdowns for YUV_400

### DIFF
--- a/YUViewLib/src/video/yuv/videoHandlerYUV.cpp
+++ b/YUViewLib/src/video/yuv/videoHandlerYUV.cpp
@@ -2870,7 +2870,7 @@ void videoHandlerYUV::setSrcPixelFormat(PixelFormatYUV format, bool emitSignal)
 
   if (ui.created())
   {
-    // Every time the pixel format changed, see if the interpolation combo box is enabled/disabled
+    // Every time the pixel format changed, see if the chroma combo boxes are enabled/disabled
     const bool chromaPresent = (format.getSubsampling() != Subsampling::YUV_400);
     QSignalBlocker blocker1(ui.colorComponentsComboBox);
     QSignalBlocker blocker2(ui.chromaInterpolationComboBox);

--- a/YUViewLib/src/video/yuv/videoHandlerYUV.cpp
+++ b/YUViewLib/src/video/yuv/videoHandlerYUV.cpp
@@ -2725,18 +2725,21 @@ QLayout *videoHandlerYUV::createVideoHandlerControls(bool isSizeFixed)
   ui.yuvFormatComboBox->setEnabled(!isSizeFixed);
 
   // Set all the values of the properties widget to the values of this class
+  const bool chromaPresent = (srcPixelFormat.getSubsampling() != Subsampling::YUV_400);
   ui.colorComponentsComboBox->addItems(
       functions::toQStringList(ComponentDisplayModeMapper.getNames()));
   ui.colorComponentsComboBox->setCurrentIndex(
       int(ComponentDisplayModeMapper.indexOf(this->conversionSettings.componentDisplayMode)));
+  ui.colorComponentsComboBox->setEnabled(chromaPresent);
   ui.chromaInterpolationComboBox->addItems(
       functions::toQStringList(ChromaInterpolationMapper.getNames()));
   ui.chromaInterpolationComboBox->setCurrentIndex(
       int(ChromaInterpolationMapper.indexOf(this->conversionSettings.chromaInterpolation)));
-  ui.chromaInterpolationComboBox->setEnabled(srcPixelFormat.isChromaSubsampled());
+  ui.chromaInterpolationComboBox->setEnabled(chromaPresent && srcPixelFormat.isChromaSubsampled());
   ui.colorConversionComboBox->addItems(functions::toQStringList(ColorConversionMapper.getNames()));
   ui.colorConversionComboBox->setCurrentIndex(
       int(ColorConversionMapper.indexOf(this->conversionSettings.colorConversion)));
+  ui.colorConversionComboBox->setEnabled(chromaPresent);
   ui.lumaScaleSpinBox->setValue(this->conversionSettings.mathParameters[Component::Luma].scale);
   ui.lumaOffsetSpinBox->setMaximum(1000);
   ui.lumaOffsetSpinBox->setValue(this->conversionSettings.mathParameters[Component::Luma].offset);
@@ -2868,10 +2871,15 @@ void videoHandlerYUV::setSrcPixelFormat(PixelFormatYUV format, bool emitSignal)
   if (ui.created())
   {
     // Every time the pixel format changed, see if the interpolation combo box is enabled/disabled
-    QSignalBlocker blocker1(ui.chromaInterpolationComboBox);
-    QSignalBlocker blocker2(ui.lumaOffsetSpinBox);
-    QSignalBlocker blocker3(ui.chromaOffsetSpinBox);
-    ui.chromaInterpolationComboBox->setEnabled(format.isChromaSubsampled());
+    const bool chromaPresent = (format.getSubsampling() != Subsampling::YUV_400);
+    QSignalBlocker blocker1(ui.colorComponentsComboBox);
+    QSignalBlocker blocker2(ui.chromaInterpolationComboBox);
+    QSignalBlocker blocker3(ui.colorConversionComboBox);
+    QSignalBlocker blocker4(ui.lumaOffsetSpinBox);
+    QSignalBlocker blocker5(ui.chromaOffsetSpinBox);
+    ui.colorComponentsComboBox->setEnabled(chromaPresent);
+    ui.chromaInterpolationComboBox->setEnabled(chromaPresent && format.isChromaSubsampled());
+    ui.colorConversionComboBox->setEnabled(chromaPresent);
     ui.lumaOffsetSpinBox->setValue(this->conversionSettings.mathParameters[Component::Luma].offset);
     ui.chromaOffsetSpinBox->setValue(
         this->conversionSettings.mathParameters[Component::Chroma].offset);


### PR DESCRIPTION

For YUV 4:0:0 that only has luma component, these controls have no effect:

* ui.colorComponentsComboBox
* ui.chromaInterpolationComboBox
* ui.colorConversionComboBox

![Imgur](https://i.imgur.com/FwzfO3o.png)

Graying out them can avoid ambiguity and bring better UX. Sample artifacts are availble here: https://github.com/der3318/YUView/actions/runs/5499025225.
