### PR TITLE
fix(yuv): set luma offset default to 0 for proper scale behavior

### DIFF
--- a/YUViewLib/src/video/yuv/videoHandlerYUV.cpp
+++ b/YUViewLib/src/video/yuv/videoHandlerYUV.cpp
@@ -2385,7 +2385,7 @@ std::vector<PixelFormatYUV> videoHandlerYUV::formatPresetList = {
 videoHandlerYUV::videoHandlerYUV() : videoHandler()
 {
   // Set the default YUV transformation parameters.
-  this->conversionSettings.mathParameters[Component::Luma]   = MathParameters(1, 125, false);
+  this->conversionSettings.mathParameters[Component::Luma]   = MathParameters(1, 0, false);
   this->conversionSettings.mathParameters[Component::Chroma] = MathParameters(1, 128, false);
 
   // If we know nothing about the YUV format, assume YUV 4:2:0 8 bit planar by default.
@@ -2597,8 +2597,7 @@ void videoHandlerYUV::setSrcPixelFormat(PixelFormatYUV format, bool emitSignal)
   // Update the math parameter offset (the default offset depends on the bit depth and the range)
   int        shift     = format.getBitsPerSample() - 8;
   const bool fullRange = isFullRange(this->conversionSettings.colorConversion);
-  this->conversionSettings.mathParameters[Component::Luma].offset   = (fullRange ? 128 : 125)
-                                                                      << shift;
+  this->conversionSettings.mathParameters[Component::Luma].offset   = 0 << shift;
   this->conversionSettings.mathParameters[Component::Chroma].offset = 128 << shift;
 
   if (ui.created())
@@ -3765,7 +3764,7 @@ QImage videoHandlerYUV::calculateDifference(FrameHandler    *item2,
   {
     // Get the format of the tmpDiffYUV buffer and convert it to RGB
     ConversionSettings conversionSettings;
-    conversionSettings.mathParameters[Component::Luma]   = MathParameters(1, 125, false);
+    conversionSettings.mathParameters[Component::Luma]   = MathParameters(1, 0, false);
     conversionSettings.mathParameters[Component::Chroma] = MathParameters(1, 128, false);
     convertYUVPlanarToRGB(
       diffYUV, outputImage.bits(), Size(w_out, h_out), tmpDiffYUVFormat, conversionSettings);


### PR DESCRIPTION
# fix(yuv): set luma offset default to 0 for proper scale behavior

## Problem

Luma scale adjustment has no visible effect on image brightness.

## Root Cause

Default Luma offset is 125 (limited range center). Transform formula `newValue = (value - offset) * scale + offset` uses offset as pivot, so pixels near 125 are minimally affected.

## Solution

Changed default Luma offset from 125 to 0, so scale adjustments affect all pixels proportionally.

## Changes

- `videoHandlerYUV.cpp`: Updated 3 locations (constructor, setSrcPixelFormat, calculateDifference)

## Effect

- Luma scale now produces visible brightness changes
- Chroma offset remains at 128 (correct for UV)
- Users can still manually adjust offset via UI