### PR TITLE
Fix drag-and-drop regression in playlist

### DIFF
--- a/YUViewLib/src/ui/widgets/PlaylistTreeWidget.cpp
+++ b/YUViewLib/src/ui/widgets/PlaylistTreeWidget.cpp
@@ -186,6 +186,12 @@ playlistItem *PlaylistTreeWidget::getDropTarget(const QPoint &pos) const
 
 void PlaylistTreeWidget::dragMoveEvent(QDragMoveEvent *event)
 {
+  if (event->mimeData()->hasUrls())
+  {
+    event->acceptProposedAction();
+    return;
+  }
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   const auto dropTarget = this->getDropTarget(event->position().toPoint());
 #else
@@ -194,7 +200,7 @@ void PlaylistTreeWidget::dragMoveEvent(QDragMoveEvent *event)
 
   if (!dropTarget)
   {
-    event->ignore();
+    QTreeWidget::dragMoveEvent(event);
     return;
   }
 


### PR DESCRIPTION
Commit 44d1d86c refactored dragMoveEvent by inverting the dropTarget null check, but introduced two regressions:

1. External file drops (e.g. from file manager) are rejected because the event is ignored when dropTarget is null (empty area) or when selectedItems() is empty (over an item).

2. Internal reordering is broken when dragging between items because the drop on the gap between items returns a null dropTarget, and the event is now explicitly ignored instead of being delegated to QTreeWidget::dragMoveEvent.

Fix by handling external file drops (hasUrls) early before any playlist-internal validation, and delegating null-dropTarget internal drags to the base class.