### PR TITLE
Add support for 32-bit content

### DIFF
--- a/YUViewLib/src/video/rgb/ConversionRGB.cpp
+++ b/YUViewLib/src/video/rgb/ConversionRGB.cpp
@@ -40,9 +40,22 @@ namespace video::rgb
 namespace
 {
 
-template <typename T> T swapLowestBytes(const T &val)
+template<int bitDepth>
+using UintValueType = typename std::conditional_t<bitDepth == 8,
+                                                  uint8_t*,
+                                                  std::conditional_t<bitDepth == 16, uint16_t*, uint32_t*>>;
+
+template <int bitDepth, typename T> T swapLowestBytes(const T &val)
 {
-  return ((val & 0xff) << 8) + ((val & 0xff00) >> 8);
+  if (bitDepth <= 8) {
+    return val;
+  }
+  if (bitDepth <= 16) {
+    return ((val & 0xff) << 8) | ((val & 0xff00) >> 8);
+  }
+  if (bitDepth <= 32) {
+    return ((val & 0xff) << 24) | ((val & 0xff00) << 8) | ((val & 0xff0000) >> 8) | ((val & 0xff000000) >> 24);
+  }
 };
 
 int getOffsetToFirstByteOfComponent(const Channel         channel,
@@ -73,7 +86,7 @@ void convertRGBToARGB(const QByteArray &    sourceBuffer,
   const auto offsetToNextValue =
       srcPixelFormat.getDataLayout() == DataLayout::Planar ? 1 : srcPixelFormat.nrChannels();
 
-  typedef typename std::conditional<bitDepth == 8, uint8_t *, uint16_t *>::type InValueType;
+  using InValueType = UintValueType<bitDepth>;
   const auto setAlpha = outputHasAlpha && srcPixelFormat.hasAlpha();
 
   const auto rawData = (InValueType)sourceBuffer.data();
@@ -96,9 +109,9 @@ void convertRGBToARGB(const QByteArray &    sourceBuffer,
     const auto isBigEndian  = bitDepth > 8 && srcPixelFormat.getEndianess() == Endianness::Big;
     auto       convertValue = [&isBigEndian, &rightShift](
                             const InValueType sourceData, const int scale, const bool invert) {
-      auto value = static_cast<int>(sourceData[0]);
+      auto value = static_cast<int64_t>(sourceData[0]);
       if (isBigEndian)
-        value = swapLowestBytes(value);
+        value = swapLowestBytes<bitDepth>(value);
       value = ((value * scale) >> rightShift);
       value = functions::clip(value, 0, 255);
       if (invert)
@@ -161,7 +174,7 @@ void convertRGBPlaneToARGB(const QByteArray &    sourceBuffer,
   const auto offsetToNextValue =
       srcPixelFormat.getDataLayout() == DataLayout::Planar ? 1 : srcPixelFormat.nrChannels();
 
-  typedef typename std::conditional<bitDepth == 8, uint8_t *, uint16_t *>::type InValueType;
+  using InValueType = UintValueType<bitDepth>;
 
   auto       src                    = (InValueType)sourceBuffer.data();
   const auto displayComponentOffset = srcPixelFormat.getChannelPosition(displayChannel);
@@ -172,9 +185,9 @@ void convertRGBPlaneToARGB(const QByteArray &    sourceBuffer,
 
   for (size_t i = 0; i < frameSize.width * frameSize.height; i++)
   {
-    auto val = static_cast<int>(src[0]);
+    auto val = static_cast<int64_t>(src[0]);
     if (bitDepth > 8 && srcPixelFormat.getEndianess() == Endianness::Big)
-      val = swapLowestBytes(val);
+      val = swapLowestBytes<bitDepth>(val);
     val = (val * scale) >> shiftTo8Bit;
     val = functions::clip(val, 0, 255);
     if (invert)
@@ -202,7 +215,7 @@ rgba_t getPixelValue(const QByteArray &    sourceBuffer,
       srcPixelFormat.getDataLayout() == DataLayout::Planar ? 1 : srcPixelFormat.nrChannels();
   const auto offsetPixelPos = frameSize.width * pixelPos.y() + pixelPos.x();
 
-  typedef typename std::conditional<bitDepth == 8, uint8_t *, uint16_t *>::type InValueType;
+  using InValueType = UintValueType<bitDepth>;
 
   const auto rawData  = (InValueType)sourceBuffer.data();
   auto       srcPixel = rawData + offsetPixelPos * offsetToNextValue;
@@ -218,7 +231,7 @@ rgba_t getPixelValue(const QByteArray &    sourceBuffer,
     auto src = srcPixel + offset;
     auto val = (unsigned)src[0];
     if (bitDepth > 8 && srcPixelFormat.getEndianess() == Endianness::Big)
-      val = swapLowestBytes(val);
+      val = swapLowestBytes<bitDepth>(val);
     value[channel] = val;
   }
 
@@ -238,7 +251,7 @@ void convertInputRGBToARGB(const QByteArray &    sourceBuffer,
                            const bool            premultiplyAlpha)
 {
   const auto bitsPerSample = srcPixelFormat.getBitsPerSample();
-  if (bitsPerSample < 8 || bitsPerSample > 16)
+  if (bitsPerSample < 8 || bitsPerSample > 32)
     throw std::invalid_argument("Invalid bit depth in pixel format for conversion");
 
   if (bitsPerSample == 8)
@@ -251,8 +264,18 @@ void convertInputRGBToARGB(const QByteArray &    sourceBuffer,
                         limitedRange,
                         outputHasAlpha,
                         premultiplyAlpha);
-  else
+  else if (9 <= bitsPerSample && bitsPerSample <= 16)
     convertRGBToARGB<16>(sourceBuffer,
+                         srcPixelFormat,
+                         targetBuffer,
+                         frameSize,
+                         componentInvert,
+                         componentScale,
+                         limitedRange,
+                         outputHasAlpha,
+                         premultiplyAlpha);
+  else
+    convertRGBToARGB<32>(sourceBuffer,
                          srcPixelFormat,
                          targetBuffer,
                          frameSize,
@@ -273,7 +296,7 @@ void convertSinglePlaneOfRGBToGreyscaleARGB(const QByteArray &    sourceBuffer,
                                             const bool            limitedRange)
 {
   const auto bitsPerSample = srcPixelFormat.getBitsPerSample();
-  if (bitsPerSample < 8 || bitsPerSample > 16)
+  if (bitsPerSample < 8 || bitsPerSample > 32)
     throw std::invalid_argument("Invalid bit depth in pixel format for conversion");
 
   if (bitsPerSample == 8)
@@ -285,8 +308,17 @@ void convertSinglePlaneOfRGBToGreyscaleARGB(const QByteArray &    sourceBuffer,
                              scale,
                              invert,
                              limitedRange);
-  else
+  else if (9 <= bitsPerSample && bitsPerSample <= 16)
     convertRGBPlaneToARGB<16>(sourceBuffer,
+                              srcPixelFormat,
+                              targetBuffer,
+                              frameSize,
+                              displayChannel,
+                              scale,
+                              invert,
+                              limitedRange);
+  else
+    convertRGBPlaneToARGB<32>(sourceBuffer,
                               srcPixelFormat,
                               targetBuffer,
                               frameSize,
@@ -302,13 +334,15 @@ rgba_t getPixelValueFromBuffer(const QByteArray &    sourceBuffer,
                                const QPoint &        pixelPos)
 {
   const auto bitsPerSample = srcPixelFormat.getBitsPerSample();
-  if (bitsPerSample < 8 || bitsPerSample > 16)
+  if (bitsPerSample < 8 || bitsPerSample > 32)
     throw std::invalid_argument("Invalid bit depth in pixel format for conversion");
 
   if (bitsPerSample == 8)
     return getPixelValue<8>(sourceBuffer, srcPixelFormat, frameSize, pixelPos);
-  else
+  else if (9 <= bitsPerSample && bitsPerSample <= 16)
     return getPixelValue<16>(sourceBuffer, srcPixelFormat, frameSize, pixelPos);
+  else
+    return getPixelValue<32>(sourceBuffer, srcPixelFormat, frameSize, pixelPos);
 }
 
 } // namespace video::rgb

--- a/YUViewLib/src/video/rgb/PixelFormatRGB.cpp
+++ b/YUViewLib/src/video/rgb/PixelFormatRGB.cpp
@@ -85,7 +85,7 @@ PixelFormatRGB::PixelFormatRGB(const std::string &name)
 
 bool PixelFormatRGB::isValid() const
 {
-  return this->bitsPerSample >= 8 && this->bitsPerSample <= 16;
+  return this->bitsPerSample >= 8 && this->bitsPerSample <= 32;
 }
 
 unsigned PixelFormatRGB::nrChannels() const
@@ -123,7 +123,7 @@ std::string PixelFormatRGB::getName() const
  */
 std::size_t PixelFormatRGB::bytesPerFrame(Size frameSize) const
 {
-  auto bpsValid = this->bitsPerSample >= 8 && this->bitsPerSample <= 16;
+  auto bpsValid = this->bitsPerSample >= 8 && this->bitsPerSample <= 32;
   if (!bpsValid || !frameSize.isValid())
     return 0;
 

--- a/YUViewLib/src/video/rgb/PixelFormatRGB.h
+++ b/YUViewLib/src/video/rgb/PixelFormatRGB.h
@@ -97,6 +97,23 @@ struct rgba_t
   };
 };
 
+template<typename T>
+inline T convertBitness(T value, unsigned src_bitness, unsigned dst_bitness) {
+  if (src_bitness > dst_bitness)
+    return value >> (src_bitness - dst_bitness);
+  else
+    return value << (dst_bitness - src_bitness);
+}
+
+inline rgba_t convertBitness(rgba_t value, unsigned src_bitness, unsigned dst_bitness) {
+  return rgba_t({
+    convertBitness(value.R, src_bitness, dst_bitness),
+    convertBitness(value.G, src_bitness, dst_bitness),
+    convertBitness(value.B, src_bitness, dst_bitness),
+    convertBitness(value.A, src_bitness, dst_bitness)
+  });
+}
+
 enum class ChannelOrder
 {
   RGB,

--- a/YUViewLib/src/video/rgb/PixelFormatRGBGuess.cpp
+++ b/YUViewLib/src/video/rgb/PixelFormatRGBGuess.cpp
@@ -97,7 +97,10 @@ std::optional<PixelFormatRGB> checkForPixelFormatIndicatorInName(
                                               {12, "12"},
                                               {16, "16"},
                                               {16, "64"},
-                                              {16, "48"}})
+                                              {16, "48"},
+                                              {32, "32"},
+                                              {32, "96"},
+                                              {32, "128"}})
       {
         for (auto [endianness, endiannessName] :
              {std::pair<Endianness, std::string>{Endianness::Little, ""},

--- a/YUViewLib/src/video/rgb/videoHandlerRGB.cpp
+++ b/YUViewLib/src/video/rgb/videoHandlerRGB.cpp
@@ -624,7 +624,7 @@ void videoHandlerRGB::convertRGBToImage(const QByteArray &sourceBuffer, QImage &
   }
 
   const auto bps = this->srcPixelFormat.getBitsPerSample();
-  if (bps < 8 || bps > 16)
+  if (bps < 8 || bps > 32)
   {
     DEBUG_RGB("Unsupported bit depth. 8-16 bit are supported.");
     return;
@@ -902,7 +902,7 @@ QImage videoHandlerRGB::calculateDifference(FrameHandler    *item2,
   const auto posG     = srcPixelFormat.getChannelPosition(Channel::Green);
   const auto posB     = srcPixelFormat.getChannelPosition(Channel::Blue);
 
-  if (bitDepth >= 8 && bitDepth <= 16)
+  if (bitDepth >= 8 && bitDepth <= 32)
   {
     // How many values do we have to skip in src to get to the next input value?
     // In case of 8 or less bits this is 1 byte per value, for 9 to 16 bits it is 2 bytes per value.
@@ -910,7 +910,7 @@ QImage videoHandlerRGB::calculateDifference(FrameHandler    *item2,
     if (srcPixelFormat.getDataLayout() == DataLayout::Planar)
       offsetToNextValue = 1;
 
-    if (bitDepth > 8 && bitDepth <= 16)
+    if (bitDepth > 8 && bitDepth <= 32)
     {
       // 9 to 16 bits per component. We assume two bytes per value.
       // First get the pointer to the first value of each channel. (this item)

--- a/YUViewUnitTest/video/rgb/ConversionRGBTest.cpp
+++ b/YUViewUnitTest/video/rgb/ConversionRGBTest.cpp
@@ -82,7 +82,7 @@ int scaleShiftClipInvertValue(const int  value,
                               const int  scale,
                               const bool invert)
 {
-  const auto valueOriginalDepth = (value >> (12 - bitDepth));
+  const auto valueOriginalDepth = static_cast<int64_t>(convertBitness(value, 12, bitDepth));
   const auto valueScaled        = valueOriginalDepth * scale;
   const auto value8BitDepth     = (valueScaled >> (bitDepth - 8));
   const auto valueClipped       = functions::clip(value8BitDepth, 0, 255);
@@ -244,7 +244,7 @@ void runTestForAllParameters(TestingFunction testingFunction)
 {
   for (const auto endianness : {Endianness::Little, Endianness::Big})
   {
-    for (const auto bitDepth : {8, 10, 12})
+    for (const auto bitDepth : {8, 10, 12, 16, 32})
     {
       for (const auto &alphaMode : AlphaModeMapper.getValues())
       {

--- a/YUViewUnitTest/video/rgb/CreateTestData.cpp
+++ b/YUViewUnitTest/video/rgb/CreateTestData.cpp
@@ -43,12 +43,12 @@ void scaleValueToBitDepthAndPushIntoArra(QByteArray      &data,
                                          const int        bitDepth,
                                          const Endianness endianness)
 {
-  const auto shift = 12 - bitDepth;
+  const auto scaledValue = convertBitness(value, 12, bitDepth);
+
   if (bitDepth == 8)
-    data.push_back(value >> shift);
-  else
+    data.push_back(scaledValue);
+  else if (bitDepth <= 16)
   {
-    const auto scaledValue = (value >> shift);
     const auto upperByte   = ((scaledValue & 0xff00) >> 8);
     const auto lowerByte   = (scaledValue & 0xff);
     if (endianness == Endianness::Little)
@@ -60,6 +60,21 @@ void scaleValueToBitDepthAndPushIntoArra(QByteArray      &data,
     {
       data.push_back(upperByte);
       data.push_back(lowerByte);
+    }
+  } else {
+    if (endianness == Endianness::Little)
+    {
+      data.push_back((scaledValue >> 0) & 0xFF);
+      data.push_back((scaledValue >> 8) & 0xFF);
+      data.push_back((scaledValue >> 16) & 0xFF);
+      data.push_back((scaledValue >> 24) & 0xFF);
+    }
+    else
+    {
+      data.push_back((scaledValue >> 24) & 0xFF);
+      data.push_back((scaledValue >> 16) & 0xFF);
+      data.push_back((scaledValue >> 8) & 0xFF);
+      data.push_back((scaledValue >> 0) & 0xFF);
     }
   }
 }

--- a/YUViewUnitTest/video/rgb/GetPixelValueTest.cpp
+++ b/YUViewUnitTest/video/rgb/GetPixelValueTest.cpp
@@ -48,7 +48,6 @@ void testGetPixelValueFromBuffer(const QByteArray     &sourceBuffer,
                                  const PixelFormatRGB &srcPixelFormat)
 {
   const auto bitDepth = srcPixelFormat.getBitsPerSample();
-  const auto shift    = 12 - bitDepth;
 
   int testValueIndex = 0;
   for (int y : {0, 1, 2, 3})
@@ -60,8 +59,7 @@ void testGetPixelValueFromBuffer(const QByteArray     &sourceBuffer,
           getPixelValueFromBuffer(sourceBuffer, srcPixelFormat, TEST_FRAME_SIZE, pixelPos);
 
       const auto testValue     = TEST_VALUES_12BIT[testValueIndex++];
-      auto       expectedValue = rgba_t(
-          {testValue.R >> shift, testValue.G >> shift, testValue.B >> shift, testValue.A >> shift});
+      auto       expectedValue = convertBitness(testValue, 12, bitDepth);
       if (!srcPixelFormat.hasAlpha())
         expectedValue.A = 0;
 
@@ -78,7 +76,7 @@ TEST(GetPixelValueTest, TestGetPixelValueFromBuffer)
 {
   for (const auto endianness : EndianessMapper.getValues())
   {
-    for (auto bitDepth : {8, 10, 12})
+    for (auto bitDepth : {8, 10, 12, 16, 32})
     {
       for (const auto &alphaMode : AlphaModeMapper.getValues())
       {

--- a/YUViewUnitTest/video/rgb/PixelFormatRGBGuessTest.cpp
+++ b/YUViewUnitTest/video/rgb/PixelFormatRGBGuessTest.cpp
@@ -148,6 +148,12 @@ INSTANTIATE_TEST_SUITE_P(
                         PixelFormatRGB(16, DataLayout::Packed, ChannelOrder::RGB)}),
         TestParameters({FileInfoForGuess({"something_1920x1080_rgb64.yuv", "", BytesNoAlpha}),
                         PixelFormatRGB(16, DataLayout::Packed, ChannelOrder::RGB)}),
+        TestParameters({FileInfoForGuess({"something_1920x1080_rgb32.yuv", "", BytesNoAlpha}),
+                        PixelFormatRGB(32, DataLayout::Packed, ChannelOrder::RGB)}),
+        TestParameters({FileInfoForGuess({"something_1920x1080_rgb96.yuv", "", BytesNoAlpha}),
+                        PixelFormatRGB(32, DataLayout::Packed, ChannelOrder::RGB)}),
+        TestParameters({FileInfoForGuess({"something_1920x1080_rgb128.yuv", "", BytesNoAlpha}),
+                        PixelFormatRGB(32, DataLayout::Packed, ChannelOrder::RGB)}),
         TestParameters({FileInfoForGuess({"something_1920x1080_rgb11.yuv", "", BytesNoAlpha}),
                         PixelFormatRGB(8, DataLayout::Packed, ChannelOrder::RGB)}),
 

--- a/YUViewUnitTest/video/rgb/PixelFormatRGBTest.cpp
+++ b/YUViewUnitTest/video/rgb/PixelFormatRGBTest.cpp
@@ -44,7 +44,7 @@ std::vector<PixelFormatRGB> getAllFormats()
 {
   std::vector<PixelFormatRGB> allFormats;
 
-  for (int bitsPerPixel = 8; bitsPerPixel <= 16; bitsPerPixel++)
+  for (int bitsPerPixel = 8; bitsPerPixel <= 32; bitsPerPixel++)
     for (auto dataLayout : DataLayoutMapper.getValues())
       for (auto channelOrder : ChannelOrderMapper.getValues())
         for (auto alphaMode : AlphaModeMapper.getValues())
@@ -99,7 +99,7 @@ TEST(PixelFormatRGBTest, testInvalidFormats)
   invalidFormats.push_back(PixelFormatRGB(0, video::DataLayout::Packed, ChannelOrder::RGB));
   invalidFormats.push_back(PixelFormatRGB(1, video::DataLayout::Packed, ChannelOrder::RGB));
   invalidFormats.push_back(PixelFormatRGB(7, video::DataLayout::Packed, ChannelOrder::RGB));
-  invalidFormats.push_back(PixelFormatRGB(17, video::DataLayout::Packed, ChannelOrder::RGB));
+  invalidFormats.push_back(PixelFormatRGB(33, video::DataLayout::Packed, ChannelOrder::RGB));
   invalidFormats.push_back(PixelFormatRGB(200, video::DataLayout::Packed, ChannelOrder::RGB));
 
   for (auto fmt : invalidFormats)


### PR DESCRIPTION
Some notable changes:
- In some places I had to temporarily cast pixel values to 64bit to prevent overflow when scaling
- The method of shifting by `shift = 12 - bitDepth` is an undefined behaviour when the shift becomes negative. This is probably why 16-bit was excluded in many tests. I added `convertBitness()` function which handles this case correctly.