### PR TITLE
Use libavformat 61 codec parameter layout consistently

### DIFF
--- a/YUViewLib/src/ffmpeg/AVCodecParametersWrapper.cpp
+++ b/YUViewLib/src/ffmpeg/AVCodecParametersWrapper.cpp
@@ -326,10 +326,15 @@ void AVCodecParametersWrapper::setClearValues()
 void AVCodecParametersWrapper::setAVMediaType(AVMediaType type)
 {
   if (this->libVer.avformat.major == 57 || this->libVer.avformat.major == 58 ||
-      this->libVer.avformat.major == 59 || this->libVer.avformat.major == 60 ||
-      this->libVer.avformat.major == 61)
+      this->libVer.avformat.major == 59 || this->libVer.avformat.major == 60)
   {
     auto p           = reinterpret_cast<AVCodecParameters_57_58_59_60 *>(this->param);
+    p->codec_type    = type;
+    this->codec_type = type;
+  }
+  else if (this->libVer.avformat.major == 61)
+  {
+    auto p           = reinterpret_cast<AVCodecParameters_61 *>(this->param);
     p->codec_type    = type;
     this->codec_type = type;
   }
@@ -355,8 +360,7 @@ void AVCodecParametersWrapper::setAVCodecID(AVCodecID id)
 void AVCodecParametersWrapper::setExtradata(QByteArray data)
 {
   if (this->libVer.avformat.major == 57 || this->libVer.avformat.major == 58 ||
-      this->libVer.avformat.major == 59 || this->libVer.avformat.major == 60 ||
-      this->libVer.avformat.major == 61)
+      this->libVer.avformat.major == 59 || this->libVer.avformat.major == 60)
   {
     this->extradata   = data;
     auto p            = reinterpret_cast<AVCodecParameters_57_58_59_60 *>(this->param);


### PR DESCRIPTION
## Summary

- route `libavformat` major 61 through the `AVCodecParameters_61` wrapper layout in `setAVMediaType`
- make `setExtradata` use the same major 61 layout branch instead of the 57-60 layout branch
- keep the wrapper's version dispatch consistent with the other `AVCodecParameters` setters

## Notes

`61` here refers to the `libavformat` ABI major version, not the FFmpeg 6.1 release.

## Testing

- `make -C build/unknown-Debug -j8`
