### PR TITLE
Fix : reenable `Build App (Mac)` on macos 13

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -131,7 +131,7 @@ jobs:
         zip -r ${{matrix.ARTIFACT_NAME}} YUView.app/
         mkdir $GITHUB_WORKSPACE/artifacts
         cp ${{matrix.ARTIFACT_NAME}} $GITHUB_WORKSPACE/artifacts/
-      if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
+      if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
     - name: Build Appimage (Linux)
       run: |
         cd build


### PR DESCRIPTION
So we can download the Artifact(YUView-Mac13-Monterey.zip) of macos 13 form github-actions.