### PR TITLE
Remove Qt dependencies from parser

### DIFF
--- a/YUViewLib/src/common/Formatting.h
+++ b/YUViewLib/src/common/Formatting.h
@@ -1,6 +1,6 @@
 /*  This file is part of YUView - The YUV player with advanced analytics toolset
  *   <https://github.com/IENT/YUView>
- *   Copyright (C) 2015  Institut f�r Nachrichtentechnik, RWTH Aachen University, GERMANY
+ *   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -32,42 +32,54 @@
 
 #pragma once
 
-#include <parser/Parser.h>
-#include <video/yuv/videoHandlerYUV.h>
+#include "Typedef.h"
 
-#include "GlobalDecodingValues.h"
-#include "sequence_header_obu.h"
+#include <sstream>
+#include <vector>
 
-namespace parser
+template <typename T>
+std::ostream &operator<<(std::ostream &stream, const std::pair<T, T> &typePair)
 {
+  stream << "(" << typePair.first << ", " << typePair.second << ")";
+  return stream;
+}
 
-class ParserAV1OBU : public Parser
+template <typename T> std::string to_string(const std::pair<T, T> &typePair)
 {
-  Q_OBJECT
+  std::ostringstream stream;
+  stream << typePair;
+  return stream.str();
+}
 
-public:
-  ParserAV1OBU(QObject *parent = nullptr);
-  ~ParserAV1OBU() {}
-
-  std::pair<size_t, std::string> parseAndAddOBU(int                       obuID,
-                                                ByteVector &              data,
-                                                std::shared_ptr<TreeItem> parent,
-                                                pairUint64 obuStartEndPosFile = pairUint64(-1, -1));
-
-  // So far, we only parse AV1 Obu files from the AVFormat parser so we don't need this (yet).
-  // When parsing of raw OBU files is added, we will need this.
-  bool runParsingOfFile(QString) override
+template <typename T> std::ostream &operator<<(std::ostream &stream, const std::vector<T> vec)
+{
+  stream << "[";
+  for (auto it = vec.begin(); it != vec.end(); it++)
   {
-    assert(false);
-    return false;
+    if (it != vec.begin())
+      stream << ", ";
+    stream << (*it);
   }
-  vector<QTreeWidgetItem *> getStreamInfo() override { return {}; }
-  unsigned int              getNrStreams() override { return 1; }
-  std::string               getShortStreamDescription(int) const override { return "Video"; }
+  stream << "]";
+  return stream;
+}
 
-protected:
-  av1::GlobalDecodingValues                 decValues;
-  std::shared_ptr<av1::sequence_header_obu> active_sequence_header;
-};
+template <typename T> std::string to_string(const std::vector<T> vec)
+{
+  std::ostringstream stream;
+  stream << vec;
+  return stream.str();
+}
 
-} // namespace parser
+static std::ostream &operator<<(std::ostream &stream, const Size &size)
+{
+  stream << "(" << size.width << "x" << size.height << ")";
+  return stream;
+}
+
+static std::string to_string(const Size &size)
+{
+  std::ostringstream stream;
+  stream << size;
+  return stream.str();
+}

--- a/YUViewLib/src/common/Typedef.h
+++ b/YUViewLib/src/common/Typedef.h
@@ -63,13 +63,13 @@
 #ifdef Q_OS_MAC
 const bool is_Q_OS_MAC = true;
 #else
-const bool is_Q_OS_MAC   = false;
+const bool is_Q_OS_MAC = false;
 #endif
 
 #ifdef Q_OS_WIN
 const bool is_Q_OS_WIN = true;
 #else
-const bool is_Q_OS_WIN   = false;
+const bool is_Q_OS_WIN = false;
 #endif
 
 #ifdef Q_OS_LINUX
@@ -207,6 +207,7 @@ typedef std::pair<int, int>                 IntPair;
 typedef std::pair<unsigned, unsigned>       UIntPair;
 typedef std::pair<std::string, std::string> StringPair;
 typedef std::vector<StringPair>             StringPairVec;
+typedef std::vector<std::string>            StringVec;
 
 /// ---- Legacy types that will be replaced
 typedef QPair<QString, QString>           QStringPair;
@@ -226,26 +227,6 @@ template <typename T> using vector4d = std::vector<vector3d<T>>;
 template <typename T, size_t N> using array               = std::array<T, N>;
 template <typename T, size_t N1, size_t N2> using array2d = std::array<std::array<T, N2>, N1>;
 
-template <typename T> std::string to_string(const std::pair<T, T> typePair)
-{
-  std::ostringstream ss;
-  ss << "(" << typePair.first << ", " << typePair.second << ")";
-  return ss.str();
-}
-
-template <typename T> std::string to_string(const std::vector<T> vec)
-{
-  std::ostringstream ss;
-  ss << "[";
-  for (auto it = vec.begin(); it != vec.end(); it++)
-  {
-    if (it != vec.begin())
-      ss << ", ";
-    ss << (*it);
-  }
-  ss << "]";
-  return ss.str();
-}
 
 template <typename T> int indexInVec(const std::vector<T> &vec, const T &item)
 {

--- a/YUViewLib/src/filesource/FileSourceFFmpegFile.cpp
+++ b/YUViewLib/src/filesource/FileSourceFFmpegFile.cpp
@@ -35,6 +35,7 @@
 #include <QProgressDialog>
 #include <QSettings>
 
+#include <common/Formatting.h>
 #include <ffmpeg/AVCodecContextWrapper.h>
 #include <parser/AV1/obu_header.h>
 #include <parser/common/SubByteReaderLogging.h>
@@ -659,7 +660,7 @@ QList<QStringPairList> FileSourceFFmpegFile::getFileInfoForAllStreams()
 {
   QList<QStringPairList> info;
 
-  info += formatCtx.getInfoText();
+  info += this->formatCtx.getInfoText();
   for (unsigned i = 0; i < this->formatCtx.getNbStreams(); i++)
   {
     auto stream         = this->formatCtx.getStream(i);
@@ -683,23 +684,22 @@ QList<AVRational> FileSourceFFmpegFile::getTimeBaseAllStreams()
   return timeBaseList;
 }
 
-QList<QString> FileSourceFFmpegFile::getShortStreamDescriptionAllStreams()
+StringVec FileSourceFFmpegFile::getShortStreamDescriptionAllStreams()
 {
-  QList<QString> descriptions;
+  StringVec descriptions;
 
-  for (unsigned i = 0; i < formatCtx.getNbStreams(); i++)
+  for (unsigned i = 0; i < this->formatCtx.getNbStreams(); i++)
   {
-    QString description;
-    auto    stream = this->formatCtx.getStream(i);
-    description    = stream.getCodecTypeName();
+    std::ostringstream description;
+    auto               stream = this->formatCtx.getStream(i);
+    description << stream.getCodecTypeName().toStdString();
 
     auto codecID = this->ff.getCodecIDWrapper(stream.getCodecID());
-    description += " " + codecID.getCodecName();
+    description << " " << codecID.getCodecName().toStdString() << " ";
 
-    description +=
-        QString(" (%1x%2)").arg(stream.getFrameSize().width).arg(stream.getFrameSize().height);
+    description << std::pair{stream.getFrameSize().width, stream.getFrameSize().height};
 
-    descriptions.append(description);
+    descriptions.push_back(description.str());
   }
 
   return descriptions;

--- a/YUViewLib/src/filesource/FileSourceFFmpegFile.cpp
+++ b/YUViewLib/src/filesource/FileSourceFFmpegFile.cpp
@@ -425,8 +425,8 @@ bool FileSourceFFmpegFile::scanBitstream(QWidget *mainWindow)
   // Create the dialog (if the given pointer is not null)
   auto maxPTS = this->getMaxTS();
   // Updating the dialog (setValue) is quite slow. Only do this if the percent value changes.
-  int                             curPercentValue = 0;
-  QScopedPointer<QProgressDialog> progress;
+  int                              curPercentValue = 0;
+  std::unique_ptr<QProgressDialog> progress;
   if (mainWindow != nullptr)
   {
     progress.reset(

--- a/YUViewLib/src/filesource/FileSourceFFmpegFile.h
+++ b/YUViewLib/src/filesource/FileSourceFFmpegFile.h
@@ -115,7 +115,7 @@ public:
   int          getVideoStreamIndex() { return video_stream.getIndex(); }
   QList<QStringPairList>    getFileInfoForAllStreams();
   QList<FFmpeg::AVRational> getTimeBaseAllStreams();
-  QList<QString>            getShortStreamDescriptionAllStreams();
+  StringVec                 getShortStreamDescriptionAllStreams();
 
   // Look through the keyframes and find the closest one before (or equal)
   // the given frameIdx where we can start decoding

--- a/YUViewLib/src/parser/AV1/ParserAV1OBU.h
+++ b/YUViewLib/src/parser/AV1/ParserAV1OBU.h
@@ -61,9 +61,9 @@ public:
     assert(false);
     return false;
   }
-  QList<QTreeWidgetItem *> getStreamInfo() override { return {}; }
-  unsigned int             getNrStreams() override { return 1; }
-  QString                  getShortStreamDescription(int) const override { return "Video"; }
+  vector<QTreeWidgetItem *> getStreamInfo() override { return {}; }
+  unsigned int              getNrStreams() override { return 1; }
+  QString                   getShortStreamDescription(int) const override { return "Video"; }
 
 protected:
   av1::GlobalDecodingValues                 decValues;

--- a/YUViewLib/src/parser/AVFormat/ParserAVFormat.cpp
+++ b/YUViewLib/src/parser/AVFormat/ParserAVFormat.cpp
@@ -91,11 +91,11 @@ vector<QTreeWidgetItem *> ParserAVFormat::getStreamInfo()
   return info;
 }
 
-QString ParserAVFormat::getShortStreamDescription(int streamIndex) const
+std::string ParserAVFormat::getShortStreamDescription(const int streamIndex) const
 {
-  if (streamIndex >= this->shortStreamInfoAllStreams.count())
+  if (streamIndex >= this->shortStreamInfoAllStreams.size())
     return {};
-  return this->shortStreamInfoAllStreams[streamIndex];
+  return this->shortStreamInfoAllStreams.at(streamIndex);
 }
 
 bool ParserAVFormat::parseExtradata(ByteVector &extradata)

--- a/YUViewLib/src/parser/AVFormat/ParserAVFormat.cpp
+++ b/YUViewLib/src/parser/AVFormat/ParserAVFormat.cpp
@@ -63,20 +63,21 @@ const ByteVector startCode({0, 0, 1});
 
 using namespace reader;
 
-QList<QTreeWidgetItem *> ParserAVFormat::getStreamInfo()
+vector<QTreeWidgetItem *> ParserAVFormat::getStreamInfo()
 {
   // streamInfoAllStreams containse all the info for all streams.
   // The first QStringPairList contains the general info, next all infos for each stream follows
 
-  QList<QTreeWidgetItem *> info;
   if (this->streamInfoAllStreams.count() == 0)
-    return info;
+    return {};
 
-  QStringPairList  generalInfo = this->streamInfoAllStreams[0];
-  QTreeWidgetItem *general     = new QTreeWidgetItem(QStringList() << "General");
+  auto generalInfo = this->streamInfoAllStreams[0];
+  auto general     = new QTreeWidgetItem(QStringList() << "General");
   for (QStringPair p : generalInfo)
     new QTreeWidgetItem(general, QStringList() << p.first << p.second);
-  info.append(general);
+
+  vector<QTreeWidgetItem *> info;
+  info.push_back(general);
 
   for (int i = 1; i < this->streamInfoAllStreams.count(); i++)
   {
@@ -84,7 +85,7 @@ QList<QTreeWidgetItem *> ParserAVFormat::getStreamInfo()
         new QTreeWidgetItem(QStringList() << QString("Stream %1").arg(i - 1));
     for (QStringPair p : this->streamInfoAllStreams[i])
       new QTreeWidgetItem(streamInfo, QStringList() << p.first << p.second);
-    info.append(streamInfo);
+    info.push_back(streamInfo);
   }
 
   return info;

--- a/YUViewLib/src/parser/AVFormat/ParserAVFormat.h
+++ b/YUViewLib/src/parser/AVFormat/ParserAVFormat.h
@@ -55,8 +55,8 @@ public:
   ParserAVFormat(QObject *parent = nullptr) : Parser(parent) {}
   ~ParserAVFormat() {}
 
-  QList<QTreeWidgetItem *> getStreamInfo() override;
-  unsigned int             getNrStreams() override
+  vector<QTreeWidgetItem *> getStreamInfo() override;
+  unsigned int              getNrStreams() override
   {
     return streamInfoAllStreams.empty() ? 0 : streamInfoAllStreams.length() - 1;
   }

--- a/YUViewLib/src/parser/AVFormat/ParserAVFormat.h
+++ b/YUViewLib/src/parser/AVFormat/ParserAVFormat.h
@@ -60,7 +60,7 @@ public:
   {
     return streamInfoAllStreams.empty() ? 0 : streamInfoAllStreams.length() - 1;
   }
-  QString getShortStreamDescription(int streamIndex) const override;
+  std::string getShortStreamDescription(const int streamIndex) const override;
 
   // This function can run in a separate thread
   bool runParsingOfFile(QString compressedFilePath) override;
@@ -95,7 +95,7 @@ private:
   // we update this list while parsing the file.
   QList<QStringPairList>    streamInfoAllStreams;
   QList<FFmpeg::AVRational> timeBaseAllStreams;
-  QList<QString>            shortStreamInfoAllStreams;
+  StringVec                 shortStreamInfoAllStreams;
 
   int    videoStreamIndex{-1};
   double framerate{-1.0};

--- a/YUViewLib/src/parser/Parser.cpp
+++ b/YUViewLib/src/parser/Parser.cpp
@@ -53,7 +53,7 @@ Parser::Parser(QObject *parent) : QObject(parent)
   this->bitratePlotModel.reset(new BitratePlotModel());
   this->hrdPlotModel.reset(new HRDPlotModel());
   this->streamIndexFilter.reset(new FilterByStreamIndexProxyModel(parent));
-  this->streamIndexFilter->setSourceModel(this->packetModel.data());
+  this->streamIndexFilter->setSourceModel(this->packetModel.get());
 }
 
 Parser::~Parser()
@@ -62,8 +62,8 @@ Parser::~Parser()
 
 HRDPlotModel *Parser::getHRDPlotModel()
 {
-  if (this->redirectPlotModel == nullptr && !this->hrdPlotModel.isNull())
-    return this->hrdPlotModel.data();
+  if (this->redirectPlotModel == nullptr && this->hrdPlotModel)
+    return this->hrdPlotModel.get();
   else if (this->redirectPlotModel != nullptr)
     return this->redirectPlotModel;
   return {};

--- a/YUViewLib/src/parser/Parser.cpp
+++ b/YUViewLib/src/parser/Parser.cpp
@@ -90,18 +90,4 @@ void Parser::updateNumberModelItems()
   this->packetModel->updateNumberModelItems();
 }
 
-QString Parser::convertSliceTypeMapToString(QMap<QString, unsigned int> &sliceTypes)
-{
-  QString text;
-  for (auto key : sliceTypes.keys())
-  {
-    text += key;
-    const auto value = sliceTypes.value(key);
-    if (value > 1)
-      text += QString("(%1x)").arg(value);
-    text += " ";
-  }
-  return text;
-}
-
 } // namespace parser

--- a/YUViewLib/src/parser/Parser.h
+++ b/YUViewLib/src/parser/Parser.h
@@ -37,6 +37,8 @@
 #include <QString>
 #include <QTreeWidgetItem>
 
+#include <memory>
+
 #include "common/BitratePlotModel.h"
 #include "common/HRDPlotModel.h"
 #include "common/PacketItemModel.h"
@@ -59,8 +61,8 @@ public:
   Parser(QObject *parent);
   virtual ~Parser() = 0;
 
-  QAbstractItemModel *getPacketItemModel() { return streamIndexFilter.data(); }
-  BitratePlotModel *  getBitratePlotModel() { return bitratePlotModel.data(); }
+  QAbstractItemModel *getPacketItemModel() { return streamIndexFilter.get(); }
+  BitratePlotModel *  getBitratePlotModel() { return bitratePlotModel.get(); }
   HRDPlotModel *      getHRDPlotModel();
   void                setRedirectPlotModel(HRDPlotModel *plotModel);
 
@@ -100,9 +102,9 @@ signals:
   void streamInfoUpdated();
 
 protected:
-  QScopedPointer<PacketItemModel>               packetModel;
-  QScopedPointer<FilterByStreamIndexProxyModel> streamIndexFilter;
-  QScopedPointer<BitratePlotModel>              bitratePlotModel;
+  std::unique_ptr<PacketItemModel>               packetModel;
+  std::unique_ptr<FilterByStreamIndexProxyModel> streamIndexFilter;
+  std::unique_ptr<BitratePlotModel>              bitratePlotModel;
 
   static QString convertSliceTypeMapToString(QMap<QString, unsigned int> &currentAUSliceTypes);
 
@@ -113,8 +115,8 @@ protected:
   bool parsingLimitEnabled{false};
 
 private:
-  QScopedPointer<HRDPlotModel> hrdPlotModel;
-  HRDPlotModel *               redirectPlotModel{nullptr};
+  std::unique_ptr<HRDPlotModel> hrdPlotModel;
+  HRDPlotModel *                redirectPlotModel{nullptr};
 };
 
 } // namespace parser

--- a/YUViewLib/src/parser/Parser.h
+++ b/YUViewLib/src/parser/Parser.h
@@ -78,8 +78,8 @@ public:
   int          getParsingProgressPercent() { return progressPercentValue; }
   void         setAbortParsing() { cancelBackgroundParser = true; }
 
-  virtual int     getVideoStreamIndex() { return -1; }
-  virtual QString getShortStreamDescription(int streamIndex) const = 0;
+  virtual int         getVideoStreamIndex() { return -1; }
+  virtual std::string getShortStreamDescription(const int streamIndex) const = 0;
 
   void setStreamColorCoding(bool colorCoding) { packetModel->setUseColorCoding(colorCoding); }
   void setFilterStreamIndex(int streamIndex)

--- a/YUViewLib/src/parser/Parser.h
+++ b/YUViewLib/src/parser/Parser.h
@@ -70,8 +70,8 @@ public:
   void enableModel();
 
   // Get info about the stream organized in a tree
-  virtual QList<QTreeWidgetItem *> getStreamInfo() = 0;
-  virtual unsigned int             getNrStreams()  = 0;
+  virtual vector<QTreeWidgetItem *> getStreamInfo() = 0;
+  virtual unsigned int              getNrStreams()  = 0;
 
   // For parsing files in the background (threading) in the bitstream analysis dialog:
   virtual bool runParsingOfFile(QString fileName) = 0;

--- a/YUViewLib/src/parser/Parser.h
+++ b/YUViewLib/src/parser/Parser.h
@@ -106,8 +106,6 @@ protected:
   std::unique_ptr<FilterByStreamIndexProxyModel> streamIndexFilter;
   std::unique_ptr<BitratePlotModel>              bitratePlotModel;
 
-  static QString convertSliceTypeMapToString(QMap<QString, unsigned int> &currentAUSliceTypes);
-
   // If this variable is set (from an external thread), the parsing process should cancel
   // immediately
   bool cancelBackgroundParser{false};

--- a/YUViewLib/src/parser/ParserAnnexB.cpp
+++ b/YUViewLib/src/parser/ParserAnnexB.cpp
@@ -150,9 +150,9 @@ bool ParserAnnexB::parseAnnexBFile(std::unique_ptr<FileSourceAnnexBFile> &file, 
 {
   DEBUG_ANNEXB("ParserAnnexB::parseAnnexBFile");
 
-  int64_t                         maxPos = file->getFileSize();
-  QScopedPointer<QProgressDialog> progressDialog;
-  int                             curPercentValue = 0;
+  auto                             maxPos = file->getFileSize();
+  std::unique_ptr<QProgressDialog> progressDialog;
+  int                              curPercentValue = 0;
   if (mainWindow)
   {
     // Show a modal QProgressDialog while this operation is running.

--- a/YUViewLib/src/parser/ParserAnnexB.cpp
+++ b/YUViewLib/src/parser/ParserAnnexB.cpp
@@ -33,8 +33,7 @@
 #include "ParserAnnexB.h"
 
 #include <common/Formatting.h>
-#include <parser/common/SubByteReaderLogging.h>F
-
+#include <parser/common/SubByteReaderLogging.h>
 
 #include <QElapsedTimer>
 #include <QProgressDialog>

--- a/YUViewLib/src/parser/ParserAnnexB.cpp
+++ b/YUViewLib/src/parser/ParserAnnexB.cpp
@@ -284,22 +284,23 @@ bool ParserAnnexB::runParsingOfFile(QString compressedFilePath)
   return this->parseAnnexBFile(file);
 }
 
-QList<QTreeWidgetItem *> ParserAnnexB::stream_info_type::getStreamInfo()
+vector<QTreeWidgetItem *> ParserAnnexB::stream_info_type::getStreamInfo()
 {
-  QList<QTreeWidgetItem *> infoList;
-  infoList.append(new QTreeWidgetItem(QStringList() << "File size" << QString::number(file_size)));
+  vector<QTreeWidgetItem *> infoList;
+  infoList.push_back(
+      new QTreeWidgetItem(QStringList() << "File size" << QString::number(file_size)));
   if (parsing)
   {
-    infoList.append(new QTreeWidgetItem(QStringList() << "Number NAL units"
-                                                      << "Parsing..."));
-    infoList.append(new QTreeWidgetItem(QStringList() << "Number Frames"
-                                                      << "Parsing..."));
+    infoList.push_back(new QTreeWidgetItem(QStringList() << "Number NAL units"
+                                                         << "Parsing..."));
+    infoList.push_back(new QTreeWidgetItem(QStringList() << "Number Frames"
+                                                         << "Parsing..."));
   }
   else
   {
-    infoList.append(
+    infoList.push_back(
         new QTreeWidgetItem(QStringList() << "Number NAL units" << QString::number(nr_nal_units)));
-    infoList.append(
+    infoList.push_back(
         new QTreeWidgetItem(QStringList() << "Number Frames" << QString::number(nr_frames)));
   }
 

--- a/YUViewLib/src/parser/ParserAnnexB.cpp
+++ b/YUViewLib/src/parser/ParserAnnexB.cpp
@@ -32,7 +32,9 @@
 
 #include "ParserAnnexB.h"
 
-#include "parser/common/SubByteReaderLogging.h"
+#include <common/Formatting.h>
+#include <parser/common/SubByteReaderLogging.h>F
+
 
 #include <QElapsedTimer>
 #include <QProgressDialog>
@@ -49,13 +51,14 @@
 namespace parser
 {
 
-QString ParserAnnexB::getShortStreamDescription(int) const
+std::string ParserAnnexB::getShortStreamDescription(const int) const
 {
-  QString info      = "Video";
-  auto    frameSize = this->getSequenceSizeSamples();
+  std::ostringstream info;
+  info << "Video";
+  auto frameSize = this->getSequenceSizeSamples();
   if (frameSize.isValid())
-    info += QString(" (%1x%2)").arg(frameSize.width).arg(frameSize.height);
-  return info;
+    info << " " << frameSize;
+  return info.str();
 }
 
 bool ParserAnnexB::addFrameToList(int                       poc,

--- a/YUViewLib/src/parser/ParserAnnexB.h
+++ b/YUViewLib/src/parser/ParserAnnexB.h
@@ -67,9 +67,9 @@ public:
   // Clear all knowledge about the bitstream.
   void clearData();
 
-  QList<QTreeWidgetItem *> getStreamInfo() override { return stream_info.getStreamInfo(); }
-  unsigned int             getNrStreams() override { return 1; }
-  QString                  getShortStreamDescription(int streamIndex) const override;
+  vector<QTreeWidgetItem *> getStreamInfo() override { return this->stream_info.getStreamInfo(); }
+  unsigned int              getNrStreams() override { return 1; }
+  QString                   getShortStreamDescription(int streamIndex) const override;
 
   /* Parse the NAL unit and what it contains
    *
@@ -158,7 +158,7 @@ protected:
   // Save general information about the file here
   struct stream_info_type
   {
-    QList<QTreeWidgetItem *> getStreamInfo();
+    vector<QTreeWidgetItem *> getStreamInfo();
 
     size_t   file_size;
     unsigned nr_nal_units{0};

--- a/YUViewLib/src/parser/ParserAnnexB.h
+++ b/YUViewLib/src/parser/ParserAnnexB.h
@@ -69,7 +69,7 @@ public:
 
   vector<QTreeWidgetItem *> getStreamInfo() override { return this->stream_info.getStreamInfo(); }
   unsigned int              getNrStreams() override { return 1; }
-  QString                   getShortStreamDescription(int streamIndex) const override;
+  std::string               getShortStreamDescription(const int streamIndex) const override;
 
   /* Parse the NAL unit and what it contains
    *

--- a/YUViewLib/src/playlistitem/playlistItem.cpp
+++ b/YUViewLib/src/playlistitem/playlistItem.cpp
@@ -46,7 +46,9 @@ playlistItem::playlistItem(const QString &itemNameOrFileName, Type type)
   this->prop.id = idCounter++;
 }
 
-playlistItem::~playlistItem() {}
+playlistItem::~playlistItem()
+{
+}
 
 void playlistItem::setName(const QString &name)
 {
@@ -62,7 +64,7 @@ void playlistItem::drawItem(QPainter *painter, int, double zoomFactor, bool)
   auto displayFont = painter->font();
   displayFont.setPointSizeF(painter->font().pointSizeF() * zoomFactor);
   painter->setFont(displayFont);
-  auto textSize = painter->fontMetrics().size(0, infoText);
+  auto  textSize = painter->fontMetrics().size(0, infoText);
   QRect textRect;
   textRect.setSize(textSize);
   textRect.moveCenter(QPoint(0, 0));
@@ -75,7 +77,7 @@ QSize playlistItem::getSize() const
 {
   // Return the size of the text that is drawn on screen.
   QPainter painter;
-  auto    displayFont = painter.font();
+  auto     displayFont = painter.font();
   return painter.fontMetrics().size(0, infoText);
 }
 
@@ -182,7 +184,7 @@ void playlistItem::createPropertiesWidget()
   this->preparePropertiesWidget(QStringLiteral("playlistItem"));
 
   // On the top level everything is layout vertically
-  auto vAllLaout = new QVBoxLayout(this->propertiesWidget.data());
+  auto vAllLaout = new QVBoxLayout(this->propertiesWidget.get());
 
   // First add the parents controls (duration) then the text specific controls (font, text...)
   vAllLaout->addLayout(createPlaylistItemControls());

--- a/YUViewLib/src/playlistitem/playlistItem.h
+++ b/YUViewLib/src/playlistitem/playlistItem.h
@@ -147,9 +147,9 @@ public:
   {
     if (!propertiesWidget)
       createPropertiesWidget();
-    return propertiesWidget.data();
+    return propertiesWidget.get();
   }
-  bool propertiesWidgetCreated() const { return !propertiesWidget.isNull(); }
+  bool propertiesWidgetCreated() const { return static_cast<bool>(this->propertiesWidget); }
 
   // Does the playlist item currently accept drops of the given item?
   virtual bool acceptDrops(playlistItem *) const { return false; }
@@ -268,7 +268,7 @@ signals:
 
 protected:
   // The widget which is put into the stack.
-  QScopedPointer<QWidget> propertiesWidget;
+  std::unique_ptr<QWidget> propertiesWidget;
 
   // Create the properties widget and set propertiesWidget to point to it.
   // Overload this function in a child class to create a custom widget.

--- a/YUViewLib/src/playlistitem/playlistItem.h
+++ b/YUViewLib/src/playlistitem/playlistItem.h
@@ -42,6 +42,8 @@
 #include <QObject>
 #include <QTreeWidgetItem>
 
+#include <memory>
+
 #include "ui_playlistItem.h"
 
 namespace video

--- a/YUViewLib/src/playlistitem/playlistItemCompressedVideo.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemCompressedVideo.cpp
@@ -905,21 +905,21 @@ void playlistItemCompressedVideo::createPropertiesWidget()
 {
   Q_ASSERT_X(!this->propertiesWidget, "createPropertiesWidget", "Properties widget already exists");
 
-  if (!video)
+  if (!this->video)
   {
     playlistItem::createPropertiesWidget();
     return;
   }
 
   // Create a new widget and populate it with controls
-  this->propertiesWidget.reset(new QWidget);
-  ui.setupUi(propertiesWidget.data());
+  this->propertiesWidget = std::make_unique<QWidget>();
+  ui.setupUi(this->propertiesWidget.get());
 
-  auto lineOne = new QFrame;
+  auto lineOne = std::make_unique<QFrame>();
   lineOne->setObjectName(QStringLiteral("line"));
   lineOne->setFrameShape(QFrame::HLine);
   lineOne->setFrameShadow(QFrame::Sunken);
-  auto lineTwo = new QFrame;
+  auto lineTwo = std::make_unique<QFrame>();
   lineTwo->setObjectName(QStringLiteral("line"));
   lineTwo->setFrameShape(QFrame::HLine);
   lineTwo->setFrameShadow(QFrame::Sunken);
@@ -927,9 +927,9 @@ void playlistItemCompressedVideo::createPropertiesWidget()
   // Insert a stretch at the bottom of the vertical global layout so that everything
   // gets 'pushed' to the top
   ui.verticalLayout->insertLayout(0, createPlaylistItemControls());
-  ui.verticalLayout->insertWidget(1, lineOne);
+  ui.verticalLayout->insertWidget(1, lineOne.release());
   ui.verticalLayout->insertLayout(2, video->createVideoHandlerControls(true));
-  ui.verticalLayout->insertWidget(5, lineTwo);
+  ui.verticalLayout->insertWidget(5, lineTwo.release());
   ui.verticalLayout->insertLayout(
       6, this->statisticsUIHandler.createStatisticsHandlerControls(), 1);
 

--- a/YUViewLib/src/playlistitem/playlistItemDifference.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemDifference.cpp
@@ -155,9 +155,9 @@ void playlistItemDifference::createPropertiesWidget()
   preparePropertiesWidget(QStringLiteral("playlistItemDifference"));
 
   // On the top level everything is layout vertically
-  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget.data());
+  auto vAllLaout = new QVBoxLayout(propertiesWidget.get());
 
-  QFrame *line = new QFrame;
+  auto line = std::make_unique<QFrame>();
   line->setObjectName(QStringLiteral("line"));
   line->setFrameShape(QFrame::HLine);
   line->setFrameShadow(QFrame::Sunken);
@@ -165,7 +165,7 @@ void playlistItemDifference::createPropertiesWidget()
   // First add the parents controls (first video controls (width/height...) then YUV controls
   // (format,...)
   vAllLaout->addLayout(difference.createFrameHandlerControls(true));
-  vAllLaout->addWidget(line);
+  vAllLaout->addWidget(line.release());
   vAllLaout->addLayout(difference.createDifferenceHandlerControls());
 
   vAllLaout->insertStretch(-1, 1); // Push controls up
@@ -257,7 +257,10 @@ void playlistItemDifference::loadFrame(int  frameIdx,
   }
 }
 
-bool playlistItemDifference::isLoading() const { return this->isDifferenceLoading; }
+bool playlistItemDifference::isLoading() const
+{
+  return this->isDifferenceLoading;
+}
 
 bool playlistItemDifference::isLoadingDoubleBuffer() const
 {

--- a/YUViewLib/src/playlistitem/playlistItemImageFileSequence.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemImageFileSequence.cpp
@@ -156,7 +156,7 @@ void playlistItemImageFileSequence::createPropertiesWidget()
   preparePropertiesWidget(QStringLiteral("playlistItemRawFile"));
 
   // On the top level everything is layout vertically
-  QVBoxLayout *vAllLaout = new QVBoxLayout(propertiesWidget.data());
+  QVBoxLayout *vAllLaout = new QVBoxLayout(this->propertiesWidget.get());
 
   // First add the parents controls (first video controls (width/height...)
   vAllLaout->addLayout(createPlaylistItemControls());

--- a/YUViewLib/src/playlistitem/playlistItemOverlay.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemOverlay.cpp
@@ -410,8 +410,8 @@ void playlistItemOverlay::createPropertiesWidget()
   Q_ASSERT_X(!this->propertiesWidget, "createPropertiesWidget", "Properties widget already exists");
 
   // Create a new widget and populate it with controls
-  this->propertiesWidget.reset(new QWidget);
-  this->ui.setupUi(this->propertiesWidget.data());
+  this->propertiesWidget = std::make_unique<QWidget>();
+  this->ui.setupUi(this->propertiesWidget.get());
 
   this->ui.verticalLayout->insertLayout(0, this->createPlaylistItemControls());
 

--- a/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemRawFile.cpp
@@ -448,7 +448,7 @@ void playlistItemRawFile::createPropertiesWidget()
   this->preparePropertiesWidget(QStringLiteral("playlistItemRawFile"));
 
   // On the top level everything is layout vertically
-  auto vAllLaout = new QVBoxLayout(this->propertiesWidget.data());
+  auto vAllLaout = new QVBoxLayout(this->propertiesWidget.get());
 
   auto line = new QFrame;
   line->setObjectName(QStringLiteral("line"));

--- a/YUViewLib/src/playlistitem/playlistItemResample.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemResample.cpp
@@ -188,7 +188,7 @@ void playlistItemResample::createPropertiesWidget()
   this->preparePropertiesWidget(QStringLiteral("playlistItemResample"));
 
   // On the top level everything is layout vertically
-  auto vAllLaout = new QVBoxLayout(propertiesWidget.data());
+  auto vAllLaout = new QVBoxLayout(this->propertiesWidget.get());
 
   ui.setupUi();
 
@@ -348,8 +348,8 @@ void playlistItemResample::slotInterpolationModeChanged(int)
 {
   this->interpolationIndex = ui.comboBoxInterpolation->currentIndex();
   auto interpolation       = (this->interpolationIndex == 0)
-                           ? video::videoHandlerResample::Interpolation::Bilinear
-                           : video::videoHandlerResample::Interpolation::Fast;
+                                 ? video::videoHandlerResample::Interpolation::Bilinear
+                                 : video::videoHandlerResample::Interpolation::Fast;
   this->video.setInterpolation(interpolation);
 }
 

--- a/YUViewLib/src/playlistitem/playlistItemStatisticsFile.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemStatisticsFile.cpp
@@ -39,8 +39,8 @@
 #include <cassert>
 #include <iostream>
 
-#include <common/YUViewDomElement.h>
 #include <common/FunctionsGui.h>
+#include <common/YUViewDomElement.h>
 #include <statistics/StatisticsDataPainting.h>
 #include <statistics/StatisticsFileCSV.h>
 #include <statistics/StatisticsFileVTMBMS.h>
@@ -243,12 +243,12 @@ void playlistItemStatisticsFile::onPOCParsed(int poc)
 
 void playlistItemStatisticsFile::createPropertiesWidget()
 {
-  Q_ASSERT_X(!propertiesWidget, "createPropertiesWidget", "Properties widget already exists");
+  Q_ASSERT_X(!this->propertiesWidget, "createPropertiesWidget", "Properties widget already exists");
 
   this->preparePropertiesWidget(QStringLiteral("playlistItemStatisticsFile"));
 
   // On the top level everything is layout vertically
-  auto vAllLaout = new QVBoxLayout(propertiesWidget.data());
+  auto vAllLaout = new QVBoxLayout(this->propertiesWidget.get());
 
   auto line = new QFrame;
   line->setObjectName(QStringLiteral("lineOne"));

--- a/YUViewLib/src/playlistitem/playlistItemText.cpp
+++ b/YUViewLib/src/playlistitem/playlistItemText.cpp
@@ -80,16 +80,16 @@ void playlistItemText::createPropertiesWidget()
 
   this->preparePropertiesWidget(QStringLiteral("playlistItemText"));
 
-  QVBoxLayout *vAllLaout = new QVBoxLayout(this->propertiesWidget.data());
+  auto vAllLaout = new QVBoxLayout(this->propertiesWidget.get());
 
-  QFrame *line = new QFrame;
+  auto line = std::make_unique<QFrame>();
   line->setObjectName(QStringLiteral("line"));
   line->setFrameShape(QFrame::HLine);
   line->setFrameShadow(QFrame::Sunken);
 
   // First add the parents controls (duration) then the text specific controls (font, text...)
   vAllLaout->addLayout(createPlaylistItemControls());
-  vAllLaout->addWidget(line);
+  vAllLaout->addWidget(line.release());
   vAllLaout->addLayout(createTextController());
   vAllLaout->insertStretch(-1, 1); // Push controls up
 }

--- a/YUViewLib/src/ui/Mainwindow.cpp
+++ b/YUViewLib/src/ui/Mainwindow.cpp
@@ -148,7 +148,7 @@ MainWindow::MainWindow(bool useAlternativeSources, QWidget *parent) : QMainWindo
   // Create the VideoCache object
   cache.reset(new video::VideoCache(
       ui.playlistTreeWidget, ui.playbackController, ui.displaySplitView, this));
-  connect(cache.data(),
+  connect(cache.get(),
           &video::VideoCache::updateCacheStatus,
           ui.cachingInfoWidget,
           &VideoCacheInfoWidget::onUpdateCacheStatus);
@@ -159,8 +159,8 @@ MainWindow::MainWindow(bool useAlternativeSources, QWidget *parent) : QMainWindo
   ui.playbackController->setPlaylist(ui.playlistTreeWidget);
   ui.displaySplitView->setPlaybackController(ui.playbackController);
   ui.displaySplitView->setPlaylistTreeWidget(ui.playlistTreeWidget);
-  ui.displaySplitView->setVideoCache(this->cache.data());
-  ui.cachingInfoWidget->setPlaylistAndCache(ui.playlistTreeWidget, this->cache.data());
+  ui.displaySplitView->setVideoCache(this->cache.get());
+  ui.cachingInfoWidget->setPlaylistAndCache(ui.playlistTreeWidget, this->cache.get());
   separateViewWindow.splitView.setPlaybackController(ui.playbackController);
   separateViewWindow.splitView.setPlaylistTreeWidget(ui.playlistTreeWidget);
 

--- a/YUViewLib/src/ui/Mainwindow.h
+++ b/YUViewLib/src/ui/Mainwindow.h
@@ -157,12 +157,12 @@ private:
 
   void performanceTest();
 
-  QPointer<QAction>                 recentFileActions[MAX_RECENT_FILES];
-  QScopedPointer<video::VideoCache> cache;
-  bool                              saveWindowsStateOnExit;
-  QScopedPointer<updateHandler>     updater;
-  ViewStateHandler                  stateHandler;
-  SeparateWindow                    separateViewWindow;
+  QPointer<QAction>                  recentFileActions[MAX_RECENT_FILES];
+  std::unique_ptr<video::VideoCache> cache;
+  bool                               saveWindowsStateOnExit;
+  std::unique_ptr<updateHandler>     updater;
+  ViewStateHandler                   stateHandler;
+  SeparateWindow                     separateViewWindow;
   bool showNormalMaximized;     // When going to full screen: Was this windows maximized?
   bool panelsVisible[5]{false}; // Which panels are visible when going to full-screen mode?
 };

--- a/YUViewLib/src/ui/YUViewApplication.cpp
+++ b/YUViewLib/src/ui/YUViewApplication.cpp
@@ -63,7 +63,7 @@ YUViewApplication::YUViewApplication(int argc, char *argv[]) : QApplication(argc
   QStringList args = arguments();
   DEBUG_APP("YUViewApplication args" << args);
 
-  QScopedPointer<singleInstanceHandler> instance;
+  std::unique_ptr<singleInstanceHandler> instance;
   if (WIN_LINUX_SINGLE_INSTANCE && (is_Q_OS_WIN || is_Q_OS_LINUX))
   {
     // On mac, we can use the singleInstanceHandler. However, these don't work on windows and linux.
@@ -107,7 +107,7 @@ YUViewApplication::YUViewApplication(int argc, char *argv[]) : QApplication(argc
 
   // If another application is opened, we will just add the given file to the playlist.
   if (WIN_LINUX_SINGLE_INSTANCE && (is_Q_OS_WIN || is_Q_OS_LINUX))
-    w.connect(instance.data(), &singleInstanceHandler::newAppStarted, &w, &MainWindow::loadFiles);
+    w.connect(instance.get(), &singleInstanceHandler::newAppStarted, &w, &MainWindow::loadFiles);
 
   if (UPDATE_FEATURE_ENABLE && is_Q_OS_WIN && args.size() == 2 &&
       (args.last() == "updateElevated" || args.last() == "updateElevatedAltSource"))

--- a/YUViewLib/src/ui/widgets/BitstreamAnalysisWidget.cpp
+++ b/YUViewLib/src/ui/widgets/BitstreamAnalysisWidget.cpp
@@ -94,7 +94,8 @@ void BitstreamAnalysisWidget::updateParserItemModel()
 void BitstreamAnalysisWidget::updateStreamInfo()
 {
   this->ui.streamInfoTreeWidget->clear();
-  this->ui.streamInfoTreeWidget->addTopLevelItems(this->parser->getStreamInfo());
+  for (auto item : this->parser->getStreamInfo())
+    this->ui.streamInfoTreeWidget->addTopLevelItem(item);
   this->ui.streamInfoTreeWidget->expandAll();
 
   DEBUG_ANALYSIS("BitstreamAnalysisWidget::updateStreamInfo comboBox entries "

--- a/YUViewLib/src/ui/widgets/BitstreamAnalysisWidget.cpp
+++ b/YUViewLib/src/ui/widgets/BitstreamAnalysisWidget.cpp
@@ -165,18 +165,18 @@ void BitstreamAnalysisWidget::updateParsingStatusText(int progressValue)
 
 void BitstreamAnalysisWidget::stopAndDeleteParserBlocking()
 {
-  if (this->parser.isNull())
+  if (!this->parser)
     return;
 
-  this->disconnect(this->parser.data(),
+  this->disconnect(this->parser.get(),
                    &parser::Parser::modelDataUpdated,
                    this,
                    &BitstreamAnalysisWidget::updateParserItemModel);
-  this->disconnect(this->parser.data(),
+  this->disconnect(this->parser.get(),
                    &parser::Parser::streamInfoUpdated,
                    this,
                    &BitstreamAnalysisWidget::updateStreamInfo);
-  this->disconnect(this->parser.data(),
+  this->disconnect(this->parser.get(),
                    &parser::Parser::backgroundParsingDone,
                    this,
                    &BitstreamAnalysisWidget::backgroundParsingDone);
@@ -272,15 +272,15 @@ void BitstreamAnalysisWidget::createAndConnectNewParser(InputFormat inputFormat)
   const bool parsingLimitSet = !this->ui.parseEntireFileCheckBox->isChecked();
   this->parser->setParsingLimitEnabled(parsingLimitSet);
 
-  this->connect(this->parser.data(),
+  this->connect(this->parser.get(),
                 &parser::Parser::modelDataUpdated,
                 this,
                 &BitstreamAnalysisWidget::updateParserItemModel);
-  this->connect(this->parser.data(),
+  this->connect(this->parser.get(),
                 &parser::Parser::streamInfoUpdated,
                 this,
                 &BitstreamAnalysisWidget::updateStreamInfo);
-  this->connect(this->parser.data(),
+  this->connect(this->parser.get(),
                 &parser::Parser::backgroundParsingDone,
                 this,
                 &BitstreamAnalysisWidget::backgroundParsingDone);

--- a/YUViewLib/src/ui/widgets/BitstreamAnalysisWidget.cpp
+++ b/YUViewLib/src/ui/widgets/BitstreamAnalysisWidget.cpp
@@ -118,8 +118,9 @@ void BitstreamAnalysisWidget::updateStreamInfo()
       this->ui.showStreamComboBox->addItem("Show all streams");
       for (unsigned i = 0; i < this->parser->getNrStreams(); i++)
       {
-        QString info = this->parser->getShortStreamDescription(i);
-        this->ui.showStreamComboBox->addItem(QString("Stream %1 - ").arg(i) + info);
+        const auto info = this->parser->getShortStreamDescription(i);
+        this->ui.showStreamComboBox->addItem(QString("Stream %1 - ").arg(i) +
+                                             QString::fromStdString(info));
       }
     }
   }

--- a/YUViewLib/src/ui/widgets/BitstreamAnalysisWidget.h
+++ b/YUViewLib/src/ui/widgets/BitstreamAnalysisWidget.h
@@ -80,9 +80,9 @@ private:
   void restartParsingOfCurrentItem();
   void createAndConnectNewParser(InputFormat inputFormatType);
 
-  QScopedPointer<parser::Parser> parser;
-  QFuture<void>                  backgroundParserFuture;
-  void                           backgroundParsingFunction();
+  std::unique_ptr<parser::Parser> parser;
+  QFuture<void>                   backgroundParserFuture;
+  void                            backgroundParsingFunction();
 
   QPointer<playlistItemCompressedVideo> currentCompressedVideo;
 

--- a/YUViewLib/src/video/VideoCache.cpp
+++ b/YUViewLib/src/video/VideoCache.cpp
@@ -207,11 +207,11 @@ public:
       quit();
     }
   }
-  loadingWorker *worker() { return threadWorker.data(); }
+  loadingWorker *worker() { return threadWorker.get(); }
   bool           isQuitting() { return quitting; }
 
 private:
-  QScopedPointer<loadingWorker> threadWorker;
+  std::unique_ptr<loadingWorker> threadWorker;
   bool quitting; // Are er quitting the job? If yes, do not push new jobs to it.
 };
 


### PR DESCRIPTION
I want to slowly get rid of some of the Qt stuff where its not really needed. This could allow to export code to other modules.