### PR TITLE
fix: accept external file drops in dragMoveEvent

### DIFF
--- a/YUViewLib/src/ui/widgets/PlaylistTreeWidget.cpp
+++ b/YUViewLib/src/ui/widgets/PlaylistTreeWidget.cpp
@@ -186,6 +186,13 @@ playlistItem *PlaylistTreeWidget::getDropTarget(const QPoint &pos) const
 
 void PlaylistTreeWidget::dragMoveEvent(QDragMoveEvent *event)
 {
+  // External file drops (from OS) don't need a specific drop target
+  if (event->mimeData()->hasUrls())
+  {
+    event->acceptProposedAction();
+    return;
+  }
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   const auto dropTarget = this->getDropTarget(event->position().toPoint());
 #else


### PR DESCRIPTION
## Summary

- dragMoveEvent was calling event->ignore() whenever the cursor was not hovering over an existing playlist item, which silently rejected all OS-level file drops landing on empty playlist space.
- The flow was: dragEnterEvent correctly accepted URL drops, but dragMoveEvent immediately cancelled them before dropEvent was ever reached.
- Fix: check hasUrls() at the top of dragMoveEvent and call cceptProposedAction() for external file drops, bypassing the drop-target logic which only applies to internal item reordering.

## Test plan

- [ ] Drag a video/YUV file from Windows Explorer onto the playlist area — file should load
- [ ] Drag a file onto an empty playlist — file should load
- [ ] Drag items within the playlist to reorder — internal reordering still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)