### PR TITLE
Add lhvC parsing (MH-HEVC in MP4)

### DIFF
--- a/YUViewLib/src/common/Functions.cpp
+++ b/YUViewLib/src/common/Functions.cpp
@@ -168,6 +168,16 @@ std::string toLower(std::string str)
   return str;
 }
 
+ByteVector readData(std::istream &istream, const size_t nrBytes)
+{
+  ByteVector data;
+  data.resize(nrBytes);
+  istream.read(reinterpret_cast<char *>(data.data()), nrBytes);
+  const auto nrBytesActuallyRead = istream.gcount();
+  data.resize(nrBytesActuallyRead);
+  return data;
+}
+
 std::optional<unsigned long> toUnsigned(const std::string &text)
 {
   try

--- a/YUViewLib/src/common/Functions.h
+++ b/YUViewLib/src/common/Functions.h
@@ -34,6 +34,7 @@
 
 #include <common/Typedef.h>
 
+#include <istream>
 #include <optional>
 
 namespace functions
@@ -64,6 +65,7 @@ QString formatDataSize(double size, bool isBits = false);
 
 QStringList toQStringList(const std::vector<std::string> &stringVec);
 std::string toLower(std::string str);
+ByteVector  readData(std::istream &istream, const size_t nrBytes);
 
 inline std::string boolToString(bool b)
 {

--- a/YUViewLib/src/ffmpeg/AVInputFormatWrapper.cpp
+++ b/YUViewLib/src/ffmpeg/AVInputFormatWrapper.cpp
@@ -65,6 +65,31 @@ AVInputFormatWrapper::AVInputFormatWrapper(AVInputFormat *f, LibraryVersion v)
   this->update();
 }
 
+QString AVInputFormatWrapper::getName() const
+{
+  return this->name;
+}
+
+QString AVInputFormatWrapper::getLongName() const
+{
+  return this->long_name;
+}
+
+int AVInputFormatWrapper::getFlags() const
+{
+  return this->flags;
+}
+
+QString AVInputFormatWrapper::getExtensions() const
+{
+  return this->extensions;
+}
+
+QString AVInputFormatWrapper::getMimeType() const
+{
+  return this->mime_type;
+}
+
 void AVInputFormatWrapper::update()
 {
   if (this->fmt == nullptr)

--- a/YUViewLib/src/filesource/FileSourceFFmpegFile.h
+++ b/YUViewLib/src/filesource/FileSourceFFmpegFile.h
@@ -35,6 +35,7 @@
 #include "FileSource.h"
 #include <ffmpeg/AVCodecIDWrapper.h>
 #include <ffmpeg/AVCodecParametersWrapper.h>
+#include <ffmpeg/AVInputFormatWrapper.h>
 #include <ffmpeg/AVPacketWrapper.h>
 #include <ffmpeg/FFmpegVersionHandler.h>
 #include <video/rgb/videoHandlerRGB.h>
@@ -85,6 +86,7 @@ public:
 
   QByteArray    getExtradata();
   StringPairVec getMetadata();
+  ByteVector    getLhvCData();
   // Return a list containing the raw data of all parameter set NAL units
   QList<QByteArray> getParameterSets();
 
@@ -134,6 +136,8 @@ protected:
   bool                           goToNextPacket(bool videoPacketsOnly = false);
   FFmpeg::AVPacketWrapper        currentPacket;    //< A place for the curren (frame) input buffer
   bool                           endOfFile{false}; //< Are we at the end of file (draining mode)?
+
+  QString fileName;
 
   // Seek the stream to the given pts value, flush the decoder and load the first packet so
   // that we are ready to start decoding from this pts.

--- a/YUViewLib/src/parser/AVFormat/DecoderConfigurationHvcC.h
+++ b/YUViewLib/src/parser/AVFormat/DecoderConfigurationHvcC.h
@@ -1,6 +1,6 @@
 /*  This file is part of YUView - The YUV player with advanced analytics toolset
  *   <https://github.com/IENT/YUView>
- *   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
+ *   Copyright (C) 2015  Institut f�r Nachrichtentechnik, RWTH Aachen University, GERMANY
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -32,40 +32,45 @@
 
 #pragma once
 
-#include "FFMpegLibrariesTypes.h"
+#include <parser/HEVC/ParserAnnexBHEVC.h>
+#include <parser/common/BitratePlotModel.h>
+#include <parser/common/TreeItem.h>
 
-namespace FFmpeg
+#include "DecoderConfigurationNalArray.h"
+
+namespace parser::avformat
 {
 
-class AVInputFormatWrapper
+class DecoderConfigurationHvcC
 {
 public:
-  AVInputFormatWrapper();
-  AVInputFormatWrapper(AVInputFormat *f, LibraryVersion v);
+  DecoderConfigurationHvcC() = default;
 
-  QString getName() const;
-  QString getLongName() const;
-  int     getFlags() const;
-  QString getExtensions() const;
-  QString getMimeType() const;
+  void parse(const ByteVector &        data,
+             std::shared_ptr<TreeItem> root,
+             ParserAnnexBHEVC *        hevcParser,
+             BitratePlotModel *        bitrateModel);
 
-  explicit operator bool() const { return fmt != nullptr; };
+  unsigned configurationVersion{};
+  unsigned general_profile_space{};
+  bool     general_tier_flag{};
+  unsigned general_profile_idc{};
+  unsigned general_profile_compatibility_flags{};
+  uint64_t general_constraint_indicator_flags{};
+  unsigned general_level_idc{};
+  unsigned min_spatial_segmentation_idc{};
+  unsigned parallelismType{};
+  unsigned chromaFormat{};
+  unsigned bitDepthLumaMinus8{};
+  unsigned bitDepthChromaMinus8{};
+  unsigned avgFrameRate{};
+  unsigned constantFrameRate{};
+  unsigned numTemporalLayers{};
+  bool     temporalIdNested{};
+  unsigned lengthSizeMinusOne{};
+  unsigned numOfArrays{};
 
-private:
-  // Update all private values from the AVCodecContext
-  void update();
-
-  // These are here for debugging purposes.
-  QString name{};
-  QString long_name{};
-  int     flags{};
-  QString extensions{};
-  // const struct AVCodecTag * const *codec_tag;
-  // const AVClass *priv_class;
-  QString mime_type{};
-
-  AVInputFormat *fmt{};
-  LibraryVersion libVer{};
+  std::vector<DecoderConfigurationNALArray> naluArrays;
 };
 
-} // namespace FFmpeg
+} // namespace parser::avformat

--- a/YUViewLib/src/parser/AVFormat/DecoderConfigurationLhvC.cpp
+++ b/YUViewLib/src/parser/AVFormat/DecoderConfigurationLhvC.cpp
@@ -1,0 +1,76 @@
+/*  This file is part of YUView - The YUV player with advanced analytics toolset
+ *   <https://github.com/IENT/YUView>
+ *   Copyright (C) 2015  Institut f�r Nachrichtentechnik, RWTH Aachen University, GERMANY
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   In addition, as a special exception, the copyright holders give
+ *   permission to link the code of portions of this program with the
+ *   OpenSSL library under certain conditions as described in each
+ *   individual source file, and distribute linked combinations including
+ *   the two.
+ *
+ *   You must obey the GNU General Public License in all respects for all
+ *   of the code used other than OpenSSL. If you modify file(s) with this
+ *   exception, you may extend this exception to your version of the
+ *   file(s), but you are not obligated to do so. If you do not wish to do
+ *   so, delete this exception statement from your version. If you delete
+ *   this exception statement from all source files in the program, then
+ *   also delete it here.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "DecoderConfigurationLhvC.h"
+
+namespace parser::avformat
+{
+
+using namespace reader;
+
+void DecoderConfigurationLhvC::parse(const ByteVector &        data,
+                                     std::shared_ptr<TreeItem> root,
+                                     ParserAnnexBHEVC *        hevcParser,
+                                     BitratePlotModel *        bitrateModel)
+{
+  SubByteReaderLogging reader(data, root, "Extradata (HEVC lhvC format)");
+  reader.disableEmulationPrevention();
+
+  // ISO/IEC 14496-15, 9.6.3
+  this->configurationVersion =
+      reader.readBits("configurationVersion", 8, Options().withCheckEqualTo(1));
+  reader.readBits("reserved_4onebits", 4, Options().withCheckEqualTo(15));
+  this->min_spatial_segmentation_idc = reader.readBits("min_spatial_segmentation_idc", 12);
+  reader.readBits("reserver_6onebits", 6, Options().withCheckEqualTo(63));
+  this->parallelismType =
+      reader.readBits("parallelismType",
+                      2,
+                      Options().withMeaningVector({"mixed-type parallel decoding",
+                                                   "slice-based parallel decoding",
+                                                   "tile-based parallel decoding",
+                                                   "wavefront-based parallel decoding"}));
+  reader.readBits("reserver_2onebits", 2, Options().withCheckEqualTo(3));
+  this->numTemporalLayers  = reader.readBits("numTemporalLayers", 3);
+  this->temporalIdNested   = reader.readFlag("temporalIdNested");
+  this->lengthSizeMinusOne = reader.readBits("lengthSizeMinusOne", 2);
+  this->numOfArrays        = reader.readBits("numOfArrays", 8);
+
+  // Now parse the contained raw NAL unit arrays
+  for (unsigned i = 0; i < this->numOfArrays; i++)
+  {
+    DecoderConfigurationNALArray array;
+    array.parse(i, reader, hevcParser, bitrateModel);
+    this->naluArrays.push_back(array);
+  }
+}
+
+} // namespace parser::avformat

--- a/YUViewLib/src/parser/AVFormat/DecoderConfigurationLhvC.h
+++ b/YUViewLib/src/parser/AVFormat/DecoderConfigurationLhvC.h
@@ -1,6 +1,6 @@
 /*  This file is part of YUView - The YUV player with advanced analytics toolset
  *   <https://github.com/IENT/YUView>
- *   Copyright (C) 2015  Institut für Nachrichtentechnik, RWTH Aachen University, GERMANY
+ *   Copyright (C) 2015  Institut f�r Nachrichtentechnik, RWTH Aachen University, GERMANY
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -32,40 +32,35 @@
 
 #pragma once
 
-#include "FFMpegLibrariesTypes.h"
+#include <parser/HEVC/ParserAnnexBHEVC.h>
+#include <parser/common/BitratePlotModel.h>
+#include <parser/common/SubByteReaderLogging.h>
+#include <parser/common/TreeItem.h>
 
-namespace FFmpeg
+#include "DecoderConfigurationNalArray.h"
+
+namespace parser::avformat
 {
 
-class AVInputFormatWrapper
+class DecoderConfigurationLhvC
 {
 public:
-  AVInputFormatWrapper();
-  AVInputFormatWrapper(AVInputFormat *f, LibraryVersion v);
+  DecoderConfigurationLhvC() = default;
 
-  QString getName() const;
-  QString getLongName() const;
-  int     getFlags() const;
-  QString getExtensions() const;
-  QString getMimeType() const;
+  void parse(const ByteVector &        data,
+             std::shared_ptr<TreeItem> root,
+             ParserAnnexBHEVC *        hevcParser,
+             BitratePlotModel *        bitrateModel);
 
-  explicit operator bool() const { return fmt != nullptr; };
+  unsigned configurationVersion{};
+  unsigned min_spatial_segmentation_idc{};
+  unsigned parallelismType{};
+  unsigned numTemporalLayers{};
+  bool     temporalIdNested{};
+  unsigned lengthSizeMinusOne{};
+  unsigned numOfArrays{};
 
-private:
-  // Update all private values from the AVCodecContext
-  void update();
-
-  // These are here for debugging purposes.
-  QString name{};
-  QString long_name{};
-  int     flags{};
-  QString extensions{};
-  // const struct AVCodecTag * const *codec_tag;
-  // const AVClass *priv_class;
-  QString mime_type{};
-
-  AVInputFormat *fmt{};
-  LibraryVersion libVer{};
+  std::vector<DecoderConfigurationNALArray> naluArrays;
 };
 
-} // namespace FFmpeg
+} // namespace parser::avformat

--- a/YUViewLib/src/parser/AVFormat/DecoderConfigurationNalArray.cpp
+++ b/YUViewLib/src/parser/AVFormat/DecoderConfigurationNalArray.cpp
@@ -1,0 +1,80 @@
+/*  This file is part of YUView - The YUV player with advanced analytics toolset
+ *   <https://github.com/IENT/YUView>
+ *   Copyright (C) 2015  Institut f�r Nachrichtentechnik, RWTH Aachen University, GERMANY
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   In addition, as a special exception, the copyright holders give
+ *   permission to link the code of portions of this program with the
+ *   OpenSSL library under certain conditions as described in each
+ *   individual source file, and distribute linked combinations including
+ *   the two.
+ *
+ *   You must obey the GNU General Public License in all respects for all
+ *   of the code used other than OpenSSL. If you modify file(s) with this
+ *   exception, you may extend this exception to your version of the
+ *   file(s), but you are not obligated to do so. If you do not wish to do
+ *   so, delete this exception statement from your version. If you delete
+ *   this exception statement from all source files in the program, then
+ *   also delete it here.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "DecoderConfigurationNalArray.h"
+
+namespace parser::avformat
+{
+
+using namespace reader;
+
+void DecoderConfigurationNALUnit::parse(const unsigned        unitID,
+                                        SubByteReaderLogging &reader,
+                                        ParserAnnexBHEVC *    hevcParser,
+                                        BitratePlotModel *    bitrateModel)
+{
+  SubByteReaderLoggingSubLevel subLevel(reader, "nal unit " + std::to_string(unitID));
+
+  this->nalUnitLength = reader.readBits("nalUnitLength", 16);
+
+  // Get the bytes of the raw nal unit to pass to the "real" hevc parser
+  auto nalData = reader.readBytes("", nalUnitLength, Options().withLoggingDisabled());
+
+  // Let the hevc annexB parser parse this
+  auto parseResult =
+      hevcParser->parseAndAddNALUnit(unitID, nalData, {}, {}, reader.getCurrentItemTree());
+  if (parseResult.success && bitrateModel != nullptr && parseResult.bitrateEntry)
+    bitrateModel->addBitratePoint(0, *parseResult.bitrateEntry);
+}
+
+void DecoderConfigurationNALArray::parse(const unsigned        arrayID,
+                                         SubByteReaderLogging &reader,
+                                         ParserAnnexBHEVC *    hevcParser,
+                                         BitratePlotModel *    bitrateModel)
+{
+  SubByteReaderLoggingSubLevel subLevel(reader, "nal unit array " + std::to_string(arrayID));
+
+  // The next 3 bytes contain info about the array
+  this->array_completeness = reader.readFlag("array_completeness");
+  reader.readFlag("reserved_flag_false", Options().withCheckEqualTo(0, CheckLevel::Warning));
+  this->nal_unit_type = reader.readBits("nal_unit_type", 6);
+  this->numNalus      = reader.readBits("numNalus", 16);
+
+  for (unsigned i = 0; i < numNalus; i++)
+  {
+    DecoderConfigurationNALUnit nal;
+    nal.parse(i, reader, hevcParser, bitrateModel);
+    nalList.push_back(nal);
+  }
+}
+
+} // namespace parser::avformat

--- a/YUViewLib/src/parser/AVFormat/DecoderConfigurationNalArray.h
+++ b/YUViewLib/src/parser/AVFormat/DecoderConfigurationNalArray.h
@@ -32,21 +32,19 @@
 
 #pragma once
 
-#include <common/Typedef.h>
 #include <parser/HEVC/ParserAnnexBHEVC.h>
 #include <parser/common/BitratePlotModel.h>
 #include <parser/common/SubByteReaderLogging.h>
-#include <parser/common/TreeItem.h>
 
 namespace parser::avformat
 {
 
-class HVCCNalUnit
+class DecoderConfigurationNALUnit
 {
 public:
-  HVCCNalUnit() = default;
+  DecoderConfigurationNALUnit() = default;
 
-  void parse(unsigned                      unitID,
+  void parse(const unsigned                unitID,
              reader::SubByteReaderLogging &reader,
              ParserAnnexBHEVC *            hevcParser,
              BitratePlotModel *            bitrateModel);
@@ -54,52 +52,20 @@ public:
   unsigned nalUnitLength{};
 };
 
-class HVCCNalArray
+class DecoderConfigurationNALArray
 {
 public:
-  HVCCNalArray() = default;
+  DecoderConfigurationNALArray() = default;
 
-  void parse(unsigned                      arrayID,
+  void parse(const unsigned                arrayID,
              reader::SubByteReaderLogging &reader,
              ParserAnnexBHEVC *            hevcParser,
              BitratePlotModel *            bitrateModel);
 
-  bool                array_completeness{};
-  unsigned            nal_unit_type{};
-  unsigned            numNalus{};
-  vector<HVCCNalUnit> nalList;
-};
-
-class HVCC
-{
-public:
-  HVCC() = default;
-
-  void parse(ByteVector &              data,
-             std::shared_ptr<TreeItem> root,
-             ParserAnnexBHEVC *        hevcParser,
-             BitratePlotModel *        bitrateModel);
-
-  unsigned configurationVersion{};
-  unsigned general_profile_space{};
-  bool     general_tier_flag{};
-  unsigned general_profile_idc{};
-  unsigned general_profile_compatibility_flags{};
-  uint64_t general_constraint_indicator_flags{};
-  unsigned general_level_idc{};
-  unsigned min_spatial_segmentation_idc{};
-  unsigned parallelismType{};
-  unsigned chromaFormat{};
-  unsigned bitDepthLumaMinus8{};
-  unsigned bitDepthChromaMinus8{};
-  unsigned avgFrameRate{};
-  unsigned constantFrameRate{};
-  unsigned numTemporalLayers{};
-  bool     temporalIdNested{};
-  unsigned lengthSizeMinusOne{};
-  unsigned numOfArrays{};
-
-  vector<HVCCNalArray> naluArrays;
+  bool                                     array_completeness{};
+  unsigned                                 nal_unit_type{};
+  unsigned                                 numNalus{};
+  std::vector<DecoderConfigurationNALUnit> nalList;
 };
 
 } // namespace parser::avformat

--- a/YUViewLib/src/parser/AVFormat/ParserAVFormat.h
+++ b/YUViewLib/src/parser/AVFormat/ParserAVFormat.h
@@ -79,17 +79,23 @@ private:
   // Used for parsing if the packets contain an obu file that we can parse.
   std::unique_ptr<ParserAV1OBU> obuParser;
 
-  bool parseExtradata_generic(ByteVector &extradata);
-  bool parseExtradata_AVC(ByteVector &extradata);
-  bool parseExtradata_hevc(ByteVector &extradata);
-  bool parseExtradata_mpeg2(ByteVector &extradata);
+  enum class HEVCExtradataType
+  {
+    hvcC,
+    lhvC
+  };
+
+  bool parseExtradataGeneric(const ByteVector &extradata);
+  bool parseExtradataAVC(const ByteVector &extradata);
+  bool parseExtradataHEVC(const ByteVector &extradata, const HEVCExtradataType type);
+  bool parseExtradataMPEG2(const ByteVector &extradata);
 
   // Parse all NAL units in data using the AnnexB parser
   std::map<std::string, unsigned>
-  parseByteVectorAnnexBStartCodes(ByteVector &                   data,
-                                  FFmpeg::PacketDataFormat       dataFormat,
-                                  BitratePlotModel::BitrateEntry packetBitrateEntry,
-                                  std::shared_ptr<TreeItem>      item);
+  parseByteVectorAnnexBStartCodes(const ByteVector &                   data,
+                                  const FFmpeg::PacketDataFormat       dataFormat,
+                                  const BitratePlotModel::BitrateEntry packetBitrateEntry,
+                                  std::shared_ptr<TreeItem>            item);
 
   // When the parser is used in the bitstream analysis window, the runParsingOfFile is used and
   // we update this list while parsing the file.

--- a/YUViewLib/src/playlistitem/playlistItems.cpp
+++ b/YUViewLib/src/playlistitem/playlistItems.cpp
@@ -142,6 +142,8 @@ playlistItem *askUserForFileTypeAndCreatePlalistItem(QWidget *  parent,
       return new playlistItemStatisticsFile(fileName, openMode);
     }
   }
+
+  return nullptr;
 }
 
 } // namespace


### PR DESCRIPTION
Add parsing of the lhvC Configuration parameters from MP4. These are used for MH-HEVC bitstreams. Unfortunately, FFmpeg does not support reading this yet and it also does not give us these in the extradata. So the solution for now is to just open the input file "raw" and search for the characters `lhvC`. The sequence is searched for in the first and last 5k of data in the file. 
This is very hacky but there is no other way unless we would have our own mp4 parser.