### PR TITLE
StatisticsUIHandler: Don't dereference secondaryControlsWidget if NULL

### DIFF
--- a/YUViewLib/src/statistics/StatisticUIHandler.cpp
+++ b/YUViewLib/src/statistics/StatisticUIHandler.cpp
@@ -294,7 +294,8 @@ void StatisticUIHandler::onSecondaryStatisticsControlChanged()
 
 void StatisticUIHandler::deleteSecondaryStatisticsHandlerControls()
 {
-  secondaryControlsWidget->deleteLater();
+  if (secondaryControlsWidget)
+    secondaryControlsWidget->deleteLater();
   ui2.clear();
   itemNameCheckBoxes[1].clear();
   itemOpacitySliders[1].clear();


### PR DESCRIPTION
Fixes #604.

I haven't done all that much analysis on this, but:
* This is the line that causes the crash observed in #604.
* Elsewhere in this file where `secondaryControlWidget` is dereferenced, it is guarded by a NULL check.
* Empirically, this fixes #604.