### PR TITLE
Add frame offset setting for comparing misaligned videos

### DIFF
--- a/YUViewLib/src/ui/PlaybackController.cpp
+++ b/YUViewLib/src/ui/PlaybackController.cpp
@@ -118,6 +118,10 @@ PlaybackController::PlaybackController()
 
   this->updateSettings();
   this->enableControls(false);
+
+  // Initialize offset spinbox
+  this->ui.offsetSpinBox->setValue(0);
+  this->frameOffset = 0;
 }
 
 void PlaybackController::setSplitViews(splitViewWidget *primary, splitViewWidget *separate)
@@ -150,6 +154,13 @@ bool PlaybackController::isWaitingForCaching() const
 int PlaybackController::getCurrentFrame() const
 {
   return this->currentFrameIdx;
+}
+
+int PlaybackController::getCurrentFrameWithOffset() const
+{
+  if (this->currentFrameIdx == -1)
+    return -1;
+  return this->getEffectiveFrame(this->currentFrameIdx);
 }
 
 void PlaybackController::setRepeatModeAndUpdateIcons(const RepeatMode mode)
@@ -304,6 +315,12 @@ void PlaybackController::currentSelectedItemsChanged(playlistItem *item1,
                                                      playlistItem *item2,
                                                      bool          chageByPlayback)
 {
+  // Save the current offset for the previous item
+  if (this->currentItem[0] && this->frameOffset != 0)
+  {
+    this->itemFrameOffsets[this->currentItem[0]->properties().id] = this->frameOffset;
+  }
+  
   QSettings settings;
   auto continuePlayback = settings.value("ContinuePlaybackOnSequenceSelection", false).toBool();
 
@@ -312,6 +329,17 @@ void PlaybackController::currentSelectedItemsChanged(playlistItem *item1,
 
   this->currentItem[0] = item1;
   this->currentItem[1] = item2;
+
+  // Restore the offset for the new item
+  if (item1)
+  {
+    int savedOffset = this->itemFrameOffsets.value(item1->properties().id, 0);
+    this->setFrameOffset(savedOffset);
+  }
+  else
+  {
+    this->setFrameOffset(0);
+  }
 
   if (!this->anyItemIndexedByFrame())
   {
@@ -583,6 +611,7 @@ void PlaybackController::enableControls(bool enable)
 {
   this->ui.frameSlider->setEnabled(enable);
   this->ui.frameSpinBox->setEnabled(enable);
+  this->ui.offsetSpinBox->setEnabled(enable);
   this->ui.fpsLabel->setEnabled(enable);
 
   const auto resetControls = !enable;
@@ -711,4 +740,49 @@ double PlaybackController::getCurrentItemsFrameRate() const
   if (frameRate < lowestPossibleFps)
     frameRate = lowestPossibleFps;
   return frameRate;
+}
+
+void PlaybackController::setFrameOffset(int offset)
+{
+  this->frameOffset = offset;
+  this->ui.offsetSpinBox->blockSignals(true);
+  this->ui.offsetSpinBox->setValue(offset);
+  this->ui.offsetSpinBox->blockSignals(false);
+  
+  // Update current frame display
+  if (this->anyItemIndexedByFrame())
+  {
+    this->splitViewPrimary->update(true);
+    this->splitViewSeparate->update();
+  }
+}
+
+int PlaybackController::getFrameOffset() const
+{
+  return this->frameOffset;
+}
+
+int PlaybackController::getEffectiveFrame(int displayFrame) const
+{
+  return displayFrame + this->frameOffset;
+}
+
+int PlaybackController::getDisplayFrame(int effectiveFrame) const
+{
+  return effectiveFrame - this->frameOffset;
+}
+
+void PlaybackController::on_offsetSpinBox_valueChanged(int value)
+{
+  if (value != this->frameOffset)
+  {
+    this->frameOffset = value;
+    
+    // Update the view to show the frame with the new offset
+    if (this->anyItemIndexedByFrame())
+    {
+      this->splitViewPrimary->update(true);
+      this->splitViewSeparate->update();
+    }
+  }
 }

--- a/YUViewLib/src/ui/PlaybackController.h
+++ b/YUViewLib/src/ui/PlaybackController.h
@@ -42,6 +42,7 @@
 #include <QPointer>
 #include <QTime>
 #include <QWidget>
+#include <QMap>
 
 #include "ui_playbackController.h"
 
@@ -87,8 +88,15 @@ public:
   bool playing() const;
   bool isWaitingForCaching() const;
   int  getCurrentFrame() const;
+  int  getCurrentFrameWithOffset() const;
 
   bool setCurrentFrameAndUpdate(int frame, bool updateView = true);
+
+  // Frame offset functions for video synchronization
+  void setFrameOffset(int offset);
+  int  getFrameOffset() const;
+  int  getEffectiveFrame(int displayFrame) const;
+  int  getDisplayFrame(int effectiveFrame) const;
 
   enum class RepeatMode
   {
@@ -138,6 +146,7 @@ public slots:
 private slots:
   void on_frameSlider_valueChanged(int val);
   void on_frameSpinBox_valueChanged(int val) { this->on_frameSlider_valueChanged(val); }
+  void on_offsetSpinBox_valueChanged(int val);
 
 private:
   std::optional<int> getNextFrameIndexInCurrentItem();
@@ -153,6 +162,12 @@ private:
   // contains the last valid frame index which will be restored if a valid indexed item is selected.
   int currentFrameIdx{-1};
   int lastValidFrameIdx{-1};
+
+  // Frame offset for video synchronization
+  int frameOffset{0};
+
+  // Store frame offsets for each playlist item
+  QMap<int, int> itemFrameOffsets;
 
   void startOrUpdateTimer();
   void startPlayback();

--- a/YUViewLib/src/ui/views/SplitViewWidget.cpp
+++ b/YUViewLib/src/ui/views/SplitViewWidget.cpp
@@ -195,7 +195,7 @@ void splitViewWidget::paintEvent(QPaintEvent *)
                   << (isMasterView ? " separate widget" : ""));
 
   // Get the current frame to draw
-  const auto frame = playback->getCurrentFrame();
+  const auto frame = playback->getCurrentFrameWithOffset();
 
   // Is playback running?
   const bool playing = (playback) ? playback->playing() : false;
@@ -1449,7 +1449,7 @@ QImage splitViewWidget::getScreenshot(bool fullItem)
     QPainter painter(&screenshot);
 
     // Get the current frame to draw
-    int frame = playback->getCurrentFrame();
+    int frame = playback->getCurrentFrameWithOffset();
 
     // Translate the painter to the position where we want the item to be
     QPoint center = QRect(QPoint(0, 0), item[0]->getSize()).center();

--- a/YUViewLib/ui/playbackController.ui
+++ b/YUViewLib/ui/playbackController.ui
@@ -61,6 +61,44 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="offsetLabel">
+     <property name="minimumSize">
+      <size>
+       <width>40</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Frame offset for video synchronization</string>
+     </property>
+     <property name="text">
+      <string>Offset</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSpinBox" name="offsetSpinBox">
+     <property name="minimumSize">
+      <size>
+       <width>60</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Set frame offset for video synchronization. Positive values delay the video, negative values advance it.</string>
+     </property>
+     <property name="minimum">
+      <number>-99999</number>
+     </property>
+     <property name="maximum">
+      <number>99999</number>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="fpsLabel">
      <property name="minimumSize">
       <size>


### PR DESCRIPTION
Add frame offset setting for RTC video synchronization

If the two videos are encoded by a complicated RTC SDK in real world 
workload, they may misaligned. So I added offset setting for manually 
adjusting.

- Add offset spinbox control in playback controller UI
- Enable real-time offset adjustment during playback
- Apply offset in video rendering for temporal synchronization