### PR TITLE
Test new runners with updated Qt

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -38,7 +38,8 @@ jobs:
     strategy:
       matrix:
         include: 
-          - os: macos-12
+          - os: macos-13
+          - os: macos-14
     steps:
     - uses: actions/checkout@v4
     - run: git fetch --prune --unshallow
@@ -59,22 +60,22 @@ jobs:
       matrix:
         include: 
           - os: ubuntu-20.04
-            QT_FILE: qtBase_6.5.2_ubuntu20.zip
+            QT_FILE: qtBase_6.7.2_ubuntu20.zip
             LIBDE265_REMOTE: libde265.so
             LIBDE265_LOCAL: libde265-internals.so
             ARTIFACT_NAME: YUView.Ubuntu20.AppImage
             CPU_COUNT_COMMAND: nproc
-          - os: macos-11
-            QT_FILE: qtBase_6.5.2_mac11.zip
-            LIBDE265_REMOTE: libde265.dylib
-            LIBDE265_LOCAL: libde265-internals.dylib
-            ARTIFACT_NAME: YUView-Mac11-BigSur.zip
-            CPU_COUNT_COMMAND: sysctl -n hw.logicalcpu
           - os: macos-12
-            QT_FILE: qtBase_6.5.2_mac12.zip
+            QT_FILE: qtBase_6.7.2_mac12.zip
             LIBDE265_REMOTE: libde265.dylib
             LIBDE265_LOCAL: libde265-internals.dylib
             ARTIFACT_NAME: YUView-Mac12-Monterey.zip
+            CPU_COUNT_COMMAND: sysctl -n hw.logicalcpu
+          - os: macos-14
+            QT_FILE: qtBase_6.7.2_mac14.zip
+            LIBDE265_REMOTE: libde265.dylib
+            LIBDE265_LOCAL: libde265-internals.dylib
+            ARTIFACT_NAME: YUView-Mac12-Sonoma.zip
             CPU_COUNT_COMMAND: sysctl -n hw.logicalcpu
     steps:
     - uses: actions/checkout@v4
@@ -84,7 +85,7 @@ jobs:
         cd ../../
         mkdir -p YUViewQt/YUViewQt
         cd YUViewQt/YUViewQt
-        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtBase-6.5.2/${{matrix.QT_FILE}} -o Qt.zip
+        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtBase-6.7.2/${{matrix.QT_FILE}} -o Qt.zip
         unzip -qa Qt.zip
         echo "$GITHUB_WORKSPACE/../../YUViewQt/YUViewQt/Qt/bin" >> $GITHUB_PATH
       shell: bash
@@ -149,11 +150,11 @@ jobs:
           - os: windows-2019
             auto_update: true
             ARTIFACT_NAME: YUView-Win2019.zip
-            QT_FILE: qtBase_6.5.2_win2019.zip
+            QT_FILE: qtBase_6.7.2_win2019.zip
           - os: windows-2019
             auto_update: false
             ARTIFACT_NAME: YUView-Win2019-noautoupdate.zip
-            QT_FILE: qtBase_6.5.2_win2019.zip
+            QT_FILE: qtBase_6.7.2_win2019.zip
     steps:
     - uses: actions/checkout@v4
     - uses: ilammy/msvc-dev-cmd@v1
@@ -163,7 +164,7 @@ jobs:
         cd ../../
         mkdir -p YUViewQt/YUViewQt
         cd YUViewQt/YUViewQt
-        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtBase-6.5.2/${{matrix.QT_FILE}} -o Qt.zip
+        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/QtBase-6.7.2/${{matrix.QT_FILE}} -o Qt.zip
         7z x  Qt.zip
         echo "${{ github.workspace }}\..\..\YUViewQt\YUViewQt\Qt\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install libde265
@@ -177,7 +178,7 @@ jobs:
       run: |
         mkdir openSSL
         cd openSSL
-        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/openSSL1.1.1u/openSSL_1_1_1u_win2019.zip -o openSSL.zip
+        curl -L https://github.com/ChristianFeldmann/YUViewQt/releases/download/openSSL1.1.1w/openSSL_1_1_1w_win2019.zip -o openSSL.zip
         7z x openSSL.zip
         cd ..
     - name: Activate auto update


### PR DESCRIPTION
 - The Github runners were updated again. Macos 11 was deprecated and Macos-14 (M1) was added.
 - In that run I also had to update the Qt version to compile on M1. The new version is 6.7.2