### PR TITLE
Harden playlist tree edge cases

### DIFF
--- a/YUViewLib/src/ui/widgets/PlaylistTreeWidget.cpp
+++ b/YUViewLib/src/ui/widgets/PlaylistTreeWidget.cpp
@@ -91,6 +91,9 @@ public:
     // Draw the cached frames
     auto frameList = plItem->getCachedFrames();
     auto range     = plItem->properties().startEndRange;
+    if (range.second <= 0)
+      return;
+
     if (frameList.count() > 0)
     {
       int lastPos = frameList[0];
@@ -206,6 +209,11 @@ void PlaylistTreeWidget::dragMoveEvent(QDragMoveEvent *event)
   }
 
   const auto draggedItem = dynamic_cast<playlistItem *>(draggedItems[0]);
+  if (!draggedItem)
+  {
+    event->ignore();
+    return;
+  }
 
   if (!dropTarget->acceptDrops(draggedItem))
   {
@@ -312,7 +320,7 @@ void PlaylistTreeWidget::addDifferenceItem()
   for (int i = 0; i < this->selectedItems().count(); i++)
   {
     auto item = dynamic_cast<playlistItem *>(this->selectedItems()[i]);
-    if (item->canBeUsedInProcessing())
+    if (item && item->canBeUsedInProcessing())
       selection.append(this->selectedItems()[i]);
   }
 
@@ -357,7 +365,7 @@ void PlaylistTreeWidget::addResampleItem()
   for (int i = 0; i < this->selectedItems().count(); i++)
   {
     auto item = dynamic_cast<playlistItem *>(this->selectedItems()[i]);
-    if (item->canBeUsedInProcessing())
+    if (item && item->canBeUsedInProcessing())
       selection.append(this->selectedItems()[i]);
   }
 
@@ -820,6 +828,8 @@ QString PlaylistTreeWidget::getPlaylistString(QDir dirName)
   {
     QTreeWidgetItem *item   = topLevelItem(i);
     playlistItem    *plItem = dynamic_cast<playlistItem *>(item);
+    if (!plItem)
+      continue;
 
     plItem->savePlaylist(plist, dirName);
   }
@@ -852,7 +862,14 @@ void PlaylistTreeWidget::savePlaylistToFile()
 
   // Write the XML structure to file
   QFile file(filename);
-  file.open(QIODevice::WriteOnly | QIODevice::Text);
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
+  {
+    QMessageBox::warning(this,
+                         tr("Save Playlist"),
+                         tr("Could not save playlist to \"%1\": %2")
+                           .arg(filename, file.errorString()));
+    return;
+  }
   QTextStream outStream(&file);
   outStream << getPlaylistString(dirName);
   file.close();


### PR DESCRIPTION
## Summary

- guard playlist tree `dynamic_cast` results before dereferencing them
- avoid division by zero while drawing cache state for invalid frame ranges
- report playlist save failures when the destination file cannot be opened

## Testing

- `make -C build/unknown-Debug -j8`
