### PR TITLE
qmake/app: Add install target for MacOS

### DIFF
--- a/YUViewApp/YUViewApp.pro
+++ b/YUViewApp/YUViewApp.pro
@@ -55,6 +55,17 @@ contains(QT_ARCH, x86_32|i386) {
 macx {
     ICON = images/YUView.icns
     SVNN = $$system("git describe --tags")
+
+    isEmpty(PREFIX) {
+        PREFIX = /
+    }
+    isEmpty(BIINDIR) {
+        BINDIR = Applications
+    }
+
+    target.path = $$PREFIX/$$BINDIR/
+
+    INSTALLS += target
 }
 
 linux {


### PR DESCRIPTION
This patch adds an install target for MacOS, so one can run `make install` after building on MacOS to copy the built package into `/Applications`, or `$$PREFIX/Applications`.