### PR TITLE
Add edit menu to enable select all shortcut in macOS file dialog

### DIFF
--- a/YUViewLib/src/ui/Mainwindow.cpp
+++ b/YUViewLib/src/ui/Mainwindow.cpp
@@ -32,6 +32,7 @@
 
 #include "Mainwindow.h"
 
+#include <QApplication>
 #include <QByteArray>
 #include <QFileDialog>
 #include <QImageWriter>
@@ -297,6 +298,27 @@ void MainWindow::createMenusAndActions()
   // On Mac, the key to delete an item is backspace. We will add this for all platforms
   auto backSpaceDelete = new QShortcut(QKeySequence(Qt::Key_Backspace), this);
   QObject::connect(backSpaceDelete, &QShortcut::activated, this, &MainWindow::deleteSelectedItems);
+
+  auto editMenu = menuBar()->addMenu(tr("&Edit"));
+  auto addEditAction = [this, editMenu](const QString &name, const QKeySequence &shortcut, const char *memberFunc) {
+    auto action = new QAction(name, editMenu);
+    action->setShortcut(shortcut);
+    QObject::connect(action, &QAction::triggered, this, [memberFunc]() {
+      QWidget *w = QApplication::focusWidget();
+      if (!w)
+        return;
+      QMetaObject::invokeMethod(w, memberFunc, Qt::DirectConnection);
+    });
+    editMenu->addAction(action);
+  };
+
+  addEditAction(tr("&Undo"), QKeySequence::Undo, "undo");
+  addEditAction(tr("&Redo"), QKeySequence::Redo, "redo");
+  editMenu->addSeparator();
+  addEditAction(tr("Cu&t"), QKeySequence::Cut, "cut");
+  addEditAction(tr("&Copy"), QKeySequence::Copy, "copy");
+  addEditAction(tr("&Paste"), QKeySequence::Paste, "paste");
+  addEditAction(tr("Select &All"), QKeySequence::SelectAll, "selectAll");
 
   auto viewMenu = menuBar()->addMenu(tr("&View"));
   // Sub menu save/load state


### PR DESCRIPTION
On macOS, the native file dialog (`NSOpenPanel`) does not handle keyboard shortcuts like `Cmd+A` (Select All) on its own. It requires the parent application to have an Edit menu with a corresponding action linked to the `selectAll:` selector.

This PR adds a standard Edit menu (Undo, Redo, Cut, Copy, Paste, and Select All) to `MainWindow`. 

Each action is dynamically dispatched to the currently focused widget via `QMetaObject::invokeMethod` using their platform-standard `QKeySequence` (which makes the shortcut work in the native file dialog and ensures it is locale-safe).
