### PR TITLE
EnumMapper: Fix out-of-bounds read

### DIFF
--- a/YUViewLib/src/common/EnumMapper.h
+++ b/YUViewLib/src/common/EnumMapper.h
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <array>
 #include <iterator>
+#include <memory>
 #include <optional>
 #include <string_view>
 
@@ -59,21 +60,15 @@ public:
     using pointer           = ValueNamePair *;
     using reference         = ValueNamePair &;
 
-    Iterator(const ItemIterator itItem, const NameIterator itName) : itItem(itItem), itName(itName)
-    {
-      this->valueNamePair.first  = *itItem;
-      this->valueNamePair.second = *itName;
-    }
+    Iterator(const ItemIterator itItem, const NameIterator itName) : itItem(itItem), itName(itName) {}
 
-    ValueNamePair const &operator*() const { return this->valueNamePair; }
-    ValueNamePair const *operator->() const { return &this->valueNamePair; }
+    ValueNamePair const operator*() const { return ValueNamePair(*this->itItem, *this->itName); }
+    std::unique_ptr<ValueNamePair> const operator->() const { return std::make_unique<ValueNamePair>(*this->itItem, *this->itName); }
 
     Iterator &operator++()
     {
       ++this->itItem;
       ++this->itName;
-      this->valueNamePair.first  = *this->itItem;
-      this->valueNamePair.second = *this->itName;
       return *this;
     }
 
@@ -89,7 +84,6 @@ public:
   private:
     ItemIterator  itItem;
     NameIterator  itName;
-    ValueNamePair valueNamePair{};
   };
 
   Iterator begin() const { return Iterator(this->items.begin(), this->names.begin()); }


### PR DESCRIPTION
This PR closes issue #607.  Read there for some more details of the issue.

Defer dereferencing the component iterators (`itItem` and `itName`) of `EnumMapper::Iterator` until `EnumMapper::Iterator` itself is dereferenced. This prevents an out-of-bounds read when constructing an `EnumMapper::Iterator` from `::end()` iterators.

Been a while since I've done any of this C++ STL stuff, so wouldn't mind some feedback.  In particular, I wasn't sure the best way to make `operator->` work.  The `std::unique_ptr` approach I've taken at the moment should work, despite not really returning anything that points to the internal values of the `EnumMapper::Iterator` — seeing as the returned pointer is marked `const` this doesn't really matter.