### PR TITLE
fix: initialize splitViewWidgetState to prevent uninitialized use in ViewStateHandler::savePlaylist

### DIFF
--- a/YUViewLib/src/ui/ViewStateHandler.h
+++ b/YUViewLib/src/ui/ViewStateHandler.h
@@ -105,11 +105,11 @@ private:
   class splitViewWidgetState
   {
   public:
-    QPointF centerOffset;
-    double zoomFactor;
-    bool splitting;
-    double splittingPoint;
-    int viewMode;
+    QPointF centerOffset{};
+    double zoomFactor{};
+    bool splitting{};
+    double splittingPoint{};
+    int viewMode{};
   };
   splitViewWidgetState viewStates[8];
 


### PR DESCRIPTION


Ensure that the splitViewWidgetState member is properly initialized to avoid using the uninitialized member `splitting` in the ViewStateHandler::savePlaylist method.