### PR TITLE
Fix bug for caching

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
-# We'll use defaults from the LLVM style, but with 4 columns indentation.
 IndentWidth: 2
+ContinuationIndentWidth: 2
 ---
 Language: Cpp
 Standard: c++17

--- a/YUViewLib/src/video/yuv/videoHandlerYUV.cpp
+++ b/YUViewLib/src/video/yuv/videoHandlerYUV.cpp
@@ -3035,9 +3035,9 @@ void videoHandlerYUV::guessAndSetPixelFormat(
 {
   auto format = guessPixelFormatFromSizeAndName(frameFormat, fileInfo);
   if (format.isValid())
-    this->setSrcPixelFormat(format);
+    this->setSrcPixelFormat(format, false);
   else
-    this->setSrcPixelFormat(PixelFormatYUV(Subsampling::YUV_420, 8, PlaneOrder::YUV));
+    this->setSrcPixelFormat(PixelFormatYUV(Subsampling::YUV_420, 8, PlaneOrder::YUV), false);
 }
 
 /** Try to guess the format of the raw YUV data. A list of candidates is tried (candidateModes) and


### PR DESCRIPTION
Don't emit the change signals when the pixel format is guessed from the filename. This will invalidate the cache in the video and it will never switch to a valid cache.