### PR TITLE
Avoid memset when clearing generated UI

### DIFF
--- a/YUViewLib/src/common/SaveUi.h
+++ b/YUViewLib/src/common/SaveUi.h
@@ -65,7 +65,7 @@ public:
 
   void clear()
   {
-    memset(static_cast<Ui *>(this), 0, sizeof(Ui));
+    *static_cast<Ui *>(this) = Ui{};
     m_created = false;
   }
 


### PR DESCRIPTION
## Summary

- replace raw `memset` clearing of generated `Ui` base objects with value initialization
- preserve the existing delayed-setup behavior while avoiding byte-wise writes to potentially non-trivial members

## Testing

- `make -C build/unknown-Debug -j8`
