### PR TITLE
Fix crash caused by dereferencing empty YUV frame format

### DIFF
--- a/YUViewLib/src/video/yuv/videoHandlerYUV.h
+++ b/YUViewLib/src/video/yuv/videoHandlerYUV.h
@@ -137,6 +137,8 @@ public:
   virtual std::optional<std::string> getFormatAsString() const override
   {
     const auto frameFormat = FrameHandler::getFormatAsString();
+    if (!frameFormat)
+      return {};
     return *frameFormat + ";YUV;" + this->srcPixelFormat.getName();
   }
   virtual bool setFormatFromString(const std::string_view format) override;


### PR DESCRIPTION
<img width="551" height="451" alt="ScreenShot_2026-07-30_175847_069" src="https://github.com/user-attachments/assets/083374b7-1bb7-4e0a-b46c-f1eb675b1775" />
