### PR TITLE
Keep AVPacketWrapper data alive

### DIFF
--- a/YUViewLib/src/ffmpeg/AVPacketWrapper.cpp
+++ b/YUViewLib/src/ffmpeg/AVPacketWrapper.cpp
@@ -163,25 +163,28 @@ AVPacketWrapper::AVPacketWrapper(LibraryVersion libVersion, AVPacket *packet)
 
 void AVPacketWrapper::clear()
 {
-  this->pkt    = nullptr;
-  this->libVer = {};
+  this->pkt        = nullptr;
+  this->libVer     = {};
+  this->packetData = {};
 }
 
-void AVPacketWrapper::setData(QByteArray &set_data)
+void AVPacketWrapper::setData(const QByteArray &set_data)
 {
+  this->packetData = set_data;
+
   if (this->libVer.avcodec.major == 56)
   {
     auto p  = reinterpret_cast<AVPacket_56 *>(this->pkt);
-    p->data = (uint8_t *)set_data.data();
-    p->size = set_data.size();
+    p->data = reinterpret_cast<uint8_t *>(this->packetData.data());
+    p->size = this->packetData.size();
     data    = p->data;
     size    = p->size;
   }
   else if (this->libVer.avcodec.major == 57 || this->libVer.avcodec.major == 58)
   {
     auto p  = reinterpret_cast<AVPacket_57_58 *>(this->pkt);
-    p->data = (uint8_t *)set_data.data();
-    p->size = set_data.size();
+    p->data = reinterpret_cast<uint8_t *>(this->packetData.data());
+    p->size = this->packetData.size();
     data    = p->data;
     size    = p->size;
   }
@@ -190,8 +193,8 @@ void AVPacketWrapper::setData(QByteArray &set_data)
            this->libVer.avcodec.major == 61)
   {
     auto p  = reinterpret_cast<AVPacket_59_60_61 *>(this->pkt);
-    p->data = (uint8_t *)set_data.data();
-    p->size = set_data.size();
+    p->data = reinterpret_cast<uint8_t *>(this->packetData.data());
+    p->size = this->packetData.size();
     data    = p->data;
     size    = p->size;
   }

--- a/YUViewLib/src/ffmpeg/AVPacketWrapper.h
+++ b/YUViewLib/src/ffmpeg/AVPacketWrapper.h
@@ -123,7 +123,7 @@ public:
 
   void clear();
 
-  void setData(QByteArray &set_data);
+  void setData(const QByteArray &set_data);
   void setPTS(int64_t pts);
   void setDTS(int64_t dts);
 
@@ -168,6 +168,7 @@ private:
 
   AVPacket *       pkt{};
   LibraryVersion   libVer{};
+  QByteArray       packetData{};
   PacketDataFormat packetFormat{PacketDataFormat::Unknown};
 };
 


### PR DESCRIPTION
## Summary

- make `AVPacketWrapper::setData` keep an owned copy of the packet bytes
- point version-specific packet layouts at the wrapper-owned storage
- accept packet input as `const QByteArray &`

## Notes

This makes the wrapper independent of the caller's `QByteArray` lifetime after `setData` returns.

## Testing

- `make -C build/unknown-Debug -j8`
