### PR TITLE
Deprecate Workflows of Ubuntu 18.04 and macOS 10.15

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -12,9 +12,6 @@ jobs:
     strategy:
       matrix:
         include: 
-          - os: ubuntu-18.04
-            INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
-            QMAKE_COMMAND: qmake
           - os: ubuntu-20.04
             INSTALL_LIBS: libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 qt5-default
             QMAKE_COMMAND: qmake
@@ -61,23 +58,23 @@ jobs:
     strategy:
       matrix:
         include: 
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             QT_FILE: qtBase_5.15.1_bionic.zip
             LIBDE265_REMOTE: libde265.so
             LIBDE265_LOCAL: libde265-internals.so
             ARTIFACT_NAME: YUView.AppImage
             CPU_COUNT_COMMAND: nproc
-          - os: macos-10.15
-            QT_FILE: qtBase_5.15.1_mac.zip
-            LIBDE265_REMOTE: libde265.dylib
-            LIBDE265_LOCAL: libde265-internals.dylib
-            ARTIFACT_NAME: YUView-Mac.zip
-            CPU_COUNT_COMMAND: sysctl -n hw.logicalcpu
-          - os: macos-11.0
+          - os: macos-11
             QT_FILE: qtBase_5.15.1_mac.zip
             LIBDE265_REMOTE: libde265.dylib
             LIBDE265_LOCAL: libde265-internals.dylib
             ARTIFACT_NAME: YUView-Mac-BigSur.zip
+            CPU_COUNT_COMMAND: sysctl -n hw.logicalcpu
+          - os: macos-12
+            QT_FILE: qtBase_5.15.1_mac.zip
+            LIBDE265_REMOTE: libde265.dylib
+            LIBDE265_LOCAL: libde265-internals.dylib
+            ARTIFACT_NAME: YUView-Mac-Monterey.zip
             CPU_COUNT_COMMAND: sysctl -n hw.logicalcpu
     steps:
     - uses: actions/checkout@v3
@@ -97,22 +94,22 @@ jobs:
         curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtDeployTools-5.15.1/qtTools_5.15.1_mac.zip -o deployQt.zip
         unzip -qa deployQt.zip
       shell: bash
-      if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
+      if: matrix.os == 'macos-11' || matrix.os == 'macos-12'
     - name: Install Macdeploy Qt
       run: |
         cp $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qttools/bin/macdeployqt $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin/macdeployqt
         strip $GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin/macdeployqt
-      if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
+      if: matrix.os == 'macos-11' || matrix.os == 'macos-12'
     - name: Install Linuxdeployqt
       run: |
         curl -L https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage -o linuxdeployqt-6-x86_64.AppImage
         chmod a+x linuxdeployqt-6-x86_64.AppImage
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
     - name: Install Linux packages
       run: |
         sudo apt-get update
         sudo apt-get install libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libatspi2.0-dev
-      if: matrix.os == 'ubuntu-16.04' || matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
     - name: Install libde265
       run: |
         curl -L https://github.com/ChristianFeldmann/libde265/releases/download/v1.1/${{matrix.LIBDE265_REMOTE}} -o ${{matrix.LIBDE265_LOCAL}}
@@ -136,7 +133,7 @@ jobs:
         zip -r ${{matrix.ARTIFACT_NAME}} YUView.app/
         mkdir $GITHUB_WORKSPACE/artifacts
         cp ${{matrix.ARTIFACT_NAME}} $GITHUB_WORKSPACE/artifacts/
-      if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
+      if: matrix.os == 'macos-11' || matrix.os == 'macos-12'
     - name: Build Appimage (Linux)
       run: |
         cd build
@@ -149,7 +146,7 @@ jobs:
         ls -l
         cd $GITHUB_WORKSPACE/artifacts
         ls -l
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -109,6 +109,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libgl1-mesa-dev libxkbcommon-x11-0 libpcre2-16-0 '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libatspi2.0-dev
+        curl -L http://security.ubuntu.com/ubuntu/pool/main/i/icu/libicu60_60.2-3ubuntu3.2_amd64.deb -o libicu60_60.2-3ubuntu3.2_amd64.deb
+        sudo apt-get install ./libicu60_60.2-3ubuntu3.2_amd64.deb
       if: matrix.os == 'ubuntu-20.04'
     - name: Install libde265
       run: |


### PR DESCRIPTION

The two runners are deprecated in 2023. Jobs relying on these OS will end up with message "waiting for a runner to pick up this job" and timeout:

* https://github.com/actions/runner-images/issues/6002
* https://github.com/actions/runner-images/issues/5583

Update the workflow definition file to use the following runners ([that are still supported](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)):

* ubuntu-20.04
* ubuntu-22.04
* macos-11
* macos-12 (newly added)
* windows-2019

A sample succeeded run: https://github.com/der3318/YUView/actions/runs/5506804312


### Notes

You will probably want to upgrade runners in  [YUViewQt/.github/workflows /qtbase.yml](https://github.com/ChristianFeldmann/YUViewQt/blob/QtBase/.github/workflows/qtbase.yml) as well, in order to generate something like qtBase_5.15.1_**focal**.zip instead of keep using qtBase_5.15.1_**bionic**.zip.

